### PR TITLE
Link with execinfo on FreeBSD because easylogging needs it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,11 @@ if (CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
     set(FREEBSD TRUE)
 endif (CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
 
+#Using NetBSD?
+if (CMAKE_SYSTEM_NAME MATCHES "NetBSD")
+  set(NETBSD TRUE)
+endif (CMAKE_SYSTEM_NAME MATCHES "NetBSD")
+
 # Add cmake script directory.
 LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
@@ -78,6 +83,8 @@ add_custom_target(
 
 IF(FREEBSD)
   set(CORE_LIBRARIES util execinfo)
+ELSEIF(NETBSD)
+  set(CORE_LIBRARIES util resolv execinfo)
 ELSE()
   set(CORE_LIBRARIES util resolv)
 ENDIF()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ add_custom_target(
   )
 
 IF(FREEBSD)
-  set(CORE_LIBRARIES util)
+  set(CORE_LIBRARIES util execinfo)
 ELSE()
   set(CORE_LIBRARIES util resolv)
 ENDIF()


### PR DESCRIPTION
Just a tiny fix to get things compiling again on FreeBSD.

As soon as a new version is released I'll update the FreeBSD package.

Also, I've setup some smoke-test CI for each of FreeBSD, NetBSD, and OpenBSD. These weren't running the tests, but seeing the CircleCI setup, I'll be switching to that soon. If there is interest I can expose the status of these, or the logs. It's a pretty simple buildbot setup so far, but whatever would be helpful I can make accessible. 
