### PR TITLE
Fix hang when filename is not set

### DIFF
--- a/sandbox/TestBacked.cpp
+++ b/sandbox/TestBacked.cpp
@@ -7,11 +7,7 @@ int main(int argc, char** argv) {
   srand(1);
 
   el::Configurations defaultConf = LogHandler::SetupLogHandler(&argc, &argv);
-
-  defaultConf.setGlobally(el::ConfigurationType::Filename,
-                          "testBacked-%datetime.log");
-  defaultConf.setGlobally(el::ConfigurationType::ToFile, "true");
-
+  defaultConf.setGlobally(el::ConfigurationType::Enabled, "false");
   el::Loggers::reconfigureLogger("default", defaultConf);
 
   std::shared_ptr<FakeSocketHandler> serverSocket(new FakeSocketHandler());

--- a/sandbox/TestConnection.cpp
+++ b/sandbox/TestConnection.cpp
@@ -62,12 +62,9 @@ void runClient(std::shared_ptr<FakeSocketHandler> clientSocket,
 int main(int argc, char** argv) {
   srand(1);
   el::Configurations defaultConf = LogHandler::SetupLogHandler(&argc, &argv);
-
-  defaultConf.setGlobally(el::ConfigurationType::Filename,
-                          "testConnection-%datetime.log");
-  defaultConf.setGlobally(el::ConfigurationType::ToFile, "true");
-
+  defaultConf.setGlobally(el::ConfigurationType::Enabled, "false");
   el::Loggers::reconfigureLogger("default", defaultConf);
+
   std::shared_ptr<FakeSocketHandler> serverSocket(new FakeSocketHandler());
   std::shared_ptr<FakeSocketHandler> clientSocket(
       new FakeSocketHandler(serverSocket));

--- a/sandbox/TestFakeSocketHandler.cpp
+++ b/sandbox/TestFakeSocketHandler.cpp
@@ -8,11 +8,7 @@ using namespace et;
 int main(int argc, char** argv) {
   srand(1);
   el::Configurations defaultConf = LogHandler::SetupLogHandler(&argc, &argv);
-
-  defaultConf.setGlobally(el::ConfigurationType::Filename,
-                          "testFakeSocketHandler-%datetime.log");
-  defaultConf.setGlobally(el::ConfigurationType::ToFile, "true");
-
+  defaultConf.setGlobally(el::ConfigurationType::Enabled, "false");
   el::Loggers::reconfigureLogger("default", defaultConf);
   std::shared_ptr<FakeSocketHandler> clientSocket(new FakeSocketHandler());
   std::shared_ptr<FakeSocketHandler> serverSocket(

--- a/sandbox/TestFlakyConnection.cpp
+++ b/sandbox/TestFlakyConnection.cpp
@@ -62,11 +62,7 @@ void runClient(std::shared_ptr<FlakyFakeSocketHandler> clientSocket,
 int main(int argc, char** argv) {
   srand(1);
   el::Configurations defaultConf = LogHandler::SetupLogHandler(&argc, &argv);
-
-  defaultConf.setGlobally(el::ConfigurationType::Filename,
-                          "testFlakyConnection-%datetime.log");
-  defaultConf.setGlobally(el::ConfigurationType::ToFile, "true");
-
+  defaultConf.setGlobally(el::ConfigurationType::Enabled, "false");
   el::Loggers::reconfigureLogger("default", defaultConf);
 
   std::shared_ptr<FakeSocketHandler> serverSocket(new FakeSocketHandler());

--- a/terminal/LogHandler.cpp
+++ b/terminal/LogHandler.cpp
@@ -10,19 +10,24 @@ el::Configurations LogHandler::SetupLogHandler(int *argc, char ***argv) {
   // GFLAGS parse command line arguments
   gflags::ParseCommandLineFlags(argc, argv, true);
 
-
   // Easylogging configurations
   el::Configurations defaultConf;
   defaultConf.setToDefault();
   defaultConf.setGlobally(el::ConfigurationType::Format,
                           "[%level %datetime %thread %fbase:%line] %msg");
   defaultConf.setGlobally(el::ConfigurationType::Enabled, "true");
-  defaultConf.setGlobally(el::ConfigurationType::MaxLogFileSize, "20971520");
   defaultConf.setGlobally(el::ConfigurationType::SubsecondPrecision, "3");
   defaultConf.setGlobally(el::ConfigurationType::PerformanceTracking, "false");
   defaultConf.setGlobally(el::ConfigurationType::LogFlushThreshold, "1");
   defaultConf.set(el::Level::Verbose, el::ConfigurationType::Format,
                   "[%levshort%vlevel %datetime %thread %fbase:%line] %msg");
   return defaultConf;
+}
+
+void LogHandler::SetupLogFile(el::Configurations *defaultConf,
+                              string filename) {
+  defaultConf->setGlobally(el::ConfigurationType::Filename, filename);
+  defaultConf->setGlobally(el::ConfigurationType::ToFile, "true");
+  defaultConf->setGlobally(el::ConfigurationType::MaxLogFileSize, "20971520");
 }
 }  // namespace et

--- a/terminal/LogHandler.hpp
+++ b/terminal/LogHandler.hpp
@@ -7,6 +7,7 @@ namespace et {
 class LogHandler {
  public:
   static el::Configurations SetupLogHandler(int *argc, char ***argv);
+  static void SetupLogFile(el::Configurations *defaultConf, string filename);
 };
 }  // namespace et
 #endif  // __ETERNAL_TCP_LOG_HANDLER__

--- a/terminal/TerminalClient.cpp
+++ b/terminal/TerminalClient.cpp
@@ -182,9 +182,7 @@ int main(int argc, char** argv) {
     defaultConf.setGlobally(el::ConfigurationType::Enabled, "false");
   }
 
-  defaultConf.setGlobally(el::ConfigurationType::Filename,
-                          "/tmp/etclient-%datetime.log");
-  defaultConf.setGlobally(el::ConfigurationType::ToFile, "true");
+  LogHandler::SetupLogFile(&defaultConf, "/tmp/etclient-%datetime.log");
 
   el::Loggers::reconfigureLogger("default", defaultConf);
 

--- a/terminal/TerminalServer.cpp
+++ b/terminal/TerminalServer.cpp
@@ -570,9 +570,8 @@ int main(int argc, char **argv) {
     string id = split(idpasskey, '/')[0];
     string username = string(ssh_get_local_username());
     // etserver with --jump cannot write to the default log file(root)
-    defaultConf.setGlobally(el::ConfigurationType::Filename,
-                            "/tmp/etjump-" + username + "-" + id + ".log");
-    defaultConf.setGlobally(el::ConfigurationType::ToFile, "true");
+    LogHandler::SetupLogFile(&defaultConf,
+                             "/tmp/etjump-" + username + "-" + id + ".log");
     // Reconfigure default logger to apply settings above
     el::Loggers::reconfigureLogger("default", defaultConf);
     startJumpHostClient(idpasskey);
@@ -584,9 +583,8 @@ int main(int argc, char **argv) {
     string id = split(idpasskey, '/')[0];
     string username = string(ssh_get_local_username());
     // etserver with --idpasskey cannot write to the default log file(root)
-    defaultConf.setGlobally(el::ConfigurationType::Filename,
-                            "/tmp/etterminal-" + username + "-" + id + ".log");
-    defaultConf.setGlobally(el::ConfigurationType::ToFile, "true");
+    LogHandler::SetupLogFile(&defaultConf,
+                             "/tmp/etterminal-" + username + "-" + id + ".log");
     // Reconfigure default logger to apply settings above
     el::Loggers::reconfigureLogger("default", defaultConf);
     startUserTerminal(idpasskey);
@@ -610,9 +608,7 @@ int main(int argc, char **argv) {
 #endif
   }
   // Set log file for etserver process here.
-  defaultConf.setGlobally(el::ConfigurationType::Filename,
-                          "/tmp/etserver-%datetime.log");
-  defaultConf.setGlobally(el::ConfigurationType::ToFile, "true");
+  LogHandler::SetupLogFile(&defaultConf, "/tmp/etserver-%datetime.log");
   // Reconfigure default logger to apply settings above
   el::Loggers::reconfigureLogger("default", defaultConf);
   startServer();


### PR DESCRIPTION
Previously we had to set log filename even when logging is off. Otherwise it causes a hang. This is fixed by setting MaxLogFileSize after the log filename is set. 