### PR TITLE
Circle CI and Linux GitHub Action vcpkg CI fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       - checkout
       - run:
           name: Set up ssh & known_hosts
-          command: sudo /etc/init.d/ssh start; rm -f ~/.ssh/id_rsa*; ssh-keygen -q -N "" -f ~/.ssh/id_rsa; sudo rm ~/.ssh/authorized_keys; cp ~/.ssh/id_rsa.pub ~/.ssh/authorized_keys; rm -f ~/.ssh/known_hosts; ssh -o "StrictHostKeyChecking no" localhost ls
+          command: sudo /etc/init.d/ssh start; rm -f ~/.ssh/id_rsa*; ssh-keygen -q -N "" -f ~/.ssh/id_rsa; sudo rm -f ~/.ssh/authorized_keys; cp ~/.ssh/id_rsa.pub ~/.ssh/authorized_keys; rm -f ~/.ssh/known_hosts; ssh -o "StrictHostKeyChecking no" localhost ls
       - run:
           name: Init submodules
           command: if [ $CIRCLE_BRANCH != "release" ]; then git submodule update --init --recursive; fi
@@ -54,7 +54,7 @@ jobs:
       - checkout
       - run:
           name: Set up ssh & known_hosts
-          command: sudo /etc/init.d/ssh start; rm -f ~/.ssh/id_rsa*; ssh-keygen -q -N "" -f ~/.ssh/id_rsa; sudo rm ~/.ssh/authorized_keys; cp ~/.ssh/id_rsa.pub ~/.ssh/authorized_keys; rm -f ~/.ssh/known_hosts; ssh -o "StrictHostKeyChecking no" localhost ls
+          command: sudo /etc/init.d/ssh start; rm -f ~/.ssh/id_rsa*; ssh-keygen -q -N "" -f ~/.ssh/id_rsa; sudo rm -f ~/.ssh/authorized_keys; cp ~/.ssh/id_rsa.pub ~/.ssh/authorized_keys; rm -f ~/.ssh/known_hosts; ssh -o "StrictHostKeyChecking no" localhost ls
       - run:
           name: Init submodules
           command: if [ $CIRCLE_BRANCH != "release" ]; then git submodule update --init --recursive; fi

--- a/.github/workflows/vcpkg_build.yml
+++ b/.github/workflows/vcpkg_build.yml
@@ -24,7 +24,26 @@ jobs:
 
     steps:
       - name: Install Dependencies (Linux)
-        run: sudo apt-get update && sudo apt-get install curl zip unzip tar cmake ninja-build libutempter-dev libunwind-dev libcurl4-openssl-dev
+        run: |
+          sudo apt-get update && \
+            sudo apt-get install --no-install-recommends \
+                libboost-dev \
+                libsodium-dev \
+                libncurses5-dev \
+                libprotobuf-dev \
+                protobuf-compiler \
+                libgflags-dev \
+                libutempter-dev \
+                build-essential \
+                ninja-build \
+                libcurl4-openssl-dev \
+                curl \
+                zip \
+                unzip \
+                tar \
+                cmake \
+                libutempter-dev \
+                libunwind-dev
         if: matrix.os == 'ubuntu-latest'
       - name: Install Dependencies (Windows)
         run: choco install ninja


### PR DESCRIPTION
For vcpkg CI, add libraries such as libsodium, based on the list used in the Ubuntu devcontainer and README.md. This should fix vcpkg CI failures I see in my fork. I'm not sure why it doesn't fail in the main repo, however.

For circle CI, ignore error if the `~/.ssh/authorized_keys` file does not exist when trying to delete it, by switching to `rm -f`

This should fix the errors from #510 and #511.