### PR TITLE
Telemetry for Mojave

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,13 @@ else()
         "${CMAKE_CURRENT_BINARY_DIR}/vcpkg_installed/${VCPKG_TARGET_TRIPLET}/debug/lib/zlibd.lib"
     )
   else()
+    # Make BoostConfig.cmake able to check its inputs
+    cmake_policy(SET CMP0057 NEW)
+    # Honor the visibility properties for all target types, including
+    # object libraries and static libraries.
+    cmake_policy(SET CMP0063 NEW)
+    # Don't ignore <PackageName>_ROOT variables
+    cmake_policy(SET CMP0074 NEW)
     set(Protobuf_PROTOC_EXECUTABLE
         "${EXTERNAL_DIR}/vcpkg/packages/protobuf_${VCPKG_TARGET_TRIPLET}/tools/protobuf/protoc"
     )
@@ -113,10 +120,13 @@ endif(CMAKE_SYSTEM_NAME MATCHES "NetBSD")
 
 option(DISABLE_SENTRY "Disable Sentry crash logging" OFF)
 option(DISABLE_TELEMETRY "Disable all crash logging" OFF)
+
 IF(APPLE)
-IF(CMAKE_HOST_SYSTEM_VERSION VERSION_LESS "19.0.0")
-SET(DISABLE_TELEMETRY ON)
-ENDIF()
+  # Proxy test for Mojave? (Clang that doesn't have std::filesystem)
+  IF(CMAKE_HOST_SYSTEM_VERSION VERSION_LESS "19.0.0")
+    # So use Boost's version
+    find_package(Boost 1.76 COMPONENTS filesystem REQUIRED)
+  ENDIF()
 ENDIF(APPLE)
 
 if(FREEBSD OR NETBSD OR DISABLE_SENTRY OR DISABLE_TELEMETRY)
@@ -216,6 +226,11 @@ else()
   set(UTEMPTER_LIBRARIES "")
 endif()
 
+if(NOT Boost_FOUND)
+  set(Boost_INCLUDE_DIR "")
+  set(Boost_LIBRARIES "")
+endif()
+
 protobuf_generate_cpp(ET_SRCS ET_HDRS proto/ET.proto)
 set_source_files_properties(${ET_SRCS} ${ET_HDRS} PROPERTIES GENERATED TRUE)
 protobuf_generate_cpp(ETERMINAL_SRCS ETERMINAL_HDRS proto/ETerminal.proto)
@@ -289,6 +304,7 @@ include_directories(
   ${sodium_INCLUDE_DIR}
   ${SELINUX_INCLUDE_DIR}
   ${UTEMPTER_INCLUDE_DIR}
+  ${Boost_INCLUDE_DIR}
   ${OPENSSL_INCLUDE_DIR})
 
 if(NOT ANDROID)
@@ -377,6 +393,7 @@ target_link_libraries(
   ${PROTOBUF_LIBS}
   ${sodium_LIBRARY_RELEASE}
   ${UTEMPTER_LIBRARIES}
+  ${Boost_LIBRARIES}
   ${CORE_LIBRARIES})
 add_dependencies(et generated-code et-lib)
 decorate_target(et)
@@ -401,6 +418,7 @@ else(WIN32)
     ${sodium_LIBRARY_RELEASE}
     ${SELINUX_LIBRARIES}
     ${UTEMPTER_LIBRARIES}
+    ${Boost_LIBRARIES}
       ${CORE_LIBRARIES})
   add_dependencies(etserver generated-code et-lib)
   decorate_target(etserver)
@@ -416,6 +434,7 @@ else(WIN32)
     ${sodium_LIBRARY_RELEASE}
     ${SELINUX_LIBRARIES}
     ${UTEMPTER_LIBRARIES}
+    ${Boost_LIBRARIES}
       ${CORE_LIBRARIES})
   add_dependencies(etterminal generated-code et-lib)
   decorate_target(etterminal)
@@ -444,6 +463,7 @@ else(WIN32)
     ${sodium_LIBRARY_RELEASE}
     ${SELINUX_LIBRARIES}
     ${UTEMPTER_LIBRARIES}
+    ${Boost_LIBRARIES}
       ${CORE_LIBRARIES})
   decorate_target(htm)
 
@@ -458,6 +478,7 @@ else(WIN32)
     ${sodium_LIBRARY_RELEASE}
     ${SELINUX_LIBRARIES}
     ${UTEMPTER_LIBRARIES}
+    ${Boost_LIBRARIES}
       ${CORE_LIBRARIES})
   decorate_target(htmd)
 
@@ -479,6 +500,7 @@ else(WIN32)
     ${sodium_LIBRARY_RELEASE}
     ${SELINUX_LIBRARIES}
     ${UTEMPTER_LIBRARIES}
+    ${Boost_LIBRARIES}
       ${CORE_LIBRARIES})
   add_test(et-test et-test)
   decorate_target(et-test)

--- a/README.md
+++ b/README.md
@@ -36,22 +36,8 @@ sudo apt-get update
 sudo apt-get install et
 ```
 
-Install and build from source:
+Or see "Debian/Ubuntu" below to install and build from source (e.g., for ARM).
 
-```
-sudo apt install build-essential libgflags-dev libprotobuf-dev protobuf-compiler libsodium-dev cmake git libcurl-dev
-git clone --recurse-submodules https://github.com/MisterTea/EternalTerminal.git
-cd EternalTerminal
-mkdir build
-cd build
-# On ARM or OS/X with apple silicon:
-# export VCPKG_FORCE_SYSTEM_BINARIES=1
-cmake ../
-make && sudo make install
-sudo cp ../etc/et.cfg /etc/
-```
-
-Once built, the binary only requires `libgflags-dev` and `libprotobuf-dev`.
 
 ### Debian
 
@@ -186,7 +172,7 @@ et dev (etserver running on port 2022 on both hostname and jumphost)
 et dev:8000 -jport 9000 (etserver running on port 9000 on jumphost)
 ```
 
-## Building from source
+## Building from Source
 
 ### macOS
 
@@ -198,31 +184,49 @@ git clone --recurse-submodules https://github.com/MisterTea/EternalTerminal.git
 cd EternalTerminal
 mkdir build
 cd build
+# Make it work on Apple Silicon:
+if [[ $(uname -a | grep arm) ]]; then export VCPKG_FORCE_SYSTEM_BINARIES=1; fi
 cmake ../
-make
+make && sudo make install
+```
+
+To run an `et` server for testing, run `./etserver`.  To run an `et`
+server daemon persistently across reboots:
+
+```
+sudo cp ../init/launchd/homebrew.mxcl.et.plist /Library/LaunchDaemons
+sudo launchctl load -w /Library/LaunchDaemons/homebrew.mxcl.et.plist
 ```
 
 ### Debian/Ubuntu
 
-Grab the deps and then follow this process:
+Grab the deps and then follow this process.
 
 Debian/Ubuntu Dependencies:
+
 ```
 sudo apt install libboost-dev libsodium-dev libncurses5-dev \
-	libprotobuf-dev protobuf-compiler cmake libgflags-dev libutempter-dev cmake git libcurl-dev
+	libprotobuf-dev protobuf-compiler libgflags-dev libutempter-dev libcurl-dev \
+    build-essential ninja-build cmake git zip
 ```
 
-Source and setup:
+Fetch source, build and install:
 
 ```
 git clone --recurse-submodules https://github.com/MisterTea/EternalTerminal.git
 cd EternalTerminal
 mkdir build
 cd build
+# For ARM (including OS/X with apple silicon):
+if [[ $(uname -a | grep arm) ]]; then export VCPKG_FORCE_SYSTEM_BINARIES=1; fi
 cmake ../
 make
 sudo make install
+sudo cp ../etc/et.cfg /etc/
 ```
+
+Once built, the binary only requires `libgflags-dev` and `libprotobuf-dev`.
+
 
 ### CentOS 7
 

--- a/src/base/Headers.hpp
+++ b/src/base/Headers.hpp
@@ -82,23 +82,6 @@ inline int close(int fd) { return ::closesocket(fd); }
 #include <unordered_set>
 #include <vector>
 
-#ifndef NO_TELEMETRY
-#if __has_include(<boost/filesystem.hpp>)
-#pragma message "Using boost::filesystem"
-#include <boost/filesystem.hpp>
-namespace fs = boost::filesystem;
-#elif __has_include(<filesystem>)
-#include <filesystem>
-namespace fs = filesystem;
-#elif __has_include(<experimental/filesystem>)
-#pragma message "Using std::experimental::filesystem"
-#include <experimental/filesystem>
-namespace fs = std::experimental;
-#else
-#pragma message "No filesystem library found."
-#endif
-#endif
-
 #include "ET.pb.h"
 #include "ETerminal.pb.h"
 #include "ThreadPool.h"

--- a/src/base/Headers.hpp
+++ b/src/base/Headers.hpp
@@ -83,11 +83,19 @@ inline int close(int fd) { return ::closesocket(fd); }
 #include <vector>
 
 #ifndef NO_TELEMETRY
-#if __has_include(<filesystem>)
+#if __has_include(<boost/filesystem.hpp>)
+#pragma message "Using boost filesystem"
+#include <boost/filesystem.hpp>
+namespace fs = boost::filesystem;
+#elif __has_include(<filesystem>)
 #include <filesystem>
-#else
+using namespace filesystem as fs;
+#elif __has_include(<experimental/filesystem>)
+#pragma message "Using std::experimental::filesystem"
 #include <experimental/filesystem>
-using namespace std::experimental;
+using namespace std::experimental as fs;
+#else
+#pragma message "No filesystem library found."
 #endif
 #endif
 

--- a/src/base/Headers.hpp
+++ b/src/base/Headers.hpp
@@ -84,16 +84,16 @@ inline int close(int fd) { return ::closesocket(fd); }
 
 #ifndef NO_TELEMETRY
 #if __has_include(<boost/filesystem.hpp>)
-#pragma message "Using boost filesystem"
+#pragma message "Using boost::filesystem"
 #include <boost/filesystem.hpp>
 namespace fs = boost::filesystem;
 #elif __has_include(<filesystem>)
 #include <filesystem>
-using namespace filesystem as fs;
+namespace fs = filesystem;
 #elif __has_include(<experimental/filesystem>)
 #pragma message "Using std::experimental::filesystem"
 #include <experimental/filesystem>
-using namespace std::experimental as fs;
+namespace fs = std::experimental;
 #else
 #pragma message "No filesystem library found."
 #endif

--- a/src/terminal/TelemetryService.cpp
+++ b/src/terminal/TelemetryService.cpp
@@ -102,7 +102,7 @@ TelemetryService::TelemetryService(const bool _allow,
   if (allowed) {
     auto telemetryConfigPath = sago::getConfigHome() + "/et/telemetry.ini";
     telemetryId = sole::uuid4();
-    if (filesystem::exists(telemetryConfigPath)) {
+    if (fs::exists(telemetryConfigPath)) {
       // Load the config file
       CSimpleIniA ini(true, false, false);
       SI_Error rc = ini.LoadFile(telemetryConfigPath.c_str());
@@ -118,7 +118,7 @@ TelemetryService::TelemetryService(const bool _allow,
       }
     } else {
       // Ensure directory exists
-      filesystem::create_directories(sago::getConfigHome() + "/et");
+      fs::create_directories(sago::getConfigHome() + "/et");
 
       // Create ini
       CSimpleIniA ini(true, false, false);

--- a/src/terminal/TelemetryService.hpp
+++ b/src/terminal/TelemetryService.hpp
@@ -4,18 +4,16 @@
 
 #ifndef NO_TELEMETRY
 #if __has_include(<boost/filesystem.hpp>)
-#pragma message "Using boost::filesystem"
 #include <boost/filesystem.hpp>
 namespace fs = boost::filesystem;
 #elif __has_include(<filesystem>)
 #include <filesystem>
 namespace fs = filesystem;
 #elif __has_include(<experimental/filesystem>)
-#pragma message "Using std::experimental::filesystem"
 #include <experimental/filesystem>
 namespace fs = std::experimental;
 #else
-#pragma message "No filesystem library found."
+#pragma message "No filesystem library found (which Telemetry needs)."
 #endif
 #endif
 

--- a/src/terminal/TelemetryService.hpp
+++ b/src/terminal/TelemetryService.hpp
@@ -2,6 +2,23 @@
 
 #include "Headers.hpp"
 
+#ifndef NO_TELEMETRY
+#if __has_include(<boost/filesystem.hpp>)
+#pragma message "Using boost::filesystem"
+#include <boost/filesystem.hpp>
+namespace fs = boost::filesystem;
+#elif __has_include(<filesystem>)
+#include <filesystem>
+namespace fs = filesystem;
+#elif __has_include(<experimental/filesystem>)
+#pragma message "Using std::experimental::filesystem"
+#include <experimental/filesystem>
+namespace fs = std::experimental;
+#else
+#pragma message "No filesystem library found."
+#endif
+#endif
+
 namespace httplib {
 class Client;
 }


### PR DESCRIPTION
This makes Telemetry work on Mojave:

1.  Install boost with `brew install boost`
2.  Cmake finds Boost
3. `TelemetryService.hpp` sets `fs` to a filesystem namespace that it can find (`boost`, `std`, or `std::experimental`)
4. `TelemetryService.cpp' uses `fs::` instead of `filesystem::`

I imagine we'll need to simultaneously change homebrew-et/et.rb to include dependencies:

```
  depends_on "boost"
  depends_on "ninja"
```

(`ninja` is just missing now; `boost` is of course a new dependency.). I don't know brew well enough to know if it's possible to only add boost as a dependency for Mojave systems and not for Catalina onward.

Compiled and tested (`et-test`) on x86 Mojave, M1 Big Sur, and PocketBeagle Debian Buster (kernel 4.19.94-ti-r64).

I would appreciate any feedback you have on this PR!


