### PR TITLE
fix input for forward tunnels

### DIFF
--- a/src/terminal/TerminalClient.cpp
+++ b/src/terminal/TerminalClient.cpp
@@ -71,7 +71,7 @@ TerminalClient::TerminalClient(shared_ptr<SocketHandler> _socketHandler,
 
   try {
     if (tunnels.length()) {
-      auto pfsrs = parseRangesToRequests(reverseTunnels);
+      auto pfsrs = parseRangesToRequests(tunnels);
       for (auto& pfsr : pfsrs) {
 #ifdef WIN32
         STFATAL << "Source tunnel not supported on windows yet";


### PR DESCRIPTION
#293 accidentally introduced a bug where the `reverseTunnels` ctor parameter to `TerminalClient` was parsed to get both the forward and reverse tunnels. This change fixes the typo and uses `tunnels` for forward tunnels, as intended.