### PR TITLE
Don't dump core when user types Ctrl-C at password prompt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ if(POLICY CMP0058)
 endif() 
 
 option(CODE_COVERAGE "Enable code coverage" OFF)
-option(DISABLE_CRASH_LOG "Disable installing easylogging crash handler" OFF)
+option(DISABLE_CRASH_LOG "Disable installing easylogging crash handler" ON)
 
 add_definitions(-DET_VERSION="${PROJECT_VERSION}")
 # For easylogging, disable default log file, enable crash log, ensure thread safe, and catch c++ exceptions


### PR DESCRIPTION
This fixes #324.

If someone uses the `et` client to connect to a server that requires password authentication, and then types `Control-C` at the password prompt, a core dump occurs. This happens only when et is compiled with GCC and the CMake option `DISABLE_CRASH_LOG` is set to `OFF` (the default).

This is due to a quirk of the Easylogging++ library that et depends on. By default, when EternalTerminal is built with GCC, it installs a "crash handler" that responds to the `SIGINT` signal (caused by typing `Control-C`) by logging a message and then raising `SIGABRT`, which causes a core dump.

This change sets the CMake option `DISABLE_CRASH_LOG` to `ON` by default. This causes the Easylogging++ crash handling feature to be disabled, and so prevents the `SIGABRT` signal and the core dump when the user types `Control-C` at a password prompt.