### PR TITLE
Fix sed error in CentOS 7 building guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Find the actual location of et:
 Correct the service file (see [#180](https://github.com/MisterTea/EternalTerminal/issues/180) for details).
 
 ```
-sudo sed -ie "s|ExecStart=.*[[:space:]]|ExecStart=$(which etserver) |" /etc/systemd/system/et.service
+sudo sed -ie "s|ExecStart=[^[:space:]]*[[:space:]]|ExecStart=$(which etserver) |" /etc/systemd/system/et.service
 ```
 
 Alternativelly, open the file /etc/systemd/system/et.service in an editor and correct the `ExectStart=...` line to point to the correct path of the `etserver` binary.


### PR DESCRIPTION
The sed script in CentOS 7 building guide has an error, which causes the `--daemon` argument deleted in systemd configuration file, and makes `systemctl start et.service` failed.

`.*` in the original sed script is ambigious, which would match all characters including space, so that only the last argument will be reserved.

`[^[:space:]]*` in the new sed script is identical to the better known `[\S]*` due to the sed's incompatibility with PCRE.

## Original:

before:

```
ExecStart=/wrong/path --daemon --cfgfile=/etc/et.cfg
```

after: 

```
ExecStart=/right/path --cfgfile=/etc/et.cfg
```

the `--daemon` is lost.

## Now:

before:

```
ExecStart=/wrong/path --daemon --cfgfile=/etc/et.cfg
```

after: 

```
ExecStart=/right/path --daemon --cfgfile=/etc/et.cfg
```

the `--daemon` will be reserved.