### PR TITLE
Fix fatal log errors caused when iOS closes background connections

### DIFF
--- a/src/base/Connection.cpp
+++ b/src/base/Connection.cpp
@@ -18,6 +18,7 @@ Connection::~Connection() {
 inline bool isSkippableError(int err_no) {
   return (err_no == EAGAIN || err_no == ECONNRESET || err_no == ETIMEDOUT ||
           err_no == EWOULDBLOCK || err_no == EHOSTUNREACH || err_no == EPIPE ||
+          err_no == ENOTCONN ||
           err_no == EBADF  // Bad file descriptor can happen when
                            // there's a race condition between a thread
                            // closing a connection and one

--- a/src/base/UnixSocketHandler.cpp
+++ b/src/base/UnixSocketHandler.cpp
@@ -159,7 +159,9 @@ void UnixSocketHandler::close(int fd) {
   auto m = it->second;
   lock_guard<std::recursive_mutex> guard(*m);
   VLOG(1) << "Closing connection: " << fd;
-  FATAL_FAIL(::close(fd));
+  if (fcntl(fd, F_GETFD) != -1) {
+    FATAL_FAIL(::close(fd));
+  }
   activeSocketMutexes.erase(it);
 }
 


### PR DESCRIPTION
Hi,

These are a couple small changes which prevent calling `FATAL_FAIL` when iOS terminates the connection of an app that's suspended in the background.

The `isSkippableError()` function is called when reading or writing to/from a connection. If the error is skippable, the code assumes the connection has failed and calls `closeSocketAndMaybeReconnect()`. It seems safe to me to add `ENOTCONN` to the list of skippable errors in this context.

The other change prevents calling `close()` on an invalid file descriptor.