### PR TITLE
Fix reconnects on FreeBSD

### DIFF
--- a/src/base/Headers.hpp
+++ b/src/base/Headers.hpp
@@ -251,6 +251,12 @@ inline string WindowsErrnoToString() {
 #define FATAL_FAIL_UNLESS_EINVAL(X)        \
   if (((X) == -1) && GetErrno() != EINVAL) \
     STFATAL << "Error: (" << GetErrno() << "): " << strerror(GetErrno());
+
+// On FreeBSD we can get EAGAIN on close if the descriptor is being
+// selected.
+#define FATAL_FAIL_UNLESS_EAGAIN(X)        \
+  if (((X) == -1) && GetErrno() != EAGAIN) \
+    STFATAL << "Error: (" << GetErrno() << "): " << strerror(GetErrno());
 #endif
 
 #ifndef ET_VERSION

--- a/src/base/UnixSocketHandler.cpp
+++ b/src/base/UnixSocketHandler.cpp
@@ -168,7 +168,11 @@ void UnixSocketHandler::close(int fd) {
 #ifdef _MSC_VER
   FATAL_FAIL_UNLESS_ZERO(::closesocket(fd));
 #else
+#ifdef __FreeBSD__
+  FATAL_FAIL_UNLESS_EAGAIN(::close(fd));
+#else
   FATAL_FAIL(::close(fd));
+#endif
 #endif
   activeSocketMutexes.erase(it);
 }

--- a/src/terminal/TerminalServer.cpp
+++ b/src/terminal/TerminalServer.cpp
@@ -274,7 +274,7 @@ void TerminalServer::runTerminal(
           tb.set_buffer(s);
           serverClientState->writePacket(
               Packet(TerminalPacketType::TERMINAL_BUFFER, protoToString(tb)));
-        } else if (rc == 0 || errno != EAGAIN) {
+        } else {
           LOG(INFO) << "Terminal session ended";
           run = false;
           break;

--- a/src/terminal/TerminalServer.cpp
+++ b/src/terminal/TerminalServer.cpp
@@ -274,7 +274,7 @@ void TerminalServer::runTerminal(
           tb.set_buffer(s);
           serverClientState->writePacket(
               Packet(TerminalPacketType::TERMINAL_BUFFER, protoToString(tb)));
-        } else {
+        } else if (rc == 0 || errno != EAGAIN) {
           LOG(INFO) << "Terminal session ended";
           run = false;
           break;


### PR DESCRIPTION
With etserver v6.1.9, attempts to reconnect cause the etserver process
to crash due to an unexpected EGAIN in UnixSocketHandler::close.

Suppressing this by ignoring EAGAIN allows etserver to keep running
but the reconnect still fails since the call to close causes the
select in TerminalServer::runTerminal to complete with EBADF and
an attempt to read from terminalFd which returns EAGAIN (since it
is non-blocking) and the terminal server session ends.

Handling EGAIN in both places allows the reconnect to succeed and
re-join the terminal server session reliably.