### PR TITLE
Run EternalTerminal server as a Type=simple systemd service

### DIFF
--- a/deployment/debian/debian_SOURCE/et.service
+++ b/deployment/debian/debian_SOURCE/et.service
@@ -3,9 +3,8 @@ Description=Eternal Terminal
 After=syslog.target network.target
 
 [Service]
-Type=forking
-PIDFile=/run/etserver.pid
-ExecStart=/usr/bin/etserver --daemon --cfgfile=/etc/et.cfg
+Type=simple
+ExecStart=/usr/bin/etserver --cfgfile=/etc/et.cfg
 
 [Install]
 WantedBy=multi-user.target

--- a/systemctl/et.service
+++ b/systemctl/et.service
@@ -3,9 +3,8 @@ Description=Eternal Terminal
 After=syslog.target network.target
 
 [Service]
-Type=forking
-PIDFile=/run/etserver.pid
-ExecStart=/usr/bin/etserver --daemon --cfgfile=/etc/et.cfg
+Type=simple
+ExecStart=/usr/bin/etserver --cfgfile=/etc/et.cfg
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Using `Type=forking` is discouraged, since systemd works best when the processes are just running in foreground.

Change to `Type=simple` and drop the `--daemon` argument.

We don't need a `PIDFile=` in this service unit either.

Also stopped seeing this message on the journal, upon restart of the service (not sure exactly why this was happening):

```
systemd[1]: et.service: Supervising process 12345 which is not our child. We'll most likely not notice when it exits.
```

Tested by making these changes to a host and ensuring I was still able to connect to the et server.
