### PR TITLE
Update TerminalClient.cpp

### DIFF
--- a/src/terminal/TerminalClient.cpp
+++ b/src/terminal/TerminalClient.cpp
@@ -211,7 +211,7 @@ void TerminalClient::run(const string& command) {
   if (command.length()) {
     LOG(INFO) << "Got command: " << command;
     et::TerminalBuffer tb;
-    tb.set_buffer(command + "; exit\n");
+    tb.set_buffer(command + "\n");
 
     connection->writePacket(
         Packet(TerminalPacketType::TERMINAL_BUFFER, protoToString(tb)));


### PR DESCRIPTION
I am unsure if you had added the `exit` in order to get around some other bug or not, but here is a patch to remove the appended exit to any command passed from `-c`