### PR TITLE
Add CLI flag for SSH socket to forward and config file parsing

### DIFF
--- a/src/terminal/TerminalClient.cpp
+++ b/src/terminal/TerminalClient.cpp
@@ -52,7 +52,8 @@ TerminalClient::TerminalClient(shared_ptr<SocketHandler> _socketHandler,
                                shared_ptr<Console> _console, bool jumphost,
                                const string& tunnels,
                                const string& reverseTunnels,
-                               bool forwardSshAgent)
+                               bool forwardSshAgent,
+                               const string& identityAgent)
     : console(_console), shuttingDown(false) {
   portForwardHandler = shared_ptr<PortForwardHandler>(
       new PortForwardHandler(_socketHandler, _pipeSocketHandler));
@@ -84,17 +85,24 @@ TerminalClient::TerminalClient(shared_ptr<SocketHandler> _socketHandler,
     }
     if (forwardSshAgent) {
       PortForwardSourceRequest pfsr;
-      auto authSockEnv = getenv("SSH_AUTH_SOCK");
-      if (!authSockEnv) {
-        cout << "Missing environment variable SSH_AUTH_SOCK.  Are you sure you "
-                "ran ssh-agent first?"
-             << endl;
-        exit(1);
+      string authSock = "";
+      if (identityAgent.length()) {
+        authSock.assign(identityAgent);
+      } else {
+        auto authSockEnv = getenv("SSH_AUTH_SOCK");
+        if (!authSockEnv) {
+          cout << "Missing environment variable SSH_AUTH_SOCK.  Are you sure you "
+                  "ran ssh-agent first?"
+               << endl;
+          exit(1);
+        }
+        authSock.assign(authSockEnv);
       }
-      string authSock = string(authSockEnv);
-      pfsr.mutable_destination()->set_name(authSock);
-      pfsr.set_environmentvariable("SSH_AUTH_SOCK");
-      *(payload.add_reversetunnels()) = pfsr;
+      if (authSock.length()) {
+        pfsr.mutable_destination()->set_name(authSock);
+        pfsr.set_environmentvariable("SSH_AUTH_SOCK");
+        *(payload.add_reversetunnels()) = pfsr;
+      }
     }
   } catch (const std::runtime_error& ex) {
     cout << "Error establishing port forward: " << ex.what() << endl;

--- a/src/terminal/TerminalClient.hpp
+++ b/src/terminal/TerminalClient.hpp
@@ -29,7 +29,8 @@ class TerminalClient {
                  const SocketEndpoint& _socketEndpoint, const string& id,
                  const string& passkey, shared_ptr<Console> _console,
                  bool jumphost, const string& tunnels,
-                 const string& reverseTunnels, bool forwardSshAgent);
+                 const string& reverseTunnels, bool forwardSshAgent,
+                 const string& identityAgent);
   virtual ~TerminalClient();
   void setUpTunnel(const string& tunnels);
   void setUpReverseTunnels(const string& reverseTunnels);

--- a/src/terminal/TerminalClientMain.cpp
+++ b/src/terminal/TerminalClientMain.cpp
@@ -61,6 +61,8 @@ int main(int argc, char** argv) {
         ("silent", "Disable logging")                        //
         ("N,no-terminal", "Do not create a terminal")        //
         ("f,forward-ssh-agent", "Forward ssh-agent socket")  //
+        ("ssh-socket", "The ssh-agent socket to forward",
+         cxxopts::value<std::string>())    //
         ("serverfifo",
          "If set, communicate to etserver on the matching fifo name",  //
          cxxopts::value<std::string>()->default_value(""))             //
@@ -144,7 +146,9 @@ int main(int argc, char** argv) {
         0,     // ssh1
         NULL,  // gss_server_identity
         NULL,  // gss_client_identity
-        0      // gss_delegate_creds
+        0,     // gss_delegate_creds
+        0,     // forward_agent
+        NULL   // identity_agent
     };
 
     char* home_dir = ssh_get_user_home_dir();
@@ -241,7 +245,10 @@ int main(int argc, char** argv) {
     TerminalClient terminalClient(
         clientSocket, clientPipeSocket, socketEndpoint, id, passkey, console,
         is_jumphost, result.count("t") ? result["t"].as<string>() : "",
-        result.count("r") ? result["r"].as<string>() : "", result.count("f"));
+        result.count("r") ? result["r"].as<string>() : "",
+        (result.count("f") || sshConfigOptions.forward_agent),
+        result.count("ssh-socket") ? result["ssh-socket"].as<string>() :
+        sshConfigOptions.identity_agent ? string(sshConfigOptions.identity_agent) : "");
     terminalClient.run(result.count("command") ? result["command"].as<string>()
                                                : "");
   } catch (cxxopts::OptionException& oe) {

--- a/test/JumphostTest.cpp
+++ b/test/JumphostTest.cpp
@@ -35,7 +35,7 @@ void readWriteTest(const string& clientId,
 
   shared_ptr<TerminalClient> terminalClient(new TerminalClient(
       clientSocketHandler, clientPipeSocketHandler, jumphostEndpoint, clientId,
-      CRYPTO_KEY, fakeConsole, true, "", "", false));
+      CRYPTO_KEY, fakeConsole, true, "", "", false, ""));
   thread terminalClientThread([terminalClient]() { terminalClient->run(""); });
   sleep(3);
 

--- a/test/TerminalTest.cpp
+++ b/test/TerminalTest.cpp
@@ -101,7 +101,7 @@ void readWriteTest(const string& clientId,
 
   shared_ptr<TerminalClient> terminalClient(new TerminalClient(
       clientSocketHandler, clientPipeSocketHandler, serverEndpoint, clientId,
-      CRYPTO_KEY, fakeConsole, false, "", "", false));
+      CRYPTO_KEY, fakeConsole, false, "", "", false, ""));
   thread terminalClientThread(
       [terminalClient]() { terminalClient->run(""); });
   sleep(3);


### PR DESCRIPTION
Adds a CLI flag to specify the SSH agent socket to forward. Although the
socket held in `SSH_AUTH_SOCK` is the default, multiple agents may run
and this allows forwarding a specific agent.

Both SSH agent forwarding and a specific SSH agent socket to use may be
specified in `ssh_config` or `~/.ssh/config`, using the `ForwardAgent`
and `IdentityAgent` parameters. EternalTerminal now knows how to parse
those options and will use them to forward an SSH agent socket and
choose the correct socket based on the values set in the config file i
CLI flags are not given.

Verified by connecting to ET using no CLI flags, only
`--forward-ssh-agent`, only `--ssh-socket`, and both CLI flags. Sockets
were correctly forwarded, with `--ssh-socket` taking priority over a
value set in `ssh_config`.