### PR TITLE
Add a build option to disable easylogging's default crash handler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ if(POLICY CMP0058)
 endif() 
 
 option(CODE_COVERAGE "Enable code coverage" OFF)
+option(DISABLE_CRASH_LOG "Disable installing easylogging crash handler" OFF)
 
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DET_VERSION='\"${PROJECT_VERSION}\"'")
 # For easylogging, disable default log file, enable crash log, ensure thread safe, and catch c++ exceptions
@@ -20,6 +21,10 @@ IF(CODE_COVERAGE)
     SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage")
   endif()
 ENDIF(CODE_COVERAGE)
+
+if(DISABLE_CRASH_LOG)
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DELPP_DISABLE_DEFAULT_CRASH_HANDLING")
+ENDIF(DISABLE_CRASH_LOG)
 
 if(UNIX)
   # Enable C++-11

--- a/build_static.sh
+++ b/build_static.sh
@@ -48,6 +48,7 @@ PROTO_LIB_DIR="$PWD/../deps/out/lib64"
 else
 PROTO_LIB_DIR="$PWD/../deps/out/lib"
 fi
+DISABLE_CRASH_LOG=${DISABLE_CRASH_LOG:-OFF}
 cmake \
     -DProtobuf_INCLUDE_DIR="$PWD"/../deps/out/include \
     -DProtobuf_LIBRARY_DEBUG="$PROTO_LIB_DIR"/libprotobuf.a \
@@ -62,6 +63,7 @@ cmake \
     -Dsodium_LIBRARY_RELEASE="$PWD"/../deps/out/lib/libsodium.a \
     -Dsodium_USE_STATIC_LIBS=ON \
     -DCMAKE_INSTALL_PREFIX="$PWD"/../out \
+    -DDISABLE_CRASH_LOG="$DISABLE_CRASH_LOG"
     ../
 make -j8 install
 cd ../out || exit

--- a/build_static.sh
+++ b/build_static.sh
@@ -63,7 +63,7 @@ cmake \
     -Dsodium_LIBRARY_RELEASE="$PWD"/../deps/out/lib/libsodium.a \
     -Dsodium_USE_STATIC_LIBS=ON \
     -DCMAKE_INSTALL_PREFIX="$PWD"/../out \
-    -DDISABLE_CRASH_LOG="$DISABLE_CRASH_LOG"
+    -DDISABLE_CRASH_LOG="$DISABLE_CRASH_LOG" \
     ../
 make -j8 install
 cd ../out || exit


### PR DESCRIPTION
Hi again. It's been a while.

We recently found that easylogging's default crash log installs a signal handler that interferes with our own signal handler when linking `libet`. Thankfully, it's fairly easy to disable, so I figured I would offer an upstream pull request for a build option to disable it.

Thanks for considering it!