### PR TITLE
Add exception handling to cxxopt usage.

### DIFF
--- a/src/terminal/TerminalClientMain.cpp
+++ b/src/terminal/TerminalClientMain.cpp
@@ -23,210 +23,216 @@ int main(int argc, char** argv) {
 
   // Parse command line arguments
   cxxopts::Options options("et", "Remote shell for the busy and impatient");
-  options.positional_help("[user@]hostname[:port]").show_positional_help();
-  options.allow_unrecognised_options();
+  try {
+    options.positional_help("[user@]hostname[:port]").show_positional_help();
+    options.allow_unrecognised_options();
 
-  options.add_options()             //
-      ("help", "Print help")        //
-      ("version", "Print version")  //
-      ("u,username", "Username")    //
-      ("host", "Remote host name",
-       cxxopts::value<std::string>())  //
-      ("p,port", "Remote machine port",
-       cxxopts::value<int>()->default_value("2022"))  //
-      ("c,command", "Run command on connect",
-       cxxopts::value<std::string>())  //
-      ("prefix", "Add prefix when launching etterminal on server side",
-       cxxopts::value<std::string>())  //
-      ("t,tunnel",
-       "Tunnel: Array of source:destination ports or "
-       "srcStart-srcEnd:dstStart-dstEnd (inclusive) port ranges (e.g. "
-       "10080:80,10443:443, 10090-10092:8000-8002)",
-       cxxopts::value<std::string>())  //
-      ("r,reversetunnel",
-       "Reverse Tunnel: Array of source:destination ports or "
-       "srcStart-srcEnd:dstStart-dstEnd (inclusive) port ranges",
-       cxxopts::value<std::string>())  //
-      ("jumphost", "jumphost between localhost and destination",
-       cxxopts::value<std::string>())  //
-      ("jport", "Jumphost machine port",
-       cxxopts::value<int>()->default_value("2022"))  //
-      ("x,kill-other-sessions",
-       "kill all old sessions belonging to the user")  //
-      ("v,verbose", "Enable verbose logging",
-       cxxopts::value<int>()->default_value("0"))    //
-      ("logtostdout", "Write log to stdout")         //
-      ("silent", "Disable logging")                  //
-      ("N,no-terminal", "Do not create a terminal")  //
-      ;
+    options.add_options()             //
+        ("h,help", "Print help")        //
+        ("version", "Print version")  //
+        ("u,username", "Username")    //
+        ("host", "Remote host name",
+         cxxopts::value<std::string>())  //
+        ("p,port", "Remote machine port",
+         cxxopts::value<int>()->default_value("2022"))  //
+        ("c,command", "Run command on connect",
+         cxxopts::value<std::string>())  //
+        ("prefix", "Add prefix when launching etterminal on server side",
+         cxxopts::value<std::string>())  //
+        ("t,tunnel",
+         "Tunnel: Array of source:destination ports or "
+         "srcStart-srcEnd:dstStart-dstEnd (inclusive) port ranges (e.g. "
+         "10080:80,10443:443, 10090-10092:8000-8002)",
+         cxxopts::value<std::string>())  //
+        ("r,reversetunnel",
+         "Reverse Tunnel: Array of source:destination ports or "
+         "srcStart-srcEnd:dstStart-dstEnd (inclusive) port ranges",
+         cxxopts::value<std::string>())  //
+        ("jumphost", "jumphost between localhost and destination",
+         cxxopts::value<std::string>())  //
+        ("jport", "Jumphost machine port",
+         cxxopts::value<int>()->default_value("2022"))  //
+        ("x,kill-other-sessions",
+         "kill all old sessions belonging to the user")  //
+        ("v,verbose", "Enable verbose logging",
+         cxxopts::value<int>()->default_value("0"))    //
+        ("logtostdout", "Write log to stdout")         //
+        ("silent", "Disable logging")                  //
+        ("N,no-terminal", "Do not create a terminal")  //
+        ;
 
-  options.parse_positional({"host", "positional"});
+    options.parse_positional({"host", "positional"});
 
-  auto result = options.parse(argc, argv);
-  if (result.count("help")) {
-    cout << options.help({}) << endl;
-    exit(0);
-  }
-  if (result.count("version")) {
-    cout << "et version " << ET_VERSION << endl;
-    exit(0);
-  }
-
-  if (result.count("logtostdout")) {
-    defaultConf.setGlobally(el::ConfigurationType::ToStandardOutput, "true");
-  } else {
-    defaultConf.setGlobally(el::ConfigurationType::ToStandardOutput, "false");
-    // Redirect std streams to a file
-    LogHandler::stderrToFile("/tmp/etclient");
-  }
-
-  // silent Flag, since etclient doesn't read /etc/et.cfg file
-  if (result.count("silent")) {
-    defaultConf.setGlobally(el::ConfigurationType::Enabled, "false");
-  }
-
-  LogHandler::setupLogFile(&defaultConf,
-                           "/tmp/etclient-%datetime{%Y-%M-%d_%H_%m_%s}.log");
-
-  el::Loggers::reconfigureLogger("default", defaultConf);
-  // set thread name
-  el::Helpers::setThreadName("client-main");
-
-  // Install log rotation callback
-  el::Helpers::installPreRollOutCallback(LogHandler::rolloutHandler);
-
-  GOOGLE_PROTOBUF_VERIFY_VERSION;
-  srand(1);
-
-  string username = "";
-  if (result.count("username")) {
-    username = result["username"].as<string>();
-  }
-  int port = result["port"].as<int>();
-  LOG(INFO) << "Port initially set to " << port;
-  string host;
-
-  // Parse command-line argument
-  if (!result.count("host")) {
-    cout << "Missing host to connect to" << endl;
-    cout << options.help({}) << endl;
-    exit(0);
-  }
-  string arg = result["host"].as<std::string>();
-  if (arg.find('@') != string::npos) {
-    int i = arg.find('@');
-    username = arg.substr(0, i);
-    arg = arg.substr(i + 1);
-  }
-  if (arg.find(':') != string::npos) {
-    int i = arg.find(':');
-    port = stoi(arg.substr(i + 1));
-    arg = arg.substr(0, i);
-  }
-  host = arg;
-
-  Options sshConfigOptions = {
-      NULL,  // username
-      NULL,  // host
-      NULL,  // sshdir
-      NULL,  // knownhosts
-      NULL,  // ProxyCommand
-      NULL,  // ProxyJump
-      0,     // timeout
-      0,     // port
-      0,     // StrictHostKeyChecking
-      0,     // ssh2
-      0,     // ssh1
-      NULL,  // gss_server_identity
-      NULL,  // gss_client_identity
-      0      // gss_delegate_creds
-  };
-
-  char* home_dir = ssh_get_user_home_dir();
-  string host_alias = host;
-  ssh_options_set(&sshConfigOptions, SSH_OPTIONS_HOST, host.c_str());
-  // First parse user-specific ssh config, then system-wide config.
-  parse_ssh_config_file(&sshConfigOptions,
-                        string(home_dir) + USER_SSH_CONFIG_PATH);
-  parse_ssh_config_file(&sshConfigOptions, SYSTEM_SSH_CONFIG_PATH);
-  LOG(INFO) << "Parsed ssh config file, connecting to "
-            << sshConfigOptions.host;
-  host = string(sshConfigOptions.host);
-
-  // Parse username: cmdline > sshconfig > localuser
-  if (username.empty()) {
-    if (sshConfigOptions.username) {
-      username = string(sshConfigOptions.username);
-    } else {
-      username = string(ssh_get_local_username());
+    auto result = options.parse(argc, argv);
+    if (result.count("help")) {
+      cout << options.help({}) << endl;
+      exit(0);
     }
-  }
+    if (result.count("version")) {
+      cout << "et version " << ET_VERSION << endl;
+      exit(0);
+    }
 
-  // Parse jumphost: cmd > sshconfig
-  string jumphost =
-      result.count("jumphost") ? result["jumphost"].as<string>() : "";
-  if (sshConfigOptions.ProxyJump && jumphost.length() == 0) {
-    string proxyjump = string(sshConfigOptions.ProxyJump);
-    size_t colonIndex = proxyjump.find(":");
-    if (colonIndex != string::npos) {
-      string userhostpair = proxyjump.substr(0, colonIndex);
-      size_t atIndex = userhostpair.find("@");
-      if (atIndex != string::npos) {
-        jumphost = userhostpair.substr(atIndex + 1);
+    if (result.count("logtostdout")) {
+      defaultConf.setGlobally(el::ConfigurationType::ToStandardOutput, "true");
+    } else {
+      defaultConf.setGlobally(el::ConfigurationType::ToStandardOutput, "false");
+      // Redirect std streams to a file
+      LogHandler::stderrToFile("/tmp/etclient");
+    }
+
+    // silent Flag, since etclient doesn't read /etc/et.cfg file
+    if (result.count("silent")) {
+      defaultConf.setGlobally(el::ConfigurationType::Enabled, "false");
+    }
+
+    LogHandler::setupLogFile(&defaultConf,
+                             "/tmp/etclient-%datetime{%Y-%M-%d_%H_%m_%s}.log");
+
+    el::Loggers::reconfigureLogger("default", defaultConf);
+    // set thread name
+    el::Helpers::setThreadName("client-main");
+
+    // Install log rotation callback
+    el::Helpers::installPreRollOutCallback(LogHandler::rolloutHandler);
+
+    GOOGLE_PROTOBUF_VERIFY_VERSION;
+    srand(1);
+
+    string username = "";
+    if (result.count("username")) {
+      username = result["username"].as<string>();
+    }
+    int port = result["port"].as<int>();
+    LOG(INFO) << "Port initially set to " << port;
+    string host;
+
+    // Parse command-line argument
+    if (!result.count("host")) {
+      cout << "Missing host to connect to" << endl;
+      cout << options.help({}) << endl;
+      exit(0);
+    }
+    string arg = result["host"].as<std::string>();
+    if (arg.find('@') != string::npos) {
+      int i = arg.find('@');
+      username = arg.substr(0, i);
+      arg = arg.substr(i + 1);
+    }
+    if (arg.find(':') != string::npos) {
+      int i = arg.find(':');
+      port = stoi(arg.substr(i + 1));
+      arg = arg.substr(0, i);
+    }
+    host = arg;
+
+    Options sshConfigOptions = {
+        NULL,  // username
+        NULL,  // host
+        NULL,  // sshdir
+        NULL,  // knownhosts
+        NULL,  // ProxyCommand
+        NULL,  // ProxyJump
+        0,     // timeout
+        0,     // port
+        0,     // StrictHostKeyChecking
+        0,     // ssh2
+        0,     // ssh1
+        NULL,  // gss_server_identity
+        NULL,  // gss_client_identity
+        0      // gss_delegate_creds
+    };
+
+    char* home_dir = ssh_get_user_home_dir();
+    string host_alias = host;
+    ssh_options_set(&sshConfigOptions, SSH_OPTIONS_HOST, host.c_str());
+    // First parse user-specific ssh config, then system-wide config.
+    parse_ssh_config_file(&sshConfigOptions,
+                          string(home_dir) + USER_SSH_CONFIG_PATH);
+    parse_ssh_config_file(&sshConfigOptions, SYSTEM_SSH_CONFIG_PATH);
+    LOG(INFO) << "Parsed ssh config file, connecting to "
+              << sshConfigOptions.host;
+    host = string(sshConfigOptions.host);
+
+    // Parse username: cmdline > sshconfig > localuser
+    if (username.empty()) {
+      if (sshConfigOptions.username) {
+        username = string(sshConfigOptions.username);
+      } else {
+        username = string(ssh_get_local_username());
       }
-    } else {
-      jumphost = proxyjump;
     }
-    LOG(INFO) << "ProxyJump found for dst in ssh config: " << proxyjump;
-  }
 
-  bool is_jumphost = false;
-  if (!jumphost.empty()) {
-    is_jumphost = true;
-    host = jumphost;
-    port = result["jport"].as<int>();
-    LOG(INFO) << "Setting port to jumphost port";
-  }
-  SocketEndpoint socketEndpoint = SocketEndpoint(host, port, is_jumphost);
-  shared_ptr<SocketHandler> clientSocket(new TcpSocketHandler());
+    // Parse jumphost: cmd > sshconfig
+    string jumphost =
+        result.count("jumphost") ? result["jumphost"].as<string>() : "";
+    if (sshConfigOptions.ProxyJump && jumphost.length() == 0) {
+      string proxyjump = string(sshConfigOptions.ProxyJump);
+      size_t colonIndex = proxyjump.find(":");
+      if (colonIndex != string::npos) {
+        string userhostpair = proxyjump.substr(0, colonIndex);
+        size_t atIndex = userhostpair.find("@");
+        if (atIndex != string::npos) {
+          jumphost = userhostpair.substr(atIndex + 1);
+        }
+      } else {
+        jumphost = proxyjump;
+      }
+      LOG(INFO) << "ProxyJump found for dst in ssh config: " << proxyjump;
+    }
 
-  if (!ping(socketEndpoint, clientSocket)) {
-    cout << "Could not reach the ET server: " << host << ":" << port << endl;
+    bool is_jumphost = false;
+    if (!jumphost.empty()) {
+      is_jumphost = true;
+      host = jumphost;
+      port = result["jport"].as<int>();
+      LOG(INFO) << "Setting port to jumphost port";
+    }
+    SocketEndpoint socketEndpoint = SocketEndpoint(host, port, is_jumphost);
+    shared_ptr<SocketHandler> clientSocket(new TcpSocketHandler());
+
+    if (!ping(socketEndpoint, clientSocket)) {
+      cout << "Could not reach the ET server: " << host << ":" << port << endl;
+      exit(1);
+    }
+
+    int jport = result["jport"].as<int>();
+    string idpasskeypair = SshSetupHandler::SetupSsh(
+        username, host, host_alias, port, jumphost, jport, result.count("x") > 0,
+        result["v"].as<int>(),
+        result.count("prefix") ? result["prefix"].as<string>() : "");
+
+    string id = "", passkey = "";
+    // Trim whitespace
+    idpasskeypair.erase(idpasskeypair.find_last_not_of(" \n\r\t") + 1);
+    size_t slashIndex = idpasskeypair.find("/");
+    if (slashIndex == string::npos) {
+      LOG(FATAL) << "Invalid idPasskey id/key pair: " << idpasskeypair;
+    } else {
+      id = idpasskeypair.substr(0, slashIndex);
+      passkey = idpasskeypair.substr(slashIndex + 1);
+      LOG(INFO) << "ID PASSKEY: " << id << " " << passkey;
+    }
+    if (passkey.length() != 32) {
+      LOG(FATAL) << "Invalid/missing passkey: " << passkey << " "
+                 << passkey.length();
+    }
+    shared_ptr<Console> console;
+    if (!result.count("N")) {
+      console.reset(new PsuedoTerminalConsole());
+    }
+
+    TerminalClient terminalClient =
+        TerminalClient(clientSocket, socketEndpoint, id, passkey, console);
+    terminalClient.run(
+        result.count("command") ? result["command"].as<string>() : "",
+        result.count("t") ? result["t"].as<string>() : "",
+        result.count("rt") ? result["rt"].as<string>() : "");
+  } catch (cxxopts::OptionException& oe) {
+    cout << "Exception: " << oe.what() << "\n" << endl;
+    cout << options.help({}) << endl;
     exit(1);
   }
-
-  int jport = result["jport"].as<int>();
-  string idpasskeypair = SshSetupHandler::SetupSsh(
-      username, host, host_alias, port, jumphost, jport, result.count("x") > 0,
-      result["v"].as<int>(),
-      result.count("prefix") ? result["prefix"].as<string>() : "");
-
-  string id = "", passkey = "";
-  // Trim whitespace
-  idpasskeypair.erase(idpasskeypair.find_last_not_of(" \n\r\t") + 1);
-  size_t slashIndex = idpasskeypair.find("/");
-  if (slashIndex == string::npos) {
-    LOG(FATAL) << "Invalid idPasskey id/key pair: " << idpasskeypair;
-  } else {
-    id = idpasskeypair.substr(0, slashIndex);
-    passkey = idpasskeypair.substr(slashIndex + 1);
-    LOG(INFO) << "ID PASSKEY: " << id << " " << passkey;
-  }
-  if (passkey.length() != 32) {
-    LOG(FATAL) << "Invalid/missing passkey: " << passkey << " "
-               << passkey.length();
-  }
-  shared_ptr<Console> console;
-  if (!result.count("N")) {
-    console.reset(new PsuedoTerminalConsole());
-  }
-
-  TerminalClient terminalClient =
-      TerminalClient(clientSocket, socketEndpoint, id, passkey, console);
-  terminalClient.run(
-      result.count("command") ? result["command"].as<string>() : "",
-      result.count("t") ? result["t"].as<string>() : "",
-      result.count("rt") ? result["rt"].as<string>() : "");
 
   // Uninstall log rotation callback
   el::Helpers::uninstallPreRollOutCallback();

--- a/src/terminal/TerminalMain.cpp
+++ b/src/terminal/TerminalMain.cpp
@@ -23,147 +23,155 @@ int main(int argc, char **argv) {
 
   // Parse command line arguments
   cxxopts::Options options("et", "Remote shell for the busy and impatient");
-  options.positional_help("[user@]hostname[:port]").show_positional_help();
-  options.allow_unrecognised_options();
 
-  options.add_options()       //
-      ("help", "Print help")  //
-      ("idpasskey",
-       "If set, uses IPC to send a client id/key to the server daemon",
-       cxxopts::value<std::string>()->default_value(""))  //
-      ("idpasskeyfile",
-       "If set, uses IPC to send a client id/key to the server daemon from a "
-       "file",
-       cxxopts::value<std::string>()->default_value(""))  //
-      ("jump",
-       "If set, forward all packets between client and dst terminal")  //
-      ("dsthost", "Must be set if jump is set to true",
-       cxxopts::value<std::string>()->default_value(""))  //
-      ("dstport", "Must be set if jump is set to true",
-       cxxopts::value<int>()->default_value("2022"))  //
-      ("v,verbose", "Enable verbose logging",
-       cxxopts::value<int>()->default_value("0"))  //
-      ("logtostdout", "Write log to stdout")       //
-      ;
+  try {
+    options.positional_help("[user@]hostname[:port]").show_positional_help();
+    options.allow_unrecognised_options();
 
-  options.parse_positional({"host", "positional"});
+    options.add_options()       //
+        ("h,help", "Print help")  //
+        ("idpasskey",
+         "If set, uses IPC to send a client id/key to the server daemon",
+         cxxopts::value<std::string>()->default_value(""))  //
+        ("idpasskeyfile",
+         "If set, uses IPC to send a client id/key to the server daemon from a "
+         "file",
+         cxxopts::value<std::string>()->default_value(""))  //
+        ("jump",
+         "If set, forward all packets between client and dst terminal")  //
+        ("dsthost", "Must be set if jump is set to true",
+         cxxopts::value<std::string>()->default_value(""))  //
+        ("dstport", "Must be set if jump is set to true",
+         cxxopts::value<int>()->default_value("2022"))  //
+        ("v,verbose", "Enable verbose logging",
+         cxxopts::value<int>()->default_value("0"))  //
+        ("logtostdout", "Write log to stdout")       //
+        ;
 
-  auto result = options.parse(argc, argv);
-  if (result.count("help")) {
-    cout << options.help({}) << endl;
-    exit(0);
-  }
+    options.parse_positional({"host", "positional"});
 
-  if (result.count("logtostdout")) {
-    defaultConf.setGlobally(el::ConfigurationType::ToStandardOutput, "true");
-  } else {
-    defaultConf.setGlobally(el::ConfigurationType::ToStandardOutput, "false");
-  }
-
-  // default max log file size is 20MB for etserver
-  string maxlogsize = "20971520";
-
-  GOOGLE_PROTOBUF_VERIFY_VERSION;
-  srand(1);
-
-  shared_ptr<SocketHandler> ipcSocketHandler(new PipeSocketHandler());
-  shared_ptr<PsuedoUserTerminal> term(new PsuedoUserTerminal());
-
-  string idpasskey;
-  if (result.count("idpasskey") == 0 && result.count("idpasskeyfile") == 0) {
-    // Try to read from stdin
-    struct timeval timeout;
-    timeout.tv_sec = 1;
-    timeout.tv_usec = 0;
-    fd_set readfds;
-    FD_ZERO(&readfds);
-
-    FD_SET(STDIN_FILENO, &readfds);
-
-    int res = select(1, &readfds, NULL, NULL, &timeout);
-    if (res < 0) {
-      FATAL_FAIL(res);
-    }
-    if (res == 0) {
-      cout << "Call etterminal with --idpasskey or --idpasskeyfile, or feed "
-              "this information on stdin\n";
-      exit(1);
+    auto result = options.parse(argc, argv);
+    if (result.count("help")) {
+      cout << options.help({}) << endl;
+      exit(0);
     }
 
-    string stdinData;
-    if (!getline(cin, stdinData)) {
-      cout << "Call etterminal with --idpasskey or --idpasskeyfile, or feed "
-              "this information on stdin\n";
-      exit(1);
+    if (result.count("logtostdout")) {
+      defaultConf.setGlobally(el::ConfigurationType::ToStandardOutput, "true");
+    } else {
+      defaultConf.setGlobally(el::ConfigurationType::ToStandardOutput, "false");
     }
-    auto tokens = split(stdinData, '_');
-    idpasskey = tokens[0];
-    FATAL_FAIL(setenv("TERM", tokens[1].c_str(), 1));
-  } else {
-    string idpasskey = result["idpasskey"].as<string>();
-    if (result.count("idpasskeyfile")) {
-      // Check for passkey file
-      std::ifstream t(result["idpasskeyfile"].as<string>().c_str());
-      std::stringstream buffer;
-      buffer << t.rdbuf();
-      idpasskey = buffer.str();
-      // Trim whitespace
-      idpasskey.erase(idpasskey.find_last_not_of(" \n\r\t") + 1);
+
+    // default max log file size is 20MB for etserver
+    string maxlogsize = "20971520";
+
+    GOOGLE_PROTOBUF_VERIFY_VERSION;
+    srand(1);
+
+    shared_ptr<SocketHandler> ipcSocketHandler(new PipeSocketHandler());
+    shared_ptr<PsuedoUserTerminal> term(new PsuedoUserTerminal());
+
+    string idpasskey;
+    if (result.count("idpasskey") == 0 && result.count("idpasskeyfile") == 0) {
+      // Try to read from stdin
+      struct timeval timeout;
+      timeout.tv_sec = 1;
+      timeout.tv_usec = 0;
+      fd_set readfds;
+      FD_ZERO(&readfds);
+
+      FD_SET(STDIN_FILENO, &readfds);
+
+      int res = select(1, &readfds, NULL, NULL, &timeout);
+      if (res < 0) {
+        FATAL_FAIL(res);
+      }
+      if (res == 0) {
+        cout << "Call etterminal with --idpasskey or --idpasskeyfile, or feed "
+                "this information on stdin\n";
+        exit(1);
+      }
+
+      string stdinData;
+      if (!getline(cin, stdinData)) {
+        cout << "Call etterminal with --idpasskey or --idpasskeyfile, or feed "
+                "this information on stdin\n";
+        exit(1);
+      }
+      auto tokens = split(stdinData, '_');
+      idpasskey = tokens[0];
+      FATAL_FAIL(setenv("TERM", tokens[1].c_str(), 1));
+    } else {
+      string idpasskey = result["idpasskey"].as<string>();
+      if (result.count("idpasskeyfile")) {
+        // Check for passkey file
+        std::ifstream t(result["idpasskeyfile"].as<string>().c_str());
+        std::stringstream buffer;
+        buffer << t.rdbuf();
+        idpasskey = buffer.str();
+        // Trim whitespace
+        idpasskey.erase(idpasskey.find_last_not_of(" \n\r\t") + 1);
+      }
     }
-  }
 
-  string id = split(idpasskey, '/')[0];
-  string username = string(ssh_get_local_username());
-  if (result.count("jump")) {
-    setDaemonLogFile(idpasskey, "jumphost");
+    string id = split(idpasskey, '/')[0];
+    string username = string(ssh_get_local_username());
+    if (result.count("jump")) {
+      setDaemonLogFile(idpasskey, "jumphost");
 
-    // etserver with --jump cannot write to the default log file(root)
+      // etserver with --jump cannot write to the default log file(root)
+      LogHandler::setupLogFile(&defaultConf,
+                               "/tmp/etjump-" + username + "-" + id + ".log",
+                               maxlogsize);
+      // Reconfigure default logger to apply settings above
+      el::Loggers::reconfigureLogger("default", defaultConf);
+      // set thread name
+      el::Helpers::setThreadName("jump-main");
+      // Install log rotation callback
+      el::Helpers::installPreRollOutCallback(LogHandler::rolloutHandler);
+
+      cout << "IDPASSKEY:" << idpasskey << endl;
+      if (DaemonCreator::create(true, "") == -1) {
+        LOG(FATAL) << "Error creating daemon: " << strerror(errno);
+      }
+      shared_ptr<SocketHandler> jumpClientSocketHandler(new TcpSocketHandler());
+      UserJumphostHandler ujh(jumpClientSocketHandler, idpasskey,
+                              SocketEndpoint(result["dsthost"].as<string>(),
+                                             result["dstport"].as<int>()),
+                              ipcSocketHandler, SocketEndpoint(ROUTER_FIFO_NAME));
+      ujh.run();
+
+      // Uninstall log rotation callback
+      el::Helpers::uninstallPreRollOutCallback();
+      return 0;
+    }
+
+    setDaemonLogFile(idpasskey, "terminal");
+
+    // etserver with --idpasskey cannot write to the default log file(root)
     LogHandler::setupLogFile(&defaultConf,
-                             "/tmp/etjump-" + username + "-" + id + ".log",
+                             "/tmp/etterminal-" + username + "-" + id + ".log",
                              maxlogsize);
     // Reconfigure default logger to apply settings above
     el::Loggers::reconfigureLogger("default", defaultConf);
     // set thread name
-    el::Helpers::setThreadName("jump-main");
+    el::Helpers::setThreadName("terminal-main");
     // Install log rotation callback
     el::Helpers::installPreRollOutCallback(LogHandler::rolloutHandler);
 
+    UserTerminalHandler uth(ipcSocketHandler, term, true,
+                            SocketEndpoint(ROUTER_FIFO_NAME), idpasskey);
     cout << "IDPASSKEY:" << idpasskey << endl;
     if (DaemonCreator::create(true, "") == -1) {
       LOG(FATAL) << "Error creating daemon: " << strerror(errno);
     }
-    shared_ptr<SocketHandler> jumpClientSocketHandler(new TcpSocketHandler());
-    UserJumphostHandler ujh(jumpClientSocketHandler, idpasskey,
-                            SocketEndpoint(result["dsthost"].as<string>(),
-                                           result["dstport"].as<int>()),
-                            ipcSocketHandler, SocketEndpoint(ROUTER_FIFO_NAME));
-    ujh.run();
+    uth.run();
 
-    // Uninstall log rotation callback
-    el::Helpers::uninstallPreRollOutCallback();
-    return 0;
+  } catch (cxxopts::OptionException& oe) {
+    cout << "Exception: " << oe.what() << "\n" << endl;
+    cout << options.help({}) << endl;
+    exit(1);
   }
-
-  setDaemonLogFile(idpasskey, "terminal");
-
-  // etserver with --idpasskey cannot write to the default log file(root)
-  LogHandler::setupLogFile(&defaultConf,
-                           "/tmp/etterminal-" + username + "-" + id + ".log",
-                           maxlogsize);
-  // Reconfigure default logger to apply settings above
-  el::Loggers::reconfigureLogger("default", defaultConf);
-  // set thread name
-  el::Helpers::setThreadName("terminal-main");
-  // Install log rotation callback
-  el::Helpers::installPreRollOutCallback(LogHandler::rolloutHandler);
-
-  UserTerminalHandler uth(ipcSocketHandler, term, true,
-                          SocketEndpoint(ROUTER_FIFO_NAME), idpasskey);
-  cout << "IDPASSKEY:" << idpasskey << endl;
-  if (DaemonCreator::create(true, "") == -1) {
-    LOG(FATAL) << "Error creating daemon: " << strerror(errno);
-  }
-  uth.run();
 
   // Uninstall log rotation callback
   el::Helpers::uninstallPreRollOutCallback();

--- a/src/terminal/TerminalServerMain.cpp
+++ b/src/terminal/TerminalServerMain.cpp
@@ -10,113 +10,124 @@ int main(int argc, char **argv) {
   // Setup easylogging configurations
   el::Configurations defaultConf = LogHandler::setupLogHandler(&argc, &argv);
 
-  // Parse command line arguments
   cxxopts::Options options("etserver",
                            "Remote shell for the busy and impatient");
-  options.allow_unrecognised_options();
+  try {
+    // Parse command line arguments
+    options.allow_unrecognised_options();
 
-  options.add_options()             //
-      ("help", "Print help")        //
-      ("version", "Print version")  //
-      ("port", "Port to listen on",
-       cxxopts::value<int>()->default_value("0"))  //
-      ("daemon", "Daemonize the server")           //
-      ("cfgfile", "Location of the config file",
-       cxxopts::value<std::string>()->default_value(""))  //
-      ("logtostdout", "log to stdout")                    //
-      ("pidfile", "Location of the pid file",
-        cxxopts::value<std::string>()->default_value("/var/run/etserver.pid"))  //
-      ("v,verbose", "Enable verbose logging",
-       cxxopts::value<int>()->default_value("0"))  //
-      ;
+    options.add_options()             //
+        ("h,help", "Print help")      //
+        ("version", "Print version")  //
+        ("port", "Port to listen on",
+         cxxopts::value<int>()->default_value("0"))  //
+        ("daemon", "Daemonize the server")              //
+        ("cfgfile", "Location of the config file",
+         cxxopts::value<std::string>()->default_value(""))  //
+        ("logtostdout", "log to stdout")                       //
+        ("pidfile", "Location of the pid file",
+         cxxopts::value<std::string>()->default_value("/var/run/etserver.pid"))  //
+        ("v,verbose", "Enable verbose logging",
+         cxxopts::value<int>()->default_value("0"), "LEVEL")  //
+        ;
 
-  auto result = options.parse(argc, argv);
-  if (result.count("help")) {
-    cout << options.help({}) << endl;
-    exit(0);
-  }
-  if (result.count("version")) {
-    cout << "et version " << ET_VERSION << endl;
-    exit(0);
-  }
+    auto result = options.parse(argc, argv);
 
-  if (result.count("daemon")) {
-    if (DaemonCreator::create(true, result["pidfile"].as<string>()) == -1) {
-      LOG(FATAL) << "Error creating daemon: " << strerror(errno);
+    if (result.count("help")) {
+      cout << options.help({}) << endl;
+      exit(0);
     }
-  }
+    if (result.count("version")) {
+      cout << "et version " << ET_VERSION << endl;
+      exit(0);
+    }
 
-  if (result.count("logtostdout")) {
-    defaultConf.setGlobally(el::ConfigurationType::ToStandardOutput, "true");
-  } else {
-    defaultConf.setGlobally(el::ConfigurationType::ToStandardOutput, "false");
-    // Redirect std streams to a file
-    LogHandler::stderrToFile("/tmp/etserver");
-  }
+    if (result.count("daemon")) {
+      if (DaemonCreator::create(true, result["pidfile"].as<string>()) == -1) {
+        LOG(FATAL) << "Error creating daemon: " << strerror(errno);
+      }
+    }
 
-  // default max log file size is 20MB for etserver
-  string maxlogsize = "20971520";
-
-  int port = 0;
-  if (result.count("cfgfile")) {
-    // Load the config file
-    CSimpleIniA ini(true, true, true);
-    string cfgfilename = result["cfgfile"].as<string>();
-    SI_Error rc = ini.LoadFile(cfgfilename.c_str());
-    if (rc == 0) {
-      if (!result.count("port")) {
-        const char *portString = ini.GetValue("Networking", "Port", NULL);
-        if (portString) {
-          port = stoi(portString);
-        }
-      }
-      // read verbose level
-      const char *vlevel = ini.GetValue("Debug", "verbose", NULL);
-      if (vlevel) {
-        el::Loggers::setVerboseLevel(atoi(vlevel));
-      }
-      // read silent setting
-      const char *silent = ini.GetValue("Debug", "silent", NULL);
-      if (silent && atoi(silent) != 0) {
-        defaultConf.setGlobally(el::ConfigurationType::Enabled, "false");
-      }
-      // read log file size limit
-      const char *logsize = ini.GetValue("Debug", "logsize", NULL);
-      if (logsize && atoi(logsize) != 0) {
-        // make sure maxlogsize is a string of int value
-        maxlogsize = string(logsize);
-      }
-
+    if (result.count("logtostdout")) {
+      defaultConf.setGlobally(el::ConfigurationType::ToStandardOutput, "true");
     } else {
-      LOG(FATAL) << "Invalid config file: " << cfgfilename;
+      defaultConf.setGlobally(el::ConfigurationType::ToStandardOutput, "false");
+      // Redirect std streams to a file
+      LogHandler::stderrToFile("/tmp/etserver");
     }
+
+    // default max log file size is 20MB for etserver
+    string maxlogsize = "20971520";
+
+    int port = 0;
+    if (result.count("cfgfile")) {
+      // Load the config file
+      CSimpleIniA ini(true, true, true);
+      string cfgfilename = result["cfgfile"].as<string>();
+      SI_Error rc = ini.LoadFile(cfgfilename.c_str());
+      if (rc == 0) {
+        if (!result.count("port")) {
+          const char *portString = ini.GetValue("Networking", "Port", NULL);
+          if (portString) {
+            port = stoi(portString);
+          }
+        }
+        // read verbose level (prioritize command line option over cfgfile)
+        const char *vlevel = ini.GetValue("Debug", "verbose", NULL);
+        if (result.count("verbose")) {
+          el::Loggers::setVerboseLevel(result["verbose"].as<int>());
+        } else if (vlevel) {
+          el::Loggers::setVerboseLevel(atoi(vlevel));
+        }
+
+        // read silent setting
+        const char *silent = ini.GetValue("Debug", "silent", NULL);
+        if (silent && atoi(silent) != 0) {
+          defaultConf.setGlobally(el::ConfigurationType::Enabled, "false");
+        }
+        // read log file size limit
+        const char *logsize = ini.GetValue("Debug", "logsize", NULL);
+        if (logsize && atoi(logsize) != 0) {
+          // make sure maxlogsize is a string of int value
+          maxlogsize = string(logsize);
+        }
+
+      } else {
+        LOG(FATAL) << "Invalid config file: " << cfgfilename;
+      }
+    }
+
+    GOOGLE_PROTOBUF_VERIFY_VERSION;
+    srand(1);
+
+    if (port == 0) {
+      port = 2022;
+    }
+
+    // Set log file for etserver process here.
+    LogHandler::setupLogFile(&defaultConf, "/tmp/etserver-%datetime.log",
+                             maxlogsize);
+    // Reconfigure default logger to apply settings above
+    el::Loggers::reconfigureLogger("default", defaultConf);
+    // set thread name
+    el::Helpers::setThreadName("etserver-main");
+    // Install log rotation callback
+    el::Helpers::installPreRollOutCallback(LogHandler::rolloutHandler);
+    std::shared_ptr<SocketHandler> tcpSocketHandler(new TcpSocketHandler());
+    std::shared_ptr<PipeSocketHandler> pipeSocketHandler(new PipeSocketHandler());
+
+    LOG(INFO) << "In child, about to start server.";
+
+    TerminalServer terminalServer(tcpSocketHandler, SocketEndpoint(port),
+                                  pipeSocketHandler,
+                                  SocketEndpoint(ROUTER_FIFO_NAME));
+    terminalServer.run();
+
+  } catch (cxxopts::OptionException& oe) {
+    cout << "Exception: " << oe.what() << "\n" << endl;
+    cout << options.help({}) << endl;
+    exit(1);
   }
-
-  GOOGLE_PROTOBUF_VERIFY_VERSION;
-  srand(1);
-
-  if (port == 0) {
-    port = 2022;
-  }
-
-  // Set log file for etserver process here.
-  LogHandler::setupLogFile(&defaultConf, "/tmp/etserver-%datetime.log",
-                           maxlogsize);
-  // Reconfigure default logger to apply settings above
-  el::Loggers::reconfigureLogger("default", defaultConf);
-  // set thread name
-  el::Helpers::setThreadName("etserver-main");
-  // Install log rotation callback
-  el::Helpers::installPreRollOutCallback(LogHandler::rolloutHandler);
-  std::shared_ptr<SocketHandler> tcpSocketHandler(new TcpSocketHandler());
-  std::shared_ptr<PipeSocketHandler> pipeSocketHandler(new PipeSocketHandler());
-
-  LOG(INFO) << "In child, about to start server.";
-
-  TerminalServer terminalServer(tcpSocketHandler, SocketEndpoint(port),
-                                pipeSocketHandler,
-                                SocketEndpoint(ROUTER_FIFO_NAME));
-  terminalServer.run();
 
   // Uninstall log rotation callback
   el::Helpers::uninstallPreRollOutCallback();


### PR DESCRIPTION
While I was debuging an issue, I didn't realize the verbose flag
required an arg (I was thinking ssh like -v or -vvv).  This change
handles option parsing exceptions and displays the issue and then the
help menu. I also added a short flag for help (-h) to
etserver/et/etterminal.