### PR TITLE
Add support for IdentityAgent and ForwardAgent in ssh config files

### DIFF
--- a/src/terminal/TerminalClient.cpp
+++ b/src/terminal/TerminalClient.cpp
@@ -52,7 +52,8 @@ TerminalClient::TerminalClient(shared_ptr<SocketHandler> _socketHandler,
                                shared_ptr<Console> _console, bool jumphost,
                                const string& tunnels,
                                const string& reverseTunnels,
-                               bool forwardSshAgent)
+                               bool forwardSshAgent,
+                               const string& identityAgent)
     : console(_console), shuttingDown(false) {
   portForwardHandler = shared_ptr<PortForwardHandler>(
       new PortForwardHandler(_socketHandler, _pipeSocketHandler));
@@ -84,14 +85,13 @@ TerminalClient::TerminalClient(shared_ptr<SocketHandler> _socketHandler,
     }
     if (forwardSshAgent) {
       PortForwardSourceRequest pfsr;
-      auto authSockEnv = getenv("SSH_AUTH_SOCK");
-      if (!authSockEnv) {
+      if (identityAgent.empty()) {
         cout << "Missing environment variable SSH_AUTH_SOCK.  Are you sure you "
                 "ran ssh-agent first?"
              << endl;
         exit(1);
       }
-      string authSock = string(authSockEnv);
+      string authSock = string(identityAgent);
       pfsr.mutable_destination()->set_name(authSock);
       pfsr.set_environmentvariable("SSH_AUTH_SOCK");
       *(payload.add_reversetunnels()) = pfsr;

--- a/src/terminal/TerminalClient.hpp
+++ b/src/terminal/TerminalClient.hpp
@@ -29,7 +29,8 @@ class TerminalClient {
                  const SocketEndpoint& _socketEndpoint, const string& id,
                  const string& passkey, shared_ptr<Console> _console,
                  bool jumphost, const string& tunnels,
-                 const string& reverseTunnels, bool forwardSshAgent);
+                 const string& reverseTunnels, bool forwardSshAgent,
+                 const string& identityAgent);
   virtual ~TerminalClient();
   void setUpTunnel(const string& tunnels);
   void setUpReverseTunnels(const string& reverseTunnels);

--- a/src/terminal/TerminalClientMain.cpp
+++ b/src/terminal/TerminalClientMain.cpp
@@ -137,6 +137,7 @@ int main(int argc, char** argv) {
         NULL,  // knownhosts
         NULL,  // ProxyCommand
         NULL,  // IdentityAgent
+        0,     // ForwardAgent
         NULL,  // ProxyJump
         0,     // timeout
         0,     // port
@@ -239,7 +240,7 @@ int main(int argc, char** argv) {
       console.reset(new PsuedoTerminalConsole());
     }
 
-    bool forwardAgent = result.count("f");
+    bool forwardAgent = result.count("f") || sshConfigOptions.ForwardAgent;
     char *identityAgent = sshConfigOptions.IdentityAgent;
     if (identityAgent == NULL && forwardAgent) {
       identityAgent = getenv("SSH_AUTH_SOCK");
@@ -248,8 +249,8 @@ int main(int argc, char** argv) {
     TerminalClient terminalClient(
         clientSocket, clientPipeSocket, socketEndpoint, id, passkey, console,
         is_jumphost, result.count("t") ? result["t"].as<string>() : "",
-        result.count("r") ? result["r"].as<string>() : "", result.count("f"),
-        result.count("f") ? identityAgent : "");
+        result.count("r") ? result["r"].as<string>() : "", forwardAgent,
+        forwardAgent ? identityAgent : "");
     terminalClient.run(result.count("command") ? result["command"].as<string>()
                                                : "");
   } catch (cxxopts::OptionException& oe) {

--- a/src/terminal/TerminalClientMain.cpp
+++ b/src/terminal/TerminalClientMain.cpp
@@ -136,6 +136,7 @@ int main(int argc, char** argv) {
         NULL,  // sshdir
         NULL,  // knownhosts
         NULL,  // ProxyCommand
+        NULL,  // IdentityAgent
         NULL,  // ProxyJump
         0,     // timeout
         0,     // port
@@ -238,10 +239,17 @@ int main(int argc, char** argv) {
       console.reset(new PsuedoTerminalConsole());
     }
 
+    bool forwardAgent = result.count("f");
+    char *identityAgent = sshConfigOptions.IdentityAgent;
+    if (identityAgent == NULL && forwardAgent) {
+      identityAgent = getenv("SSH_AUTH_SOCK");
+    }
+
     TerminalClient terminalClient(
         clientSocket, clientPipeSocket, socketEndpoint, id, passkey, console,
         is_jumphost, result.count("t") ? result["t"].as<string>() : "",
-        result.count("r") ? result["r"].as<string>() : "", result.count("f"));
+        result.count("r") ? result["r"].as<string>() : "", result.count("f"),
+        result.count("f") ? identityAgent : "");
     terminalClient.run(result.count("command") ? result["command"].as<string>()
                                                : "");
   } catch (cxxopts::OptionException& oe) {

--- a/test/JumphostTest.cpp
+++ b/test/JumphostTest.cpp
@@ -35,7 +35,7 @@ void readWriteTest(const string& clientId,
 
   shared_ptr<TerminalClient> terminalClient(new TerminalClient(
       clientSocketHandler, clientPipeSocketHandler, jumphostEndpoint, clientId,
-      CRYPTO_KEY, fakeConsole, true, "", "", false));
+      CRYPTO_KEY, fakeConsole, true, "", "", false, NULL));
   thread terminalClientThread([terminalClient]() { terminalClient->run(""); });
   sleep(3);
 

--- a/test/TerminalTest.cpp
+++ b/test/TerminalTest.cpp
@@ -101,7 +101,7 @@ void readWriteTest(const string& clientId,
 
   shared_ptr<TerminalClient> terminalClient(new TerminalClient(
       clientSocketHandler, clientPipeSocketHandler, serverEndpoint, clientId,
-      CRYPTO_KEY, fakeConsole, false, "", "", false));
+      CRYPTO_KEY, fakeConsole, false, "", "", false, NULL));
   thread terminalClientThread(
       [terminalClient]() { terminalClient->run(""); });
   sleep(3);


### PR DESCRIPTION
This commit turns on SSH agent forwarding `-f` by default when `ForwardAgent yes` is found in an ssh config file, and uses the `IdentityAgent` if specified rather than only looking at the `SSH_AUTH_SOCK` variable, making it possible to use et with krypton.

Fix https://github.com/MisterTea/EternalTerminal/issues/262