### PR TITLE
Expand tilde before parsing include file

### DIFF
--- a/src/terminal/ParseConfigFile.hpp
+++ b/src/terminal/ParseConfigFile.hpp
@@ -1157,7 +1157,11 @@ static int ssh_config_parse_line(const char *targethost, struct Options *options
 
       p = ssh_config_get_str_tok(&s, NULL);
       if (p && *parsing) {
-        local_parse_file(targethost, options, p, parsing, seen);
+        char *filename = ssh_path_expand_tilde(p);
+        if (filename) {
+          local_parse_file(targethost, options, filename, parsing, seen);
+        }
+        SAFE_FREE(filename);
       }
       break;
     case SOC_HOST: {


### PR DESCRIPTION
Adds support for tilde in included config files (which is supported by ssh).  Example:
```
Include ~/.ssh/conf/settings.ssh
Include ~/.ssh/conf/hosts.ssh
```
Related to https://github.com/MisterTea/EternalTerminal/issues/197

Severely lacking any cpp skills so let me know if I should change something.
