### PR TITLE
Do not hard code protobuf lookup properties when using external protobuf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,8 @@ else()
         "${EXTERNAL_DIR}/vcpkg/packages/protobuf_${VCPKG_TARGET_TRIPLET}/tools/protobuf/protoc"
     )
   endif()
+  set(Protobuf_USE_STATIC_LIBS ON)
+  set(protobuf_MSVC_STATIC_RUNTIME ON)
 endif()
 
 # Don't specify languages yet in case we need to bump the cmake version
@@ -87,8 +89,6 @@ find_package(OpenSSL REQUIRED)
 find_package(Sanitizers REQUIRED)
 find_package(Threads REQUIRED)
 find_package(sodium REQUIRED)
-set(Protobuf_USE_STATIC_LIBS ON)
-set(protobuf_MSVC_STATIC_RUNTIME ON)
 find_package(Protobuf REQUIRED)
 find_package(ZLIB REQUIRED)
 find_package(Unwind)


### PR DESCRIPTION
E.g. the static library may not exist or may not be the one to use.
