### PR TITLE
Mention that libprotobuf-dev is also required (by the client)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ cmake ../
 make && sudo make install
 sudo cp ../etc/et.cfg /etc/
 ```
-Once built, the binary only requires `libgflags-dev`.
+Once built, the binary only requires `libgflags-dev` and `libprotobuf-dev`.
 
 ### Debian
 


### PR DESCRIPTION
Without libprotobuf-dev installed, on Ubuntu I got `error while loading shared libraries: libprotobuf-lite.so.10: cannot open shared object file: No such file or directory`. After installing it, `et` started fine.