### PR TITLE
Add execinfo as option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,11 @@ endif()
 
 option(CODE_COVERAGE "Enable code coverage" OFF)
 option(DISABLE_CRASH_LOG "Disable installing easylogging crash handler" OFF)
+option(ENABLE_EXECINFO "Enable execinfo support" OFF)
+
+if(ENABLE_EXECINFO)
+	SET(CMAKE_LINKER_FLAGS "${CMAKE_LINKER_FLAGS} -lexecinfo")
+endif()
 
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DET_VERSION='\"${PROJECT_VERSION}\"'")
 # For easylogging, disable default log file, enable crash log, ensure thread safe, and catch c++ exceptions


### PR DESCRIPTION
libexecinfo is not native to MUSL libc, and this
allows one to either enable/disable the need
to have libexecinfo on their system.

I will be submitting a PR for the external_imported/easyloggingcpp to add support for optional execinfo as well.

Signed-off-by: Nathan Owens <ndowens04@gmail.com>