### PR TITLE
Update Debian installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ Once built, the binary only requires `libgflags-dev` and `libprotobuf-dev`.
 
 For debian, use our deb repo. For stretch:
 
-	echo "deb https://mistertea.github.io/debian-et/debian-source/ stretch main" | sudo tee -a /etc/apt/sources.list
-	curl -sS https://mistertea.github.io/debian-et/et.gpg | sudo apt-key add -
+	echo "deb https://github.com/MisterTea/debian-et/raw/master/debian-source/ buster main" | sudo tee -a /etc/apt/sources.list
+	curl -sS https://github.com/MisterTea/debian-et/raw/master/et.gpg | sudo apt-key add -
 	sudo apt update
 	sudo apt install et
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Once built, the binary only requires `libgflags-dev` and `libprotobuf-dev`.
 
 ### Debian
 
-For debian, use our deb repo. For stretch:
+For debian, use our deb repo. For buster:
 
 	echo "deb https://github.com/MisterTea/debian-et/raw/master/debian-source/ buster main" | sudo tee -a /etc/apt/sources.list
 	curl -sS https://github.com/MisterTea/debian-et/raw/master/et.gpg | sudo apt-key add -


### PR DESCRIPTION
`github.io` doesn't seem to properly serve files stored in Github LFS. It only serves LFS metadata, not the whole file.
Also Debian stretch source doesn't work with Debian buster, which is the most recent stable release.
Resolves: https://github.com/MisterTea/EternalTerminal/issues/245