### PR TITLE
Write a pidfile for the 2nd child process for systemd.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,11 @@ sudo cp ../etc/et.cfg /etc/
 ```
 Find the actual location of et:
 
-	which etserver	
+	which etserver
 
 Correct the service file:
 Open up /etc/systemd/system/et.service in an editor.
-Correct the ExectStart line to have the correct path to the etserver binary (see [#180](https://github.com/MisterTea/EternalTerminal/issues/180)). 
+Correct the ExectStart line to have the correct path to the etserver binary (see [#180](https://github.com/MisterTea/EternalTerminal/issues/180)).
 
 	 ExecStart=/usr/local/bin/etserver --daemon --cfgfile=/etc/et.cfg
 
@@ -85,7 +85,7 @@ Start the et service:
 sudo systemctl enable et.service
 sudo systemctl start et.service
 ```
-	
+
 
 ### FreeBSD
 On FreeBSD, use:
@@ -187,12 +187,26 @@ cmake ../
 make
 ```
 
-### Debian/Ubuntu
+### Debian/Ubuntu/CentOS
 
 Grab the deps and then follow this process:
 
+Debian/Ubuntu Dependencies:
 ```
 sudo apt install libboost-dev libsodium-dev libncurses5-dev libprotobuf-dev protobuf-compiler cmake libgflags-dev libutempter-dev cmake git
+```
+
+CentOS/RHEL Dependencies:
+```
+sudo yum -y install epel-release
+sudo yum install cmake3
+sudo yum install boost-devel libsodium-devel ncurses-devel protobuf-devel \
+  protobuf-compiler cmake gflags-devel wget unzip
+```
+
+Source and setup:
+
+```
 git clone --recurse-submodules https://github.com/MisterTea/EternalTerminal.git
 cd EternalTerminal
 mkdir build

--- a/src/base/DaemonCreator.hpp
+++ b/src/base/DaemonCreator.hpp
@@ -6,7 +6,7 @@
 namespace et {
 class DaemonCreator {
  public:
-  static int create(bool terminateParent);
+  static int create(bool terminateParent, string childPidFile);
   static const int PARENT = 1;
   static const int CHILD = 2;
 };

--- a/src/htm/HtmClientMain.cpp
+++ b/src/htm/HtmClientMain.cpp
@@ -86,7 +86,7 @@ int main(int argc, char** argv) {
 
   if (pgrepOutput.length() == 0) {
     // Fork to create the daemon
-    int result = DaemonCreator::create(false);
+    int result = DaemonCreator::create(false, "");
     if (result == DaemonCreator::CHILD) {
       // This means we are the daemon
       exit(system("htmd"));

--- a/src/terminal/TerminalMain.cpp
+++ b/src/terminal/TerminalMain.cpp
@@ -129,7 +129,7 @@ int main(int argc, char **argv) {
     el::Helpers::installPreRollOutCallback(LogHandler::rolloutHandler);
 
     cout << "IDPASSKEY:" << idpasskey << endl;
-    if (DaemonCreator::create(true) == -1) {
+    if (DaemonCreator::create(true, "") == -1) {
       LOG(FATAL) << "Error creating daemon: " << strerror(errno);
     }
     shared_ptr<SocketHandler> jumpClientSocketHandler(new TcpSocketHandler());
@@ -160,7 +160,7 @@ int main(int argc, char **argv) {
   UserTerminalHandler uth(ipcSocketHandler, term, true,
                           SocketEndpoint(ROUTER_FIFO_NAME), idpasskey);
   cout << "IDPASSKEY:" << idpasskey << endl;
-  if (DaemonCreator::create(true) == -1) {
+  if (DaemonCreator::create(true, "") == -1) {
     LOG(FATAL) << "Error creating daemon: " << strerror(errno);
   }
   uth.run();

--- a/src/terminal/TerminalServerMain.cpp
+++ b/src/terminal/TerminalServerMain.cpp
@@ -24,6 +24,8 @@ int main(int argc, char **argv) {
       ("cfgfile", "Location of the config file",
        cxxopts::value<std::string>()->default_value(""))  //
       ("logtostdout", "log to stdout")                    //
+      ("pidfile", "Location of the pid file",
+        cxxopts::value<std::string>()->default_value("/var/run/etserver.pid"))  //
       ("v,verbose", "Enable verbose logging",
        cxxopts::value<int>()->default_value("0"))  //
       ;
@@ -39,7 +41,7 @@ int main(int argc, char **argv) {
   }
 
   if (result.count("daemon")) {
-    if (DaemonCreator::create(true) == -1) {
+    if (DaemonCreator::create(true, result["pidfile"].as<string>()) == -1) {
       LOG(FATAL) << "Error creating daemon: " << strerror(errno);
     }
   }
@@ -108,6 +110,8 @@ int main(int argc, char **argv) {
   el::Helpers::installPreRollOutCallback(LogHandler::rolloutHandler);
   std::shared_ptr<SocketHandler> tcpSocketHandler(new TcpSocketHandler());
   std::shared_ptr<PipeSocketHandler> pipeSocketHandler(new PipeSocketHandler());
+
+  LOG(INFO) << "In child, about to start server.";
 
   TerminalServer terminalServer(tcpSocketHandler, SocketEndpoint(port),
                                 pipeSocketHandler,

--- a/systemctl/et.service
+++ b/systemctl/et.service
@@ -4,6 +4,7 @@ After=syslog.target network.target
 
 [Service]
 Type=forking
+PIDFile=/var/run/etserver.pid
 ExecStart=/usr/bin/etserver --daemon --cfgfile=/etc/et.cfg
 
 [Install]


### PR DESCRIPTION
DaemonCreator forks twice which confuses systemd, so this changes has
the main child process write a pidfile which can be referenced in the
et.service systemd configuration.