### PR TITLE
Add --ssh-option argument for passing arguments to ssh

### DIFF
--- a/src/terminal/SshSetupHandler.hpp
+++ b/src/terminal/SshSetupHandler.hpp
@@ -10,7 +10,8 @@ class SshSetupHandler {
                          const string &host_alias, int port,
                          const string &jumphost, int jport, bool kill,
                          int vlevel, const string &cmd_prefix,
-                         const string &serverFifo);
+                         const string &serverFifo,
+                         const std::vector<std::string>& ssh_options);
 };
 }  // namespace et
 #endif  // __ET_SSH_SETUP_HANDLER__

--- a/src/terminal/TerminalClientMain.cpp
+++ b/src/terminal/TerminalClientMain.cpp
@@ -74,6 +74,8 @@ int main(int argc, char** argv) {
         ("serverfifo",
          "If set, communicate to etserver on the matching fifo name",  //
          cxxopts::value<std::string>()->default_value(""))             //
+        ("ssh-option", "Options to pass down to `ssh -o`",
+         cxxopts::value<std::vector<std::string>>())
         ;
 
     options.parse_positional({"host", "positional"});
@@ -232,11 +234,16 @@ int main(int argc, char** argv) {
     if (result["serverfifo"].as<string>() != "") {
       serverFifo = result["serverfifo"].as<string>();
     }
+    std::vector<string> ssh_options;
+    if (result.count("ssh-option")) {
+      ssh_options = result["ssh-option"].as<std::vector<string>>();
+    }
     string idpasskeypair = SshSetupHandler::SetupSsh(
         username, destinationHost, host_alias, destinationPort, jumphost, jport,
         result.count("x") > 0, result["verbose"].as<int>(),
         result.count("prefix") ? result["prefix"].as<string>() : "",
-        serverFifo);
+        serverFifo,
+        ssh_options);
 
     string id = "", passkey = "";
     // Trim whitespace


### PR DESCRIPTION
We'd like to be able to pass arbitrary ssh `-o` config options
down to the underlying ssh command.

Following the suggestions in the last comment on:
https://github.com/MisterTea/EternalTerminal/issues/72

this commit adds a vector of string arguments that can be passed down.

As part of this, tidy up construction of the ssh args list to remove
some redundant string -> c_string -> string conversion and clarify the
control flow a bit.

Test Plan:

I tried running this, with an option picked at random to have
no real effect other than showing up in the argument list:

```
$ ./et --ssh-option RequestTTY=yes SOME.HOST
```

then inspecting the process listing I can see that it made it
into the ssh command that gets run:

```
ssh USER@SHOME.HOST -oRequestTTY=yes echo 'XXXXXXX_xterm-256color\012' |  etterminal --verbose=0
```