### PR TITLE
read() return 0 from stdin is valid

### DIFF
--- a/terminal/ParseConfigFile.hpp
+++ b/terminal/ParseConfigFile.hpp
@@ -1286,8 +1286,7 @@ static int ssh_config_parse_line(struct Options *options, const char *line,
       }
       break;
     case SOC_UNSUPPORTED:
-      LOG(INFO) << "unsupported config line: " << string(line) << ", ignored"
-                << endl;
+      LOG(INFO) << "unsupported config line: " << string(line) << ", ignored";
       break;
     default:
       cout << "parse error" << endl;

--- a/terminal/TerminalClient.cpp
+++ b/terminal/TerminalClient.cpp
@@ -407,8 +407,6 @@ int main(int argc, char** argv) {
           globalClient->writeMessage(headerString);
           globalClient->writeProto(tb);
           keepaliveTime = time(NULL) + KEEP_ALIVE_DURATION;
-        } else {
-          LOG(FATAL) << "Got an error reading from stdin: " << rc;
         }
       }
 


### PR DESCRIPTION
* Remove LOG(FATAL) when read() returns 0 from stdin. As in some emulators it's valid. https://stackoverflow.com/questions/8975521/read-from-stdin/8975733#8975733
* Removed an extra line