### PR TITLE
Parse named socket port forwards (Fixes #292)

### DIFF
--- a/src/terminal/forwarding/PortForwardHandler.cpp
+++ b/src/terminal/forwarding/PortForwardHandler.cpp
@@ -37,8 +37,8 @@ PortForwardSourceResponse PortForwardHandler::createSource(
     const PortForwardSourceRequest& pfsr, string* sourceName, uid_t userid,
     gid_t groupid) {
   try {
-    if (pfsr.has_source() && !pfsr.source().has_port()) {
-      throw runtime_error("Do not set a source when forwarding named pipes");
+    if (pfsr.has_source() && sourceName) {
+      throw runtime_error("Do not set a source when forwarding named pipes with environment variables");
     }
     SocketEndpoint source;
     if (pfsr.has_source()) {


### PR DESCRIPTION
As of 1b3a488, forwarding named sockets is supported in the core, but
the only socket accessible to forward was the SSH auth socket.

This is resolved by allowing arbitrary named sockets alongside numeric
port forwards with `-t`/`-r`.

Fixes #292.

--
I am unsure of the changes to `PortForwardHandler.cpp`, so I left it commented instead of removing. Everything _seems_ to work and test fine. I'm very much unfamiliar with C++, apologies if there's something egregiously wrong here.