### PR TITLE
drop -dev dependencies on debian

### DIFF
--- a/deployment/debian/debian_SOURCE/control
+++ b/deployment/debian/debian_SOURCE/control
@@ -10,6 +10,6 @@ Homepage: https://mistertea.github.io/EternalTCP/
 
 Package: et
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}, libgcc1 (>= 1:3.3), libprotobuf-dev, libsodium-dev, libstdc++6, libtinfo5, libutempter-dev, libcurl4-openssl-dev, libssl-dev, libunwind-dev
+Depends: ${misc:Depends}, ${shlibs:Depends}, libgcc1 (>= 1:3.3), libstdc++6, libtinfo5
 Description: Remote terminal for the busy and impatient
  Eternal Terminal is a remote shell that automatically reconnects without interrupting the session.


### PR DESCRIPTION
The debian build system will add all the necessary dependencies
automatically, so -dev dependencies are only needed in Build-Depends.