### PR TITLE
Update Debian download instructions to use Bullseye repo

### DIFF
--- a/download.md
+++ b/download.md
@@ -24,14 +24,15 @@ sudo apt-get install et
 
 # Debian
 
-For debian, use our deb repo.  For stretch:
+For Debian, use our deb repo.  For bullseye:
 
 ```
-echo "deb https://mistertea.github.io/debian-et/debian-source/ buster main" | sudo tee /etc/apt/sources.list.d/et.list
+echo "deb https://mistertea.github.io/debian-et/debian-source/ bullseye main" | sudo tee /etc/apt/sources.list.d/et.list
 curl -sS https://mistertea.github.io/debian-et/et.gpg | sudo apt-key add -
 sudo apt update
 sudo apt install et
 ```
+See [the repo source](https://github.com/MisterTea/debian-et/tree/master/debian-source/dists) for a list of the other supposed Debian versions.
 
 # Other Linux/Unix
 


### PR DESCRIPTION
Bullseye is the latest stable version so it should be used here.