### PR TITLE
Execute shell with -l rather than --login for dash compatibility

### DIFF
--- a/src/htm/TerminalHandler.cpp
+++ b/src/htm/TerminalHandler.cpp
@@ -19,7 +19,7 @@ void TerminalHandler::start() {
       chdir(pwd->pw_dir);
       string terminal = string(::getenv("SHELL"));
       setenv("HTM_VERSION", ET_VERSION, 1);
-      execl(terminal.c_str(), terminal.c_str(), "--login", NULL);
+      execl(terminal.c_str(), terminal.c_str(), "-l", NULL);
       exit(0);
       break;
     }

--- a/src/terminal/PsuedoUserTerminal.hpp
+++ b/src/terminal/PsuedoUserTerminal.hpp
@@ -79,7 +79,7 @@ class PsuedoUserTerminal : public UserTerminal {
     // no requirements for any wait(2) on our part.
     //
     signal(SIGCHLD, SIG_DFL);
-    FATAL_FAIL(execl(terminal.c_str(), terminal.c_str(), "--login", NULL));
+    FATAL_FAIL(execl(terminal.c_str(), terminal.c_str(), "-l", NULL));
   }
 
   virtual void cleanup() {


### PR DESCRIPTION
I use dash as my login shell and noticed that etterminal launches SHELL with --login, which dash doesn't support.

Since -l seems to be supported by the major shells like bash and zsh, I'm wondering whether this could be an appropriate change to support dash as well.

Thanks!