### PR TITLE
setup easylogging log rotation-20M

### DIFF
--- a/etc/et.cfg
+++ b/etc/et.cfg
@@ -7,3 +7,4 @@ port = 2022
 [Debug]
 verbose = 0
 silent = 0
+logsize = 20971520

--- a/terminal/LogHandler.cpp
+++ b/terminal/LogHandler.cpp
@@ -24,13 +24,13 @@ el::Configurations LogHandler::SetupLogHandler(int *argc, char ***argv) {
   return defaultConf;
 }
 
-void LogHandler::SetupLogFile(el::Configurations *defaultConf,
-                              string filename) {
+void LogHandler::SetupLogFile(el::Configurations *defaultConf, string filename,
+                              string maxlogsize) {
   // Enable strict log file size check
   el::Loggers::addFlag(el::LoggingFlag::StrictLogFileSizeCheck);
   defaultConf->setGlobally(el::ConfigurationType::Filename, filename);
   defaultConf->setGlobally(el::ConfigurationType::ToFile, "true");
-  defaultConf->setGlobally(el::ConfigurationType::MaxLogFileSize, "20971520");
+  defaultConf->setGlobally(el::ConfigurationType::MaxLogFileSize, maxlogsize);
 }
 
 void LogHandler::rolloutHandler(const char *filename, std::size_t size) {

--- a/terminal/LogHandler.cpp
+++ b/terminal/LogHandler.cpp
@@ -26,8 +26,18 @@ el::Configurations LogHandler::SetupLogHandler(int *argc, char ***argv) {
 
 void LogHandler::SetupLogFile(el::Configurations *defaultConf,
                               string filename) {
+  // Enable strict log file size check
+  el::Loggers::addFlag(el::LoggingFlag::StrictLogFileSizeCheck);
   defaultConf->setGlobally(el::ConfigurationType::Filename, filename);
   defaultConf->setGlobally(el::ConfigurationType::ToFile, "true");
   defaultConf->setGlobally(el::ConfigurationType::MaxLogFileSize, "20971520");
+}
+
+void LogHandler::rolloutHandler(const char *filename, std::size_t size) {
+  // SHOULD NOT LOG ANYTHING HERE BECAUSE LOG FILE IS CLOSED!
+  std::stringstream ss;
+  // REMOVE OLD LOG
+  ss << "rm " << filename;
+  system(ss.str().c_str());
 }
 }  // namespace et

--- a/terminal/LogHandler.hpp
+++ b/terminal/LogHandler.hpp
@@ -8,6 +8,7 @@ class LogHandler {
  public:
   static el::Configurations SetupLogHandler(int *argc, char ***argv);
   static void SetupLogFile(el::Configurations *defaultConf, string filename);
+  static void rolloutHandler(const char *filename, std::size_t size);
 };
 }  // namespace et
 #endif  // __ETERNAL_TCP_LOG_HANDLER__

--- a/terminal/LogHandler.hpp
+++ b/terminal/LogHandler.hpp
@@ -7,7 +7,8 @@ namespace et {
 class LogHandler {
  public:
   static el::Configurations SetupLogHandler(int *argc, char ***argv);
-  static void SetupLogFile(el::Configurations *defaultConf, string filename);
+  static void SetupLogFile(el::Configurations *defaultConf, string filename,
+                           string maxlogsize = "20971520");
   static void rolloutHandler(const char *filename, std::size_t size);
 };
 }  // namespace et

--- a/terminal/TerminalClient.cpp
+++ b/terminal/TerminalClient.cpp
@@ -189,6 +189,9 @@ int main(int argc, char** argv) {
 
   el::Loggers::reconfigureLogger("default", defaultConf);
 
+  // Install log rotation callback
+  el::Helpers::installPreRollOutCallback(LogHandler::rolloutHandler);
+
   // Override -h & --help
   for (int i = 1; i < argc; i++) {
     string s(argv[i]);
@@ -492,5 +495,7 @@ int main(int argc, char** argv) {
   LOG(INFO) << "Client derefernced";
   tcsetattr(0, TCSANOW, &terminal_backup);
   cout << "Session terminated" << endl;
+  // Uninstall log rotation callback
+  el::Helpers::uninstallPreRollOutCallback();
   return 0;
 }

--- a/terminal/TerminalServer.cpp
+++ b/terminal/TerminalServer.cpp
@@ -576,7 +576,13 @@ int main(int argc, char **argv) {
                              "/tmp/etjump-" + username + "-" + id + ".log");
     // Reconfigure default logger to apply settings above
     el::Loggers::reconfigureLogger("default", defaultConf);
+    // Install log rotation callback
+    el::Helpers::installPreRollOutCallback(LogHandler::rolloutHandler);
+
     startJumpHostClient(idpasskey);
+
+    // Uninstall log rotation callback
+    el::Helpers::uninstallPreRollOutCallback();
     return 0;
   }
 
@@ -589,7 +595,13 @@ int main(int argc, char **argv) {
                              "/tmp/etterminal-" + username + "-" + id + ".log");
     // Reconfigure default logger to apply settings above
     el::Loggers::reconfigureLogger("default", defaultConf);
+    // Install log rotation callback
+    el::Helpers::installPreRollOutCallback(LogHandler::rolloutHandler);
+
     startUserTerminal(idpasskey);
+
+    // Uninstall log rotation callback
+    el::Helpers::uninstallPreRollOutCallback();
     return 0;
   }
 
@@ -613,5 +625,11 @@ int main(int argc, char **argv) {
   LogHandler::SetupLogFile(&defaultConf, "/tmp/etserver-%datetime.log");
   // Reconfigure default logger to apply settings above
   el::Loggers::reconfigureLogger("default", defaultConf);
+  // Install log rotation callback
+  el::Helpers::installPreRollOutCallback(LogHandler::rolloutHandler);
+
   startServer();
+
+  // Uninstall log rotation callback
+  el::Helpers::uninstallPreRollOutCallback();
 }

--- a/terminal/TerminalServer.cpp
+++ b/terminal/TerminalServer.cpp
@@ -534,6 +534,9 @@ int main(int argc, char **argv) {
     defaultConf.setGlobally(el::ConfigurationType::ToStandardOutput, "false");
   }
 
+  // default max log file size is 20MB for etserver
+  string maxlogsize = "20971520";
+
   if (FLAGS_cfgfile.length()) {
     // Load the config file
     CSimpleIniA ini(true, true, true);
@@ -555,6 +558,13 @@ int main(int argc, char **argv) {
       if (silent && atoi(silent) != 0) {
         defaultConf.setGlobally(el::ConfigurationType::Enabled, "false");
       }
+      // read log file size limit
+      const char *logsize = ini.GetValue("Debug", "logsize", NULL);
+      if (logsize && atoi(logsize) != 0) {
+        // make sure maxlogsize is a string of int value
+        maxlogsize = string(logsize);
+      }
+
     } else {
       LOG(FATAL) << "Invalid config file: " << FLAGS_cfgfile;
     }
@@ -573,7 +583,8 @@ int main(int argc, char **argv) {
     string username = string(ssh_get_local_username());
     // etserver with --jump cannot write to the default log file(root)
     LogHandler::SetupLogFile(&defaultConf,
-                             "/tmp/etjump-" + username + "-" + id + ".log");
+                             "/tmp/etjump-" + username + "-" + id + ".log",
+                             maxlogsize);
     // Reconfigure default logger to apply settings above
     el::Loggers::reconfigureLogger("default", defaultConf);
     // Install log rotation callback
@@ -592,7 +603,8 @@ int main(int argc, char **argv) {
     string username = string(ssh_get_local_username());
     // etserver with --idpasskey cannot write to the default log file(root)
     LogHandler::SetupLogFile(&defaultConf,
-                             "/tmp/etterminal-" + username + "-" + id + ".log");
+                             "/tmp/etterminal-" + username + "-" + id + ".log",
+                             maxlogsize);
     // Reconfigure default logger to apply settings above
     el::Loggers::reconfigureLogger("default", defaultConf);
     // Install log rotation callback
@@ -622,7 +634,8 @@ int main(int argc, char **argv) {
 #endif
   }
   // Set log file for etserver process here.
-  LogHandler::SetupLogFile(&defaultConf, "/tmp/etserver-%datetime.log");
+  LogHandler::SetupLogFile(&defaultConf, "/tmp/etserver-%datetime.log",
+                           maxlogsize);
   // Reconfigure default logger to apply settings above
   el::Loggers::reconfigureLogger("default", defaultConf);
   // Install log rotation callback


### PR DESCRIPTION
- Enable log rotation in easylogging.
- Set the max log file to 20MB, log file will be deleted when exceeding size limit. 