### PR TITLE
Run EternalTerminal systemd service with Restart=on-failure

### DIFF
--- a/systemctl/et.service
+++ b/systemctl/et.service
@@ -4,6 +4,7 @@ After=syslog.target network.target
 
 [Service]
 Type=simple
+Restart=on-failure
 ExecStart=/usr/bin/etserver --cfgfile=/etc/et.cfg
 
 [Install]


### PR DESCRIPTION
With Restart=on-failure, the service will be restarted when the process
exits with a non-zero exit code, is terminated by a signal, when an
operation (such as service reload) times out, and when the configured
watchdog timeout is triggered.

Setting this to on-failure is the recommended choice for long-running
services, in order to increase reliability by attempting automatic
recovery from errors.