### PR TITLE
Replace reading from urandom with libsodium's randombytes_uniform

### DIFF
--- a/src/terminal/SshSetupHandler.cpp
+++ b/src/terminal/SshSetupHandler.cpp
@@ -1,6 +1,7 @@
 #include "SshSetupHandler.hpp"
 
 #include <sys/wait.h>
+#include <sodium.h>
 
 namespace et {
 string genRandom(int len) {
@@ -10,15 +11,9 @@ string genRandom(int len) {
       "abcdefghijklmnopqrstuvwxyz";
   string s(len, '\0');
 
-  int randomFd = ::open("/dev/urandom", O_RDONLY);
-  FATAL_FAIL(randomFd);
   for (int i = 0; i < len; ++i) {
-    uint32_t randNum;
-    ssize_t rc = ::read(randomFd, &randNum, sizeof(uint32_t));
-    FATAL_FAIL(rc);
-    s[i] = alphanum[randNum % (sizeof(alphanum) - 1)];
+    s[i] = alphanum[randombytes_uniform(sizeof(alphanum))];
   }
-  close(randomFd);
 
   return s;
 }


### PR DESCRIPTION
Hello again,

This is a small change to SshSetupHandler which replaces reading from `urandom`, which doesn't provide great randomness on some systems, and doesn't exist on some others. Since ET is already using libsodium, I used `randombytes_uniform`, which not only guarantees good randomness on all systems, but also avoids modulo bias.

This isn't actually a change that I'm relying on for iOS code. I had to implement my own version of SshSetuphandler for iOS, but I used `randombytes_uniform` there, and figured it might be a good change on other systems as well. If it turns out there's a reason why it's important to use `urandom` on desktop, rejecting this pull request won't cause any difficulties for me.