### PR TITLE
iOS: Use remove() instead of system() to remove log files

### DIFF
--- a/src/base/LogHandler.cpp
+++ b/src/base/LogHandler.cpp
@@ -34,10 +34,8 @@ void LogHandler::setupLogFile(el::Configurations *defaultConf, string filename,
 
 void LogHandler::rolloutHandler(const char *filename, std::size_t size) {
   // SHOULD NOT LOG ANYTHING HERE BECAUSE LOG FILE IS CLOSED!
-  std::stringstream ss;
   // REMOVE OLD LOG
-  ss << "rm " << filename;
-  system(ss.str().c_str());
+  remove(filename);
 }
 
 string LogHandler::stderrToFile(const string &pathPrefix) {


### PR DESCRIPTION
Hi again,

This is a change that allows libet to be compiled on iOS. The only change is that instead of calling `system()` to remove a file using `rm`, it uses the C++ standard `remove()` function.

I am unaware of any platform that EternalTerminal supports that has `rm` but not `remove()`, but I am more than happy to make changes if this causes a compatibility problem.