### PR TITLE
Remove duplicate/incorrect entries from target_link_libraries for et-test in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -358,8 +358,6 @@ target_link_libraries(
   ${SELINUX_LIBRARIES}
   ${UTEMPTER_LIBRARIES}
   ${CORE_LIBRARIES}
-  resolv
-  util
   )
 add_test(
   et-test


### PR DESCRIPTION
The `target_link_libraries` list for `et-test` included `util` and `resolv` in the list, but these are already in `${CORE_LIBRARIES}` when needed, which itself is in that list already.

This prevented building Eternal Terminal v6.0.4 from source on FreeBSD, since for FreeBSD, libresolv is not a thing and instead the relevant functions are part of the FreeBSD standard C library like you know (since you were already handling that for `${CORE_LIBRARIES}`).