### PR TITLE
Fix boost library reference on macOS

### DIFF
--- a/src/base/Headers.hpp
+++ b/src/base/Headers.hpp
@@ -88,7 +88,7 @@ inline int close(int fd) { return ::closesocket(fd); }
 #include <Availability.h>
 #endif
 
-#if defined(__APPLE__) && __MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_15
+#if defined(__APPLE__) && (!defined(MAC_OS_X_VERSION_10_15) || __MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_15)
 #if __has_include(<boost/filesystem.hpp>)
 #include <boost/filesystem.hpp>
 namespace fs = boost::filesystem;


### PR DESCRIPTION
Check if `MAC_OS_X_VERSION_10_15` is defined, so that if the code is loaded on an older system that does not include the symbol definition, it still works.