### PR TITLE
Allow disabling Sentry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "NetBSD")
   set(NETBSD TRUE)
 endif(CMAKE_SYSTEM_NAME MATCHES "NetBSD")
 
-if(FREEBSD OR NETBSD)
+if(FREEBSD OR NETBSD OR DISABLE_SENTRY)
   # Sentry doesn't work on BSD
 else()
   # Enable sentry


### PR DESCRIPTION
We might want to build ET without Sentry in unforeseen circumstances
(e.g. on Fedora and EL, Sentry does not compile on ppc64le and s390x).

Add DISABLE_SENTRY that works the same way as DISABLE_VCPKG - if set,
ET is built without Sentry support.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mistertea/eternalterminal/414)
<!-- Reviewable:end -->
