### PR TITLE
move setVersion up

### DIFF
--- a/terminal/TerminalClient.cpp
+++ b/terminal/TerminalClient.cpp
@@ -168,6 +168,9 @@ vector<pair<int, int>> parseRangesToPairs(const string& input) {
 }
 
 int main(int argc, char** argv) {
+  // Version string need to be set before GFLAGS parse arguments
+  SetVersionString(string(ET_VERSION));
+
   // Setup easylogging configurations
   el::Configurations defaultConf = LogHandler::SetupLogHandler(&argc, &argv);
 
@@ -212,7 +215,6 @@ int main(int argc, char** argv) {
     }
   }
 
-  SetVersionString(string(ET_VERSION));
   GOOGLE_PROTOBUF_VERIFY_VERSION;
   srand(1);
 

--- a/terminal/TerminalServer.cpp
+++ b/terminal/TerminalServer.cpp
@@ -522,6 +522,9 @@ void startJumpHostClient(string idpasskey) {
 }
 
 int main(int argc, char **argv) {
+  // Version string need to be set before GFLAGS parse arguments
+  SetVersionString(string(ET_VERSION));
+
   // Setup easylogging configurations
   el::Configurations defaultConf = LogHandler::SetupLogHandler(&argc, &argv);
 
@@ -557,7 +560,6 @@ int main(int argc, char **argv) {
     }
   }
 
-  SetVersionString(string(ET_VERSION));
   GOOGLE_PROTOBUF_VERIFY_VERSION;
   srand(1);
 


### PR DESCRIPTION
etserver didn't show version correctly on Ubuntu. Move the setVersionString() before GFLAGS parsing arguments fixes the problem.