### PR TITLE
Switch to using the protobuf-lite library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,7 +165,7 @@ target_link_libraries (
   TerminalCommon
   et-lib
   ${CMAKE_THREAD_LIBS_INIT}
-  ${PROTOBUF_LIBRARIES}
+  ${PROTOBUF_LITE_LIBRARIES}
   ${sodium_LIBRARY_RELEASE}
   ${SELINUX_LIBRARIES}
   ${UTEMPTER_LIBRARIES}
@@ -183,7 +183,7 @@ target_link_libraries (
   TerminalCommon
   et-lib
   ${CMAKE_THREAD_LIBS_INIT}
-  ${PROTOBUF_LIBRARIES}
+  ${PROTOBUF_LITE_LIBRARIES}
   ${sodium_LIBRARY_RELEASE}
   ${SELINUX_LIBRARIES}
   ${UTEMPTER_LIBRARIES}
@@ -201,7 +201,7 @@ target_link_libraries (
     TerminalCommon
     et-lib
     ${CMAKE_THREAD_LIBS_INIT}
-    ${PROTOBUF_LIBRARIES}
+    ${PROTOBUF_LITE_LIBRARIES}
     ${sodium_LIBRARY_RELEASE}
     ${UTEMPTER_LIBRARIES}
     ${CORE_LIBRARIES}
@@ -237,7 +237,7 @@ target_link_libraries (
   HtmCommon
   et-lib
   ${CMAKE_THREAD_LIBS_INIT}
-  ${PROTOBUF_LIBRARIES}
+  ${PROTOBUF_LITE_LIBRARIES}
   ${sodium_LIBRARY_RELEASE}
   ${SELINUX_LIBRARIES}
   ${UTEMPTER_LIBRARIES}
@@ -257,7 +257,7 @@ target_link_libraries (
   HtmCommon
   et-lib
   ${CMAKE_THREAD_LIBS_INIT}
-  ${PROTOBUF_LIBRARIES}
+  ${PROTOBUF_LITE_LIBRARIES}
   ${sodium_LIBRARY_RELEASE}
   ${SELINUX_LIBRARIES}
   ${UTEMPTER_LIBRARIES}
@@ -284,7 +284,7 @@ target_link_libraries(
   TerminalCommon
   et-lib
   ${CMAKE_THREAD_LIBS_INIT}
-  ${PROTOBUF_LIBRARIES}
+  ${PROTOBUF_LITE_LIBRARIES}
   ${sodium_LIBRARY_RELEASE}
   ${SELINUX_LIBRARIES}
   ${UTEMPTER_LIBRARIES}

--- a/proto/ET.proto
+++ b/proto/ET.proto
@@ -1,5 +1,6 @@
 syntax = "proto2";
 package et;
+option optimize_for = LITE_RUNTIME;
 
 enum EtPacketType {
   // Count down from 254 to avoid collisions

--- a/proto/ETerminal.proto
+++ b/proto/ETerminal.proto
@@ -1,5 +1,6 @@
 syntax = "proto2";
 package et;
+option optimize_for = LITE_RUNTIME;
 
 enum TerminalPacketType {
   KEEP_ALIVE = 0;

--- a/src/base/Headers.hpp
+++ b/src/base/Headers.hpp
@@ -55,7 +55,7 @@
 #include <unordered_set>
 #include <vector>
 
-#include <google/protobuf/message.h>
+#include <google/protobuf/message_lite.h>
 #include "ET.pb.h"
 #include "easylogging++.h"
 

--- a/src/base/SocketHandler.hpp
+++ b/src/base/SocketHandler.hpp
@@ -45,12 +45,12 @@ class SocketHandler {
   inline void writeProto(int fd, const T& t, bool timeout) {
     string s;
     if (!t.SerializeToString(&s)) {
-      LOG(FATAL) << "Serialization of " << t.DebugString() << " failed!";
+      LOG(FATAL) << "Serialization of " << t.GetTypeName() << " failed!";
     }
     int64_t length = s.length();
     if (length < 0 || length > 128 * 1024 * 1024) {
       LOG(FATAL) << "Invalid proto length: " << length << " For proto "
-                 << t.DebugString();
+                 << t.GetTypeName();
     }
     writeAllOrThrow(fd, &length, sizeof(int64_t), timeout);
     if (length > 0) {

--- a/src/terminal/TerminalClient.cpp
+++ b/src/terminal/TerminalClient.cpp
@@ -272,7 +272,11 @@ void TerminalClient::run(const string& command, const string& tunnels,
         TerminalInfo ti = console->getTerminalInfo();
 
         if (ti != lastTerminalInfo) {
-          LOG(INFO) << "Window size changed: " << ti.DebugString();
+          LOG(INFO)
+              << "Window size changed: row: " << ti.row()
+              << " column: " << ti.column()
+              << " width: " << ti.width()
+              << " height: " << ti.height();
           lastTerminalInfo = ti;
           connection->writePacket(
               Packet(TerminalPacketType::TERMINAL_INFO, protoToString(ti)));


### PR DESCRIPTION
Hi,

This pull requests switches from using the full protobuf library to the lite version, which reduces our binary size by about 10 MB.

The `DebugString()` method was the only full protobuf feature being used in the ET code. It was being used in a few logs. I was able to provide a suitable replacement for the log line in which we know the message type, but the other two log lines are in templated methods. The best I could do there was to replace the debug string with the message type.

If this will make diagnosing issues too difficult, I could look into perhaps `#ifdef` ing the code into lite and regular variants.

Thanks!