### PR TITLE
Increase keepaliveTime when get message from dst terminal to router

### DIFF
--- a/terminal/TerminalServer.cpp
+++ b/terminal/TerminalServer.cpp
@@ -496,6 +496,7 @@ void startJumpHostClient(string idpasskey) {
         } else {
           string s = RawSocketUtils::readMessage(routerFd);
           jumpclient->writeMessage(s);
+          VLOG(3) << "Sent message from router to dst terminal: " << s.length();
         }
       }
       // forward DST terminal -> local router
@@ -504,7 +505,10 @@ void startJumpHostClient(string idpasskey) {
           string receivedMessage;
           jumpclient->readMessage(&receivedMessage);
           RawSocketUtils::writeMessage(routerFd, receivedMessage);
+          VLOG(3) << "Send message from dst terminal to router: "
+                  << receivedMessage.length();
         }
+        keepaliveTime = time(NULL) + KEEP_ALIVE_DURATION;
       }
       // src disconnects, close jump -> dst
       if (jumpClientFd > 0 && keepaliveTime < time(NULL)) {


### PR DESCRIPTION
Originally I thought it makes more sense to keep the connection alive only if there's something from client to server direction. However, it's possible that writing from server to client(on jumphost that's from dst terminal to local router) takes too long and use up all the keepalivetime(7s) since last sync with client, which finally result in a fake disconnection from jumphost's perspective. Referring to https://github.com/MisterTea/EternalTerminal/blob/master/terminal/TerminalClient.cpp#L440, we also increase keepaliveTime when something is sent from server to client direction, which turns out to make the jumphost connection more stable in the experiments. 

Also add some VLOG messages for debugging purpose. 