### PR TITLE
add configurable client keep-alive duration

### DIFF
--- a/src/base/Headers.hpp
+++ b/src/base/Headers.hpp
@@ -161,8 +161,8 @@ const string SYSTEM_SSH_CONFIG_PATH = "/etc/ssh/ssh_config";
 const string USER_SSH_CONFIG_PATH = "/.ssh/config";
 
 // Keepalive configs
-const int CLIENT_KEEP_ALIVE_DURATION = 5;
-// This should be at least double the value of CLIENT_KEEP_ALIVE_DURATION to
+const int MAX_CLIENT_KEEP_ALIVE_DURATION = 5;
+// This should be at least double the value of MAX_CLIENT_KEEP_ALIVE_DURATION to
 // allow enough time.
 const int SERVER_KEEP_ALIVE_DURATION = 11;
 

--- a/src/terminal/TerminalClient.hpp
+++ b/src/terminal/TerminalClient.hpp
@@ -24,7 +24,7 @@ class TerminalClient {
                  const string& passkey, shared_ptr<Console> _console,
                  bool jumphost, const string& tunnels,
                  const string& reverseTunnels, bool forwardSshAgent,
-                 const string& identityAgent);
+                 const string& identityAgent, int _keepaliveDuration);
   virtual ~TerminalClient();
   void run(const string& command);
   void shutdown() {
@@ -38,6 +38,7 @@ class TerminalClient {
   shared_ptr<PortForwardHandler> portForwardHandler;
   bool shuttingDown;
   recursive_mutex shutdownMutex;
+  int keepaliveDuration;
 };
 
 }  // namespace et

--- a/test/JumphostTest.cpp
+++ b/test/JumphostTest.cpp
@@ -35,7 +35,8 @@ void readWriteTest(const string& clientId,
 
   shared_ptr<TerminalClient> terminalClient(new TerminalClient(
       clientSocketHandler, clientPipeSocketHandler, jumphostEndpoint, clientId,
-      CRYPTO_KEY, fakeConsole, true, "", "", false, ""));
+      CRYPTO_KEY, fakeConsole, true, "", "", false, "",
+      MAX_CLIENT_KEEP_ALIVE_DURATION));
   thread terminalClientThread([terminalClient]() { terminalClient->run(""); });
   sleep(3);
 

--- a/test/TerminalTest.cpp
+++ b/test/TerminalTest.cpp
@@ -98,7 +98,8 @@ void readWriteTest(const string& clientId,
 
   shared_ptr<TerminalClient> terminalClient(new TerminalClient(
       clientSocketHandler, clientPipeSocketHandler, serverEndpoint, clientId,
-      CRYPTO_KEY, fakeConsole, false, "", "", false, ""));
+      CRYPTO_KEY, fakeConsole, false, "", "", false, "",
+      MAX_CLIENT_KEEP_ALIVE_DURATION));
   thread terminalClientThread([terminalClient]() { terminalClient->run(""); });
   sleep(3);
 


### PR DESCRIPTION
hello! thanks for a great tool. this PR (should) make the client keep-alive duration configurable.

i created this because i noticed that reconnection times seemed to be slow sometimes (especially when compared to mosh) and am suffering frequently from lost keys. i realize that UDP is probably better suited for cases where there is frequent switching but many public wifi networks (at least in my locale) has some sort of filtering in place that makes EternalTerminal much more practical to use.

disclaimer: i don't have any actual data that this would improve the situation for my use case, because i'm still having issues building on MacOS M1. but this seemed like a fast enough change that i thought i'd make it and get some feedback :)

please take a look, thanks!