### PR TITLE
Add simple fuzzers for etserver sockets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,6 +157,7 @@ if(POLICY CMP0058)
 endif()
 
 option(CODE_COVERAGE "Enable code coverage" OFF)
+option(FUZZING "Enable builds for fuzz testing" OFF)
 option(DISABLE_CRASH_LOG "Disable installing easylogging crash handler" OFF)
 
 add_definitions(-DET_VERSION="${PROJECT_VERSION}")
@@ -285,6 +286,26 @@ macro(DECORATE_TARGET TARGET_NAME)
     # Doesn't work when cross-compiling
   else()
     cotire(${TARGET_NAME})
+  endif()
+endmacro()
+
+macro(DECORATE_FUZZER TARGET_NAME)
+  add_sanitizers(${TARGET_NAME})
+
+  if(FUZZING)
+    # ASAN must also be enabled to build fuzzers.
+    if(NOT SANITIZE_ADDRESS)
+      message(FATAL_ERROR "Fuzzing requires SANITIZE_ADDRESS=ON to detect memory errors.")
+    endif()
+
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+      set_property(TARGET ${TARGET_NAME} APPEND_STRING
+          PROPERTY COMPILE_FLAGS " -fsanitize=fuzzer")
+      set_property(TARGET ${TARGET_NAME} APPEND_STRING
+          PROPERTY LINK_FLAGS " -fsanitize=fuzzer")
+    else()
+      message(FATAL_ERROR "Currently fuzzing is only supported with Clang.")
+    endif()
   endif()
 endmacro()
 
@@ -512,6 +533,46 @@ else(WIN32)
       ${CORE_LIBRARIES})
   add_test(et-test et-test)
   decorate_target(et-test)
+
+  if(FUZZING)
+    add_executable(
+    TerminalServerFuzzer
+    test/TerminalServerFuzzer.cpp
+    test/FuzzableTerminalServer.hpp
+    )
+    add_dependencies(TerminalServerFuzzer TerminalCommon et-lib)
+    target_link_libraries(
+      TerminalServerFuzzer
+      TerminalCommon
+      et-lib
+      ${CMAKE_THREAD_LIBS_INIT}
+      ${PROTOBUF_LIBS}
+      ${sodium_LIBRARY_RELEASE}
+      ${SELINUX_LIBRARIES}
+      ${UTEMPTER_LIBRARIES}
+      ${Boost_LIBRARIES}
+        ${CORE_LIBRARIES})
+    decorate_fuzzer(TerminalServerFuzzer)
+
+    add_executable(
+    TerminalServerRouterFuzzer
+    test/TerminalServerRouterFuzzer.cpp
+    test/FuzzableTerminalServer.hpp
+    )
+    add_dependencies(TerminalServerRouterFuzzer TerminalCommon et-lib)
+    target_link_libraries(
+      TerminalServerRouterFuzzer
+      TerminalCommon
+      et-lib
+      ${CMAKE_THREAD_LIBS_INIT}
+      ${PROTOBUF_LIBS}
+      ${sodium_LIBRARY_RELEASE}
+      ${SELINUX_LIBRARIES}
+      ${UTEMPTER_LIBRARIES}
+      ${Boost_LIBRARIES}
+        ${CORE_LIBRARIES})
+    decorate_fuzzer(TerminalServerRouterFuzzer)
+  endif(FUZZING)
 
   install(
     TARGETS etserver etterminal et htm htmd

--- a/src/terminal/TerminalServer.cpp
+++ b/src/terminal/TerminalServer.cpp
@@ -35,8 +35,10 @@ void TerminalServer::run() {
   maxCoreFd = max(maxCoreFd, terminalRouter->getServerFd());
   numCoreFds++;
 
-  TelemetryService::get()->logToDatadog("Server started", el::Level::Info,
-                                        __FILE__, __LINE__);
+  if (TelemetryService::exists()) {
+    TelemetryService::get()->logToDatadog("Server started", el::Level::Info,
+                                          __FILE__, __LINE__);
+  }
 
   while (true) {
     {

--- a/src/terminal/UserTerminalRouter.cpp
+++ b/src/terminal/UserTerminalRouter.cpp
@@ -42,7 +42,9 @@ IdKeyPair UserTerminalRouter::acceptNewConnection() {
     idInfoMap[tui.id()] = tui;
     return IdKeyPair({tui.id(), tui.passkey()});
   } catch (const std::runtime_error &re) {
-    STFATAL << "Router can't talk to terminal: " << re.what();
+    LOG(ERROR) << "Router can't talk to terminal: " << re.what();
+    socketHandler->close(terminalFd);
+    return IdKeyPair({"", ""});
   }
 
   STFATAL << "Should never get here";

--- a/test/FuzzableTerminalServer.hpp
+++ b/test/FuzzableTerminalServer.hpp
@@ -1,0 +1,45 @@
+#ifndef __ET_FUZZABLE_TERMINAL_SERVER__
+#define __ET_FUZZABLE_TERMINAL_SERVER__
+
+#include "TerminalServer.hpp"
+
+namespace et {
+class FuzzableTerminalServer {
+ public:
+  FuzzableTerminalServer() {
+    serverSocketHandler.reset(new PipeSocketHandler());
+    pipeSocketHandler.reset(new PipeSocketHandler());
+
+    string tmpPath = GetTempDirectory() + string("etserver_fuzzer_XXXXXXXX");
+    const string pipeDirectory = string(mkdtemp(&tmpPath[0]));
+
+    const string serverPipePath = pipeDirectory + "/pipe_server";
+    SocketEndpoint serverEndpoint;
+    serverEndpoint.set_name(serverPipePath);
+
+    const string routerPath = pipeDirectory + "/pipe_router";
+    routerEndpoint.set_name(routerPath);
+
+    terminalServer.reset(new TerminalServer(serverSocketHandler, serverEndpoint,
+                                            pipeSocketHandler, routerEndpoint));
+    terminalServerThread = thread([this]() { terminalServer->run(); });
+  }
+
+  ~FuzzableTerminalServer() {
+    terminalServer->shutdown();
+    terminalServerThread.join();
+  }
+
+  std::shared_ptr<PipeSocketHandler> serverSocketHandler;
+  std::shared_ptr<PipeSocketHandler> pipeSocketHandler;
+
+  SocketEndpoint serverEndpoint;
+  SocketEndpoint routerEndpoint;
+
+  shared_ptr<TerminalServer> terminalServer;
+  thread terminalServerThread;
+};
+
+}  // namespace et
+
+#endif  // __ET_FUZZABLE_TERMINAL_SERVER__

--- a/test/TerminalServerFuzzer.cpp
+++ b/test/TerminalServerFuzzer.cpp
@@ -1,0 +1,31 @@
+#include "FuzzableTerminalServer.hpp"
+
+namespace et {
+
+static std::unique_ptr<FuzzableTerminalServer> sServer;
+
+extern "C" int LLVMFuzzerInitialize(int* argc, char*** argv) {
+  sServer.reset(new FuzzableTerminalServer());
+
+  return 0;
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  PipeSocketHandler sockerHandler;
+  const int fd = sockerHandler.connect(sServer->serverEndpoint);
+  if (fd == -1) {
+    // Ignore if we fail to connect.
+    return 0;
+  }
+
+  sockerHandler.write(fd, data, size);
+
+  // Shutdown the server, to verify that it gracefully exits.
+  sServer->terminalServer->shutdown();
+
+  sockerHandler.close(fd);
+
+  return 0;
+}
+
+}  // namespace et

--- a/test/TerminalServerRouterFuzzer.cpp
+++ b/test/TerminalServerRouterFuzzer.cpp
@@ -1,0 +1,30 @@
+#include "FuzzableTerminalServer.hpp"
+
+namespace et {
+
+static std::unique_ptr<FuzzableTerminalServer> sServer;
+
+extern "C" int LLVMFuzzerInitialize(int* argc, char*** argv) {
+  sServer.reset(new FuzzableTerminalServer());
+  return 0;
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  PipeSocketHandler sockerHandler;
+  const int fd = sockerHandler.connect(sServer->routerEndpoint);
+  if (fd == -1) {
+    // Ignore if we fail to connect.
+    return 0;
+  }
+
+  sockerHandler.write(fd, data, size);
+
+  // Shutdown the server, to verify that it gracefully exits.
+  sServer->terminalServer->shutdown();
+
+  sockerHandler.close(fd);
+
+  return 0;
+}
+
+}  // namespace et


### PR DESCRIPTION
etserver has two interfaces, the "server" and "router". Add fuzzers for
each of these, and fix crashes from invalid input to the router
(internal) interface.

The fuzz build currently requires libFuzzer and clang, and can be
invoked with:
```
export CC=/usr/bin/clang
export CXX=/usr/bin/clang++

mkdir build && cd build
cmake -DSANITIZE_ADDRESS=ON -DFUZZING=ON ../
make -j`nproc`
```

To run the fuzzers:
```
mkdir router-corpus
cd router-corpus
../TerminalServerRouterFuzzer -jobs=10 .

mkdir server-corpus
cd server-corpus
../TerminalServerFuzzer -jobs=10 .
```

These will keep running unless they hit a crash.

Note that easyloggingpp still overrides the signal handlers, so doing a
Ctrl-C will trigger a spurious crash report, but these can be safely
ignored.

The integration can still be improved, and this can be integrated with
CI and infra like OSSFuzz at a later point, but this change focuses on
bootstrapping the fuzzers.

I included the code fix in this change, since that was blocking running
the fuzzer for longer periods of time.  The failure is an STFATAL that
gets hit in UserTerminalRouter, which I changed to a graceful failure.