### PR TITLE
Use Boost-compatible signature of permissions()

### DIFF
--- a/src/base/LogHandler.cpp
+++ b/src/base/LogHandler.cpp
@@ -50,8 +50,7 @@ string LogHandler::stderrToFile(const string &pathPrefix) {
   FILE *stderr_stream = freopen(stderrFilename.c_str(), "w", stderr);
   fs::permissions(
       stderrFilename,
-      fs::perms::owner_read | fs::perms::owner_write | fs::perms::group_read,
-      fs::perm_options::replace);
+      fs::perms::owner_read | fs::perms::owner_write | fs::perms::group_read);
   if (!stderr_stream) {
     STFATAL << "Invalid filename " << stderrFilename;
   }


### PR DESCRIPTION
Boost.Filesystem does not support permissions() with perm_options.

perm_options::replace is the default in std::filesystem, so code behavior is not affected.