### PR TITLE
Add tests and fix logic holes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -63,7 +63,8 @@
         "hashtable": "cpp",
         "queue": "cpp",
         "stack": "cpp",
-        "future": "cpp"
+        "future": "cpp",
+        "cfenv": "cpp"
     },
     "C_Cpp.clang_format_style": "Google",
     "C_Cpp.configurationWarnings": "Disabled"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -62,7 +62,8 @@
         "*.in": "cpp",
         "hashtable": "cpp",
         "queue": "cpp",
-        "stack": "cpp"
+        "stack": "cpp",
+        "future": "cpp"
     },
     "C_Cpp.clang_format_style": "Google",
     "C_Cpp.configurationWarnings": "Disabled"

--- a/coverage.sh
+++ b/coverage.sh
@@ -8,3 +8,6 @@ lcov --directory ./build --capture --output-file ./code-coverage.info -rc lcov_b
 genhtml code-coverage.info --branch-coverage --output-directory ./code_coverage_report/
 echo "Report generated in code_coverage_report"
 open code_coverage_report/index.html
+pushd ./build
+cmake ../ -DBUILD_TEST=ON -DBUILD_GTEST=ON -DCODE_COVERAGE=OFF
+popd

--- a/src/base/ClientConnection.cpp
+++ b/src/base/ClientConnection.cpp
@@ -19,7 +19,7 @@ void ClientConnection::connect() {
     if (socketFd == -1) {
       throw std::runtime_error("Could not connect to host");
     }
-    VLOG(1) << "Sending null id";
+    VLOG(1) << "Sending id";
     et::ConnectRequest request;
     request.set_clientid(id);
     request.set_version(PROTOCOL_VERSION);

--- a/src/base/ClientConnection.cpp
+++ b/src/base/ClientConnection.cpp
@@ -2,7 +2,9 @@
 
 namespace et {
 ClientConnection::ClientConnection(
-    std::shared_ptr<SocketHandler> _socketHandler, const SocketEndpoint& _remoteEndpoint, const string& _id, const string& _key)
+    std::shared_ptr<SocketHandler> _socketHandler,
+    const SocketEndpoint& _remoteEndpoint, const string& _id,
+    const string& _key)
     : Connection(_socketHandler, _id, _key), remoteEndpoint(_remoteEndpoint) {}
 
 ClientConnection::~ClientConnection() {
@@ -27,7 +29,11 @@ void ClientConnection::connect() {
     VLOG(1) << "Receiving client id";
     et::ConnectResponse response =
         socketHandler->readProto<et::ConnectResponse>(socketFd, true);
-    if (response.status() != NEW_CLIENT) {
+    if (response.status() != NEW_CLIENT &&
+        response.status() != RETURNING_CLIENT) {
+      // Note: the response can be returning client if the client died while
+      // performing the initial connection but the server thought the client
+      // survived.
       LOG(ERROR) << "Error connecting to server: " << response.status() << ": "
                  << response.error();
       cout << "Error connecting to server: " << response.status() << ": "

--- a/src/base/Connection.cpp
+++ b/src/base/Connection.cpp
@@ -95,9 +95,7 @@ bool Connection::readMessage(string* buf) {
 }
 
 ssize_t Connection::write(const string& buf) {
-  VLOG(4) << "Before write get connectionMutex";
   lock_guard<std::recursive_mutex> guard(connectionMutex);
-  VLOG(4) << "After write get connectionMutex";
   if (socketFd == -1) {
     return 0;
   }

--- a/src/base/CryptoHandler.cpp
+++ b/src/base/CryptoHandler.cpp
@@ -10,7 +10,7 @@ namespace et {
 CryptoHandler::CryptoHandler(const string& _key, unsigned char nonceMSB) {
   lock_guard<std::mutex> guard(cryptoMutex);
   if (-1 == sodium_init()) {
-    throw std::runtime_error("libsodium init failed");
+    LOG(FATAL) << "libsodium init failed";
   }
   if (_key.length() != crypto_secretbox_KEYBYTES) {
     LOG(FATAL) << "Invalid key length";
@@ -39,7 +39,7 @@ string CryptoHandler::decrypt(const string& buffer) {
   if (crypto_secretbox_open_easy((unsigned char*)&retval[0],
                                  (const unsigned char*)buffer.c_str(),
                                  buffer.length(), nonce, key) == -1) {
-    throw std::runtime_error("Decrypt failed.  Possible key mismatch?");
+    LOG(FATAL) << "Decrypt failed.  Possible key mismatch?";
   }
   return retval;
 }

--- a/src/base/FlakySocketHandler.hpp
+++ b/src/base/FlakySocketHandler.hpp
@@ -1,0 +1,62 @@
+#ifndef __ET_FLAKY_SOCKET_HANDLER__
+#define __ET_FLAKY_SOCKET_HANDLER__
+
+#include "UnixSocketHandler.hpp"
+
+namespace et {
+class FlakySocketHandler : public SocketHandler {
+ public:
+  FlakySocketHandler(shared_ptr<SocketHandler> _actualSocketHandler)
+      : actualSocketHandler(_actualSocketHandler) {}
+  virtual ~FlakySocketHandler() {}
+
+  virtual int connect(const SocketEndpoint& endpoint) {
+    if (rand() % 2 == 0) {
+      return -1;
+    }
+    return actualSocketHandler->connect(endpoint);
+  }
+  virtual set<int> listen(const SocketEndpoint& endpoint) {
+    return actualSocketHandler->listen(endpoint);
+  }
+  virtual set<int> getEndpointFds(const SocketEndpoint& endpoint) {
+    return actualSocketHandler->getEndpointFds(endpoint);
+  }
+  virtual void stopListening(const SocketEndpoint& endpoint) {
+    return actualSocketHandler->stopListening(endpoint);
+  }
+  virtual bool hasData(int fd) {
+    if (rand() % 2 == 0) {
+      return false;
+    }
+    return actualSocketHandler->hasData(fd);
+  }
+  virtual ssize_t read(int fd, void* buf, size_t count) {
+    if (rand() % 20 == 0) {
+      errno=EPIPE;
+      return -1;
+    }
+    return actualSocketHandler->read(fd, buf, count);
+  }
+  virtual ssize_t write(int fd, const void* buf, size_t count) {
+    if (rand() % 20 == 0) {
+      errno=EPIPE;
+      return -1;
+    }
+    return actualSocketHandler->write(fd, buf, count);
+  }
+  virtual int accept(int fd) {
+    if (rand() % 2 == 0) {
+      errno=EAGAIN;
+      return -1;
+    }
+    return actualSocketHandler->accept(fd);
+  }
+  virtual void close(int fd) { actualSocketHandler->close(fd); }
+
+ protected:
+  shared_ptr<SocketHandler> actualSocketHandler;
+};
+}  // namespace et
+
+#endif  // __ET_FLAKY_SOCKET_HANDLER__

--- a/src/base/Headers.hpp
+++ b/src/base/Headers.hpp
@@ -85,6 +85,10 @@ static const unsigned char SERVER_CLIENT_NONCE_MSB = 1;
   if (((X) == -1))    \
     LOG(FATAL) << "Error: (" << errno << "): " << strerror(errno);
 
+#define FATAL_FAIL_UNLESS_EINVAL(X) \
+  if (((X) == -1) && errno != EINVAL)    \
+    LOG(FATAL) << "Error: (" << errno << "): " << strerror(errno);
+
 template <typename Out>
 inline void split(const std::string& s, char delim, Out result) {
   std::stringstream ss;

--- a/src/base/PipeSocketHandler.hpp
+++ b/src/base/PipeSocketHandler.hpp
@@ -16,8 +16,6 @@ class PipeSocketHandler : public UnixSocketHandler {
 
  protected:
   map<string, set<int>> pipeServerSockets;
-
-  void initSocket(int fd);
 };
 }  // namespace et
 

--- a/src/base/ServerConnection.hpp
+++ b/src/base/ServerConnection.hpp
@@ -44,7 +44,7 @@ class ServerConnection {
 
   inline shared_ptr<SocketHandler> getSocketHandler() { return socketHandler; }
 
-  void acceptNewConnection(int fd);
+  bool acceptNewConnection(int fd);
 
   void close();
 

--- a/src/base/TcpSocketHandler.hpp
+++ b/src/base/TcpSocketHandler.hpp
@@ -17,7 +17,7 @@ class TcpSocketHandler : public UnixSocketHandler {
  protected:
   map<int, set<int>> portServerSockets;
 
-  void initSocket(int fd);
+  virtual void initSocket(int fd);
 };
 }  // namespace et
 

--- a/src/base/UnixSocketHandler.hpp
+++ b/src/base/UnixSocketHandler.hpp
@@ -17,7 +17,8 @@ class UnixSocketHandler : public SocketHandler {
 
  protected:
   void addToActiveSockets(int fd);
-  virtual void initSocket(int fd) = 0;
+  virtual void initSocket(int fd);
+  virtual void initServerSocket(int fd);
 
   set<int> activeSockets;
   recursive_mutex mutex;

--- a/test/BackedTest.cpp
+++ b/test/BackedTest.cpp
@@ -18,9 +18,7 @@ class BackedCollector {
     collectorThread = std::thread(&BackedCollector::run, this);
   }
 
-  ~BackedCollector() {
-      finish();
-  }
+  ~BackedCollector() { finish(); }
 
   void run() {
     while (!done) {
@@ -29,7 +27,7 @@ class BackedCollector {
         lock_guard<std::mutex> guard(collectorMutex);
         fifo.push_back(s);
       } else {
-          ::usleep(1000);
+        ::usleep(1000);
       }
     }
   }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,12 +22,16 @@ target_link_libraries(
   TerminalCommon
   et-lib
   ${CMAKE_THREAD_LIBS_INIT}
+  ${PROTOBUF_LIBRARIES}
+  ${GFLAGS_LIBRARIES}
+  ${sodium_LIBRARY_RELEASE}
+  ${SELINUX_LIBRARIES}
+  ${UTEMPTER_LIBRARIES}
+  ${CORE_LIBRARIES}
   gtest
   gtest_main
   gmock
   gmock_main
-  ${GFLAGS_LIBRARIES}
-  ${sodium_LIBRARY_RELEASE}
   resolv
   util
   )

--- a/test/ConnectionTest.cpp
+++ b/test/ConnectionTest.cpp
@@ -1,0 +1,179 @@
+#include "Headers.hpp"
+
+#include "gtest/gtest.h"
+
+#include "ClientConnection.hpp"
+#include "Connection.hpp"
+#include "LogHandler.hpp"
+#include "PipeSocketHandler.hpp"
+#include "ServerConnection.hpp"
+
+using namespace et;
+
+class Collector {
+ public:
+  Collector(shared_ptr<Connection> _connection) : connection(_connection), done(false) {
+    collectorThread = std::thread(&Collector::run, this);
+  }
+
+  ~Collector() {
+    done=true;
+    collectorThread.join();
+  }
+
+  void run() {
+    while (!done) {
+      {
+        lock_guard<std::mutex> guard(collectorMutex);
+        string s;
+        int status = connection->readMessage(&s);
+        if (status == 1) {
+          fifo.push_back(s);
+          if (s == string("DONE")) {
+            break;
+          }
+        } else if (status < 0) {
+          FATAL_FAIL(status);
+        }
+      }
+      ::usleep(1000);
+    }
+  }
+
+  void finish() {
+    done = true;
+    connection->shutdown();
+  }
+
+  bool hasData() {
+    lock_guard<std::mutex> guard(collectorMutex);
+    return !fifo.empty();
+  }
+
+  string pop() {
+    lock_guard<std::mutex> guard(collectorMutex);
+    if (fifo.empty()) {
+      LOG(FATAL) << "Tried to pop an empty fifo";
+    }
+    string s = fifo.front();
+    fifo.pop_front();
+    return s;
+  }
+
+  string read() {
+    while (!hasData()) {
+      ::usleep(1000);
+    }
+    return pop();
+  }
+
+  void write(const string& s) { return connection->writeMessage(s); }
+
+ protected:
+  shared_ptr<Connection> connection;
+  deque<string> fifo;
+  std::thread collectorThread;
+  std::mutex collectorMutex;
+  bool done;
+};
+
+void listenFn(int serverFd, shared_ptr<ServerConnection> serverConnection) {
+  // Only works when there is 1:1 mapping between endpoint and fds.  Will fix in
+  // future api
+  while (true) {
+    if (serverConnection->acceptNewConnection(serverFd)) {
+      return;
+    }
+    ::usleep(10 * 1000);  // Sleep 10ms for client to connect
+  }
+}
+
+shared_ptr<ServerClientConnection> serverClientConnection;
+class NewConnectionHandler : public ServerConnectionHandler {
+ public:
+  virtual bool newClient(
+      shared_ptr<ServerClientConnection> _serverClientState) {
+    serverClientConnection = _serverClientState;
+    return true;
+  }
+};
+
+class ConnectionTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    srand(1);
+
+    serverSocketHandler.reset(new PipeSocketHandler());
+    clientSocketHandler.reset(new PipeSocketHandler());
+
+    const string CRYPTO_KEY = "12345678901234567890123456789012";
+    const string CLIENT_ID = "1234567890123456";
+
+    string tmpPath = string("/tmp/et_test_XXXXXXXX");
+    pipeDirectory = string(mkdtemp(&tmpPath[0]));
+    pipePath = string(pipeDirectory) + "/pipe";
+    SocketEndpoint endpoint(pipePath);
+
+    serverConnection.reset(new ServerConnection(
+        serverSocketHandler, endpoint,
+        shared_ptr<ServerConnectionHandler>(new NewConnectionHandler())));
+    serverConnection->addClientKey(CLIENT_ID, CRYPTO_KEY);
+
+    int serverFd = *(serverSocketHandler->getEndpointFds(endpoint).begin());
+    std::thread serverListenThread(listenFn, serverFd, serverConnection);
+
+    // Wait for server to spin up
+    ::usleep(100 * 1000);
+    clientConnection.reset(new ClientConnection(clientSocketHandler, endpoint,
+                                                CLIENT_ID, CRYPTO_KEY));
+    clientConnection->connect();
+    serverListenThread.join();
+
+    serverCollector.reset(
+        new Collector(std::static_pointer_cast<Connection>(serverClientConnection)));
+    clientCollector.reset(
+        new Collector(std::static_pointer_cast<Connection>(clientConnection)));
+  }
+
+  void TearDown() override {
+    FATAL_FAIL(::remove(pipePath.c_str()));
+    FATAL_FAIL(::remove(pipeDirectory.c_str()));
+  }
+
+  shared_ptr<PipeSocketHandler> serverSocketHandler;
+  shared_ptr<PipeSocketHandler> clientSocketHandler;
+  shared_ptr<ServerConnection> serverConnection;
+  shared_ptr<ClientConnection> clientConnection;
+  shared_ptr<Collector> serverCollector;
+  shared_ptr<Collector> clientCollector;
+  string pipeDirectory;
+  string pipePath;
+};
+
+TEST_F(ConnectionTest, ReadWrite) {
+  string s(64 * 1024, '\0');
+  for (int a = 0; a < 64 * 1024 - 1; a++) {
+    s[a] = rand() % 26 + 'A';
+  }
+  s[64 * 1024 - 1] = 0;
+
+  for (int a = 0; a < 64; a++) {
+    VLOG(1) << "Writing packet " << a;
+    serverCollector->write(string((&s[0] + a * 1024), 1024));
+  }
+  serverCollector->write("DONE");
+
+  string resultConcat;
+  string result;
+  for (int a = 0; a < 64; a++) {
+    result = clientCollector->read();
+    resultConcat = resultConcat.append(result);
+  }
+  result = clientCollector->read();
+  EXPECT_EQ(result, "DONE");
+
+  serverCollector->finish();
+  serverConnection->close();
+
+  EXPECT_EQ(resultConcat, s);
+}

--- a/test/Main.cpp
+++ b/test/Main.cpp
@@ -8,6 +8,7 @@ DEFINE_int32(v, 0, "verbose level");
 
 int main(int argc, char **argv) {
   srand(1);
+  testing::InitGoogleTest(&argc, argv);
 
   // Setup easylogging configurations
   el::Configurations defaultConf =
@@ -18,6 +19,5 @@ int main(int argc, char **argv) {
   // Reconfigure default logger to apply settings above
   el::Loggers::reconfigureLogger("default", defaultConf);
 
-  testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
I added a flaky test and this exposed some errors:

1. It's possible for a client to get a RETURNING_CLIENT from the server on the first successful connect if the client connection dies right as the connection is established.
2. If a connection dies early, initSocket() could FATAL
3. Some ServerConnection cleanup was needed to prevent crash on exit
4. I went back to blocking sockets now that SNDTIMEO and RCVTIMEO work reliably