### PR TITLE
Add Android support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,9 @@ add_custom_target(
   ${ETERMINAL_SRCS} ${ETERMINAL_HDRS}
   )
 
-IF(FREEBSD)
+IF(ANDROID)
+  set(CORE_LIBRARIES util)
+ELSEIF(FREEBSD)
   set(CORE_LIBRARIES util execinfo)
 ELSEIF(NETBSD)
   set(CORE_LIBRARIES util resolv execinfo)
@@ -133,7 +135,11 @@ ENDIF()
 MACRO(DECORATE_TARGET TARGET_NAME)
   add_sanitizers(${TARGET_NAME})
   set_target_properties(${TARGET_NAME} PROPERTIES COTIRE_CXX_PREFIX_HEADER_INIT "src/base/Headers.hpp")
-  cotire(${TARGET_NAME})
+  IF(CMAKE_CROSSCOMPILING)
+    # Doesn't work when cross-compiling
+  ELSE()
+    cotire(${TARGET_NAME})
+  ENDIF()
 ENDMACRO()
 
 include_directories(
@@ -142,7 +148,6 @@ include_directories(
   external/Catch2/single_include
   external/cxxopts/include
   external/msgpack-c/include
-  external/UniversalStacktrace/ust
   external/sentry-native/include
   src/base
   src/terminal
@@ -156,6 +161,10 @@ include_directories(
   ${SELINUX_INCLUDE_DIR}
   ${UTEMPTER_INCLUDE_DIR}
   )
+
+IF(NOT ANDROID)
+  include_directories( external/UniversalStacktrace/ust )
+ENDIF()
 
 add_library(
   et-lib

--- a/src/base/Headers.hpp
+++ b/src/base/Headers.hpp
@@ -85,7 +85,9 @@ inline int close(int fd) { return ::closesocket(fd); }
 #include "easylogging++.h"
 #include "json.hpp"
 #include "sole.hpp"
+#if !defined(__ANDROID__)
 #include "ust.hpp"
+#endif
 
 #ifdef WITH_UTEMPTER
 #include <utempter.h>
@@ -135,9 +137,15 @@ const int CLIENT_KEEP_ALIVE_DURATION = 5;
 // allow enough time.
 const int SERVER_KEEP_ALIVE_DURATION = 11;
 
+#if defined(__ANDROID__)
+#define STFATAL LOG(FATAL) << "No Stack Trace on Android" << endl
+
+#define STERROR LOG(ERROR) << "No Stack Trace on Android" << endl
+#else
 #define STFATAL LOG(FATAL) << "Stack Trace: " << endl << ust::generate()
 
 #define STERROR LOG(ERROR) << "Stack Trace: " << endl << ust::generate()
+#endif
 
 #ifdef WIN32
 inline string WindowsErrnoToString() {
@@ -288,7 +296,7 @@ inline string GetTempDirectory() {
   std::wstring_convert<std::codecvt_utf8_utf16<wchar_t> > converter;
   std::string tmpDir = converter.to_bytes(wstring(buf, retval));
 #else
-  string tmpDir = "/tmp";
+  string tmpDir = _PATH_TMP;
 #endif
   return tmpDir;
 }

--- a/src/base/TcpSocketHandler.cpp
+++ b/src/base/TcpSocketHandler.cpp
@@ -12,7 +12,7 @@ int TcpSocketHandler::connect(const SocketEndpoint &endpoint) {
   memset(&hints, 0, sizeof(addrinfo));
   hints.ai_family = AF_UNSPEC;
   hints.ai_socktype = SOCK_STREAM;
-#if __NetBSD__
+#if defined(__NetBSD__) || defined(__ANDROID__)
   hints.ai_flags = (AI_CANONNAME | AI_ADDRCONFIG);
 #else
   hints.ai_flags = (AI_CANONNAME | AI_V4MAPPED | AI_ADDRCONFIG | AI_ALL);

--- a/src/htm/HtmClientMain.cpp
+++ b/src/htm/HtmClientMain.cpp
@@ -64,9 +64,9 @@ int main(int argc, char** argv) {
   el::Loggers::setVerboseLevel(3);
   // default max log file size is 20MB for etserver
   string maxlogsize = "20971520";
-  LogHandler::setupLogFile(&defaultConf, "/tmp/htm.log", maxlogsize);
+  LogHandler::setupLogFile(&defaultConf, GetTempDirectory() + "htm.log", maxlogsize);
   // Redirect std streams to a file
-  LogHandler::stderrToFile("/tmp/htm");
+  LogHandler::stderrToFile(GetTempDirectory() + "htm");
 
   // Reconfigure default logger to apply settings above
   el::Loggers::reconfigureLogger("default", defaultConf);

--- a/src/htm/HtmServer.cpp
+++ b/src/htm/HtmServer.cpp
@@ -176,6 +176,6 @@ void HtmServer::recover() {
 
 string HtmServer::getPipeName() {
   uid_t myuid = getuid();
-  return string("/tmp/htm.") + to_string(myuid) + string(".ipc");
+  return string(GetTempDirectory() + "htm.") + to_string(myuid) + string(".ipc");
 }
 }  // namespace et

--- a/src/htm/HtmServerMain.cpp
+++ b/src/htm/HtmServerMain.cpp
@@ -18,9 +18,9 @@ int main(int argc, char **argv) {
   el::Loggers::setVerboseLevel(3);
   // default max log file size is 20MB for etserver
   string maxlogsize = "20971520";
-  LogHandler::setupLogFile(&defaultConf, "/tmp/htmd.log", maxlogsize);
+  LogHandler::setupLogFile(&defaultConf, GetTempDirectory() + "htmd.log", maxlogsize);
   // Redirect std streams to a file
-  LogHandler::stderrToFile("/tmp/htmd");
+  LogHandler::stderrToFile(GetTempDirectory() + "htmd");
 
   // Reconfigure default logger to apply settings above
   el::Loggers::reconfigureLogger("default", defaultConf);

--- a/src/terminal/ParseConfigFile.hpp
+++ b/src/terminal/ParseConfigFile.hpp
@@ -34,6 +34,8 @@
 #include <sys/time.h>
 #endif /* HAVE_SYS_TIME_H */
 
+#include "Headers.hpp"
+
 using namespace std;
 
 #define MAX_LINE_SIZE 1024

--- a/src/terminal/TerminalMain.cpp
+++ b/src/terminal/TerminalMain.cpp
@@ -14,7 +14,7 @@ using namespace et;
 void setDaemonLogFile(string idpasskey, string daemonType) {
   string first_idpass_chars = idpasskey.substr(0, 10);
   string logFile =
-      string("/tmp/etterminal_") + daemonType + "_" + first_idpass_chars;
+      string(GetTempDirectory() + "etterminal_") + daemonType + "_" + first_idpass_chars;
 }
 
 int main(int argc, char** argv) {
@@ -140,7 +140,7 @@ int main(int argc, char** argv) {
 
       // etserver with --jump cannot write to the default log file(root)
       LogHandler::setupLogFile(&defaultConf,
-                               "/tmp/etjump-" + username + "-" + id + ".log",
+                               GetTempDirectory() + "etjump-" + username + "-" + id + ".log",
                                maxlogsize);
       // Reconfigure default logger to apply settings above
       el::Loggers::reconfigureLogger("default", defaultConf);
@@ -173,7 +173,7 @@ int main(int argc, char** argv) {
 
     // etserver with --idpasskey cannot write to the default log file(root)
     LogHandler::setupLogFile(&defaultConf,
-                             "/tmp/etterminal-" + username + "-" + id + ".log",
+                             GetTempDirectory() + "etterminal-" + username + "-" + id + ".log",
                              maxlogsize);
     // Reconfigure default logger to apply settings above
     el::Loggers::reconfigureLogger("default", defaultConf);

--- a/src/terminal/TerminalServerMain.cpp
+++ b/src/terminal/TerminalServerMain.cpp
@@ -58,7 +58,7 @@ int main(int argc, char **argv) {
     } else {
       defaultConf.setGlobally(el::ConfigurationType::ToStandardOutput, "false");
       // Redirect std streams to a file
-      LogHandler::stderrToFile("/tmp/etserver");
+      LogHandler::stderrToFile(GetTempDirectory() + "etserver");
     }
 
     string serverFifo = ROUTER_FIFO_NAME;
@@ -89,7 +89,7 @@ int main(int argc, char **argv) {
 
         {
           const char *fifoName =
-              ini.GetValue("Debug", "serverfifo", ROUTER_FIFO_NAME);
+              ini.GetValue("Debug", "serverfifo", ROUTER_FIFO_NAME.c_str());
           if (fifoName) {
             serverFifo = string(fifoName);
           }
@@ -129,7 +129,7 @@ int main(int argc, char **argv) {
     }
 
     // Set log file for etserver process here.
-    LogHandler::setupLogFile(&defaultConf, "/tmp/etserver-%datetime.log",
+    LogHandler::setupLogFile(&defaultConf, GetTempDirectory() + "etserver-%datetime.log",
                              maxlogsize);
     // Reconfigure default logger to apply settings above
     el::Loggers::reconfigureLogger("default", defaultConf);

--- a/src/terminal/UserTerminalRouter.hpp
+++ b/src/terminal/UserTerminalRouter.hpp
@@ -6,7 +6,7 @@
 #include "PipeSocketHandler.hpp"
 #include "ServerConnection.hpp"
 
-#define ROUTER_FIFO_NAME "/tmp/etserver.idpasskey.fifo"
+const string ROUTER_FIFO_NAME = GetTempDirectory() + "etserver.idpasskey.fifo";
 
 namespace et {
 class UserTerminalRouter {

--- a/src/terminal/forwarding/PortForwardHandler.cpp
+++ b/src/terminal/forwarding/PortForwardHandler.cpp
@@ -45,7 +45,7 @@ PortForwardSourceResponse PortForwardHandler::createSource(
       source = pfsr.source();
     } else {
       // Make a random file to forward the pipe
-      string sourcePattern = string("/tmp/et_forward_sock_XXXXXX");
+      string sourcePattern = GetTempDirectory() + string("et_forward_sock_XXXXXX");
       string sourceDirectory = string(mkdtemp(&sourcePattern[0]));
       FATAL_FAIL(::chmod(sourceDirectory.c_str(), S_IRUSR | S_IWUSR | S_IXUSR));
       FATAL_FAIL(::chown(sourceDirectory.c_str(), userid, groupid));

--- a/test/BackedTest.cpp
+++ b/test/BackedTest.cpp
@@ -109,7 +109,7 @@ TEST_CASE("BackedTest", "[BackedTest]") {
   string pipeDirectory;
   string pipePath;
 
-  string tmpPath = string("/tmp/et_test_XXXXXXXX");
+  string tmpPath = GetTempDirectory() + string("et_test_XXXXXXXX");
   pipeDirectory = string(mkdtemp(&tmpPath[0]));
   pipePath = string(pipeDirectory) + "/pipe";
   SocketEndpoint endpoint;

--- a/test/ConnectionTest.cpp
+++ b/test/ConnectionTest.cpp
@@ -264,7 +264,7 @@ TEST_CASE("ConnectionTest", "[ConnectionTest]") {
 
   el::Helpers::setThreadName("Main");
 
-  string tmpPath = string("/tmp/et_test_XXXXXXXX");
+  string tmpPath = GetTempDirectory() + string("et_test_XXXXXXXX");
   pipeDirectory = string(mkdtemp(&tmpPath[0]));
   pipePath = string(pipeDirectory) + "/pipe";
   endpoint = SocketEndpoint();

--- a/test/FakeConsole.hpp
+++ b/test/FakeConsole.hpp
@@ -45,7 +45,7 @@ class FakeConsole : public Console {
     fakeTerminalInfo.set_width(8);
     fakeTerminalInfo.set_height(10);
 
-    string tmpPath = string("/tmp/et_test_console_XXXXXXXX");
+    string tmpPath = GetTempDirectory() + string("et_test_console_XXXXXXXX");
     pipeDirectory = string(mkdtemp(&tmpPath[0]));
     pipePath = string(pipeDirectory) + "/pipe";
     SocketEndpoint endpoint;
@@ -140,7 +140,7 @@ class FakeUserTerminal : public UserTerminal {
   }
 
   virtual int setup(int routerFd) {
-    string tmpPath = string("/tmp/et_test_userterminal_XXXXXXXX");
+    string tmpPath = GetTempDirectory() + string("et_test_userterminal_XXXXXXXX");
     pipeDirectory = string(mkdtemp(&tmpPath[0]));
     pipePath = string(pipeDirectory) + "/pipe";
     SocketEndpoint endpoint;

--- a/test/JumphostTest.cpp
+++ b/test/JumphostTest.cpp
@@ -106,7 +106,7 @@ TEST_CASE("JumphostEndToEndTest", "[JumphostEndToEndTest]") {
   fakeUserTerminal.reset(new FakeUserTerminal(terminalUserSocketHandler));
   fakeUserTerminal->setup(-1);
 
-  string tmpPath = string("/tmp/etserver_test_XXXXXXXX");
+  string tmpPath = GetTempDirectory() + string("etserver_test_XXXXXXXX");
   pipeDirectory = string(mkdtemp(&tmpPath[0]));
 
   string routerPipePath = string(pipeDirectory) + "/pipe_router";

--- a/test/Main.cpp
+++ b/test/Main.cpp
@@ -17,7 +17,7 @@ int main(int argc, char **argv) {
   defaultConf.setGlobally(el::ConfigurationType::ToFile, "true");
   // el::Loggers::setVerboseLevel(9);
 
-  string logDirectoryPattern = string("/tmp/et_test_XXXXXXXX");
+  string logDirectoryPattern = GetTempDirectory() + string("et_test_XXXXXXXX");
   string logDirectory = string(mkdtemp(&logDirectoryPattern[0]));
   string logPath = string(logDirectory) + "/log";
   CLOG(INFO, "stdout") << "Writing log to " << logPath << endl;

--- a/test/TerminalTest.cpp
+++ b/test/TerminalTest.cpp
@@ -167,7 +167,7 @@ TEST_CASE("EndToEndTest", "[EndToEndTest]") {
   fakeUserTerminal.reset(new FakeUserTerminal(userTerminalSocketHandler));
   fakeUserTerminal->setup(-1);
 
-  string tmpPath = string("/tmp/etserver_test_XXXXXXXX");
+  string tmpPath = GetTempDirectory() + string("etserver_test_XXXXXXXX");
   pipeDirectory = string(mkdtemp(&tmpPath[0]));
 
   string routerPipePath = string(pipeDirectory) + "/pipe_router";


### PR DESCRIPTION
Works both completely locally in Termux without root, and when connecting to a linux server. Only remaining issue is that `etserver --help` doesn't work: I think that's because `cxxopts` is incompatible with LLVM libc++, as this patch runs fine on linux x86_64 with GNU libstdc++. I will look into that and patch that last bug later.