### PR TITLE
Mark socket as non-blocking before calling connect (#366)

### DIFF
--- a/src/base/TcpSocketHandler.cpp
+++ b/src/base/TcpSocketHandler.cpp
@@ -52,6 +52,7 @@ int TcpSocketHandler::connect(const SocketEndpoint &endpoint) {
       continue;
     }
 
+#ifndef WIN32
     // Try set non-blocking flag on the socket to avoid connect from hanging.
     // If we can't make the socket non-blocking, we'll just wait longer.
     int flags = 0;
@@ -62,6 +63,7 @@ int TcpSocketHandler::connect(const SocketEndpoint &endpoint) {
                   << localErrno << " " << strerror(localErrno);
       }
     }
+#endif
 
     // initiate non-blocking connect (set above via fcntl)
     if (::connect(sockFd, p->ai_addr, p->ai_addrlen) == -1 &&


### PR DESCRIPTION
Reconnection is sometimes slow because 'connect' cannot establish
connection immediately and blocks until underlying timeout.

This change marks the socket non-blocking making use of the fact that
we're later calling select with a low timeout allowing fast failure.