### PR TITLE
Add additional checks to connection path and relocate router fifo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -399,6 +399,8 @@ add_library(
   src/terminal/UserTerminalRouter.cpp
   src/terminal/TerminalClient.hpp
   src/terminal/TerminalClient.cpp
+  src/terminal/ServerFifoPath.hpp
+  src/terminal/ServerFifoPath.cpp
   src/terminal/SshSetupHandler.hpp
   src/terminal/SshSetupHandler.cpp
   src/terminal/UserTerminalHandler.hpp

--- a/src/base/ServerClientConnection.cpp
+++ b/src/base/ServerClientConnection.cpp
@@ -33,4 +33,19 @@ bool ServerClientConnection::recoverClient(int newSocketFd) {
   }
   return recover(newSocketFd);
 }
+
+bool ServerClientConnection::verifyPasskey(const string& targetKey) {
+  // Do a string comparison without revealing timing information if an early
+  // character mismatches, always loop through the entire string.
+  const size_t commonSize =
+      key.size() < targetKey.size() ? key.size() : targetKey.size();
+
+  bool matchFailed = key.size() != targetKey.size();
+  for (size_t i = 0; i < commonSize; ++i) {
+    matchFailed |= key[i] != targetKey[i];
+  }
+
+  return !matchFailed;
+}
+
 }  // namespace et

--- a/src/base/ServerClientConnection.hpp
+++ b/src/base/ServerClientConnection.hpp
@@ -1,9 +1,8 @@
 #ifndef __ET_SERVER_CLIENT_CONNECTION__
 #define __ET_SERVER_CLIENT_CONNECTION__
 
-#include "Headers.hpp"
-
 #include "Connection.hpp"
+#include "Headers.hpp"
 
 namespace et {
 class ServerClientConnection : public Connection {
@@ -15,6 +14,8 @@ class ServerClientConnection : public Connection {
   virtual ~ServerClientConnection();
 
   bool recoverClient(int newSocketFd);
+
+  bool verifyPasskey(const string& targetKey);
 
  protected:
 };

--- a/src/base/ServerConnection.hpp
+++ b/src/base/ServerConnection.hpp
@@ -57,6 +57,8 @@ class ServerConnection {
       shared_ptr<ServerClientConnection> serverClientState) = 0;
 
  protected:
+  void destroyPartialConnection(const string& clientId);
+
   shared_ptr<SocketHandler> socketHandler;
   SocketEndpoint serverEndpoint;
   std::unordered_map<string, string> clientKeys;

--- a/src/terminal/ServerFifoPath.cpp
+++ b/src/terminal/ServerFifoPath.cpp
@@ -1,0 +1,223 @@
+#ifndef WIN32
+#include "ServerFifoPath.hpp"
+
+namespace et {
+
+/**
+ * @file
+ *
+ * Provides utilities for creating and finding the server fifo path, handling
+ * cases where etserver is running as either root or another user.
+ *
+ * When running as root, this applies the following principles to be defensive:
+ * - Only use "/var/run" as the fifo directory.
+ * - Do not query environment variables.
+ * - Do not create directories or change file permissions.
+ *
+ * For all users, this takes a fail-fast approach, where instead of correcting
+ * issues it will crash or error out.
+ */
+
+namespace {
+
+// As root, prefer "/var/run" since it is not world-writeable.
+const string ROUTER_FIFO_BASENAME = "etserver.idpasskey.fifo";
+const string ROOT_FIFO_DIRECTORY = "/var/run";
+const string ROOT_ROUTER_FIFO_NAME =
+    ROOT_FIFO_DIRECTORY + "/" + ROUTER_FIFO_BASENAME;
+
+struct ValueWithDefault {
+  string value;
+  bool isDefault;
+};
+
+bool IsRoot() { return ::geteuid() == 0; }
+
+bool IsAbsolutePath(const string& path) {
+  return (!path.empty() && path[0] == '/');
+}
+
+string GetHome() {
+  const char* home = getenv("HOME");
+  CHECK_NOTNULL(home)
+      << "Failed to get the value of the $HOME environment variable.";
+
+  string homeStr(home);
+  CHECK(IsAbsolutePath(homeStr))
+      << "Unexpected relative path for $HOME environment variable: " << homeStr;
+  return homeStr;
+}
+
+/**
+ * Get the value of XDG_RUNTIME_DIR, by following the specification defined
+ * here:
+ * https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+ */
+ValueWithDefault GetXdgRuntimeDir() {
+  // If the env doesn't exist, or is not an absolute path, fallback to
+  // $HOME/.local/share since it can be created on mac as well.
+  //
+  // Per the spec:
+  // > If an implementation encounters a relative path in any of these variables
+  // > it should consider the path invalid and ignore it
+  if (const char* dataHome = getenv("XDG_RUNTIME_DIR")) {
+    if (IsAbsolutePath(dataHome)) {
+      return ValueWithDefault{dataHome, /*isDefault*/ false};
+    }
+  }
+
+  return ValueWithDefault{GetHome() + string("/.local/share"),
+                          /*isDefault*/ true};
+}
+
+void TryCreateDirectory(string dir, mode_t mode) {
+  // Reset umask to 0 while creating subdirs, and restore after.
+  const mode_t oldMode = ::umask(0);
+
+  if (::mkdir(dir.c_str(), mode) == -1) {
+    // Permit EEXIST if the directory already exists.
+    CHECK_EQ(errno, EEXIST)
+        << "Unexpected result creating " << dir << ": " << strerror(errno);
+  }
+
+  CHECK_EQ(::umask(oldMode), 0)
+      << "Unexpected result when restoring umask, which should return the "
+         "previous overriden value (0).";
+}
+
+}  // namespace
+
+ServerFifoPath::ServerFifoPath() = default;
+
+void ServerFifoPath::setPathOverride(string path) {
+  CHECK(!path.empty()) << "Server fifo path must not be empty";
+  pathOverride = path;
+}
+
+void ServerFifoPath::createDirectoriesIfRequired() {
+  // No action required unless we're running as non-root.
+  if (pathOverride || IsRoot()) {
+    return;
+  }
+
+  const auto xdgRuntimeDir = GetXdgRuntimeDir();
+  if (xdgRuntimeDir.isDefault) {
+    // Only create directories if the default path is returned.
+    //
+    // Create subdirectories for ~/.local/share. These may already be created
+    // with different permissions on different machines, so also create an
+    // etserver subdir to enforce 0700 permssions.
+    const string homeDir = GetHome();
+    TryCreateDirectory(homeDir + "/.local", 0755);
+    TryCreateDirectory(homeDir + "/.local/share", 0755);
+  }
+
+  const string etserverDir = xdgRuntimeDir.value + "/etserver";
+
+  // First try creating the directory. TryCreateDirectory will ignore error if
+  // the directory already exists.
+  TryCreateDirectory(etserverDir, 0700);
+
+  struct stat etserverStat;
+  const int statResult = ::stat(etserverDir.c_str(), &etserverStat);
+  if (statResult != 0) {
+    LOG(FATAL) << "Failed to create server fifo directory: " << etserverDir
+               << "\n"
+               << "Error: " << strerror(errno);
+  }
+
+  // Directory exists, verify that it has the appropriate permissions.
+  if (etserverStat.st_uid != ::geteuid()) {
+    LOG(FATAL) << "Server fifo directory must be owned by the current "
+                  "user: "
+               << etserverDir << "\n"
+               << "Expected euid=" << ::geteuid()
+               << ", actual=" << etserverStat.st_uid;
+  }
+
+  if (!S_ISDIR(etserverStat.st_mode)) {
+    LOG(FATAL) << "Server fifo directory must be a directory: " << etserverDir;
+  }
+
+  // Fail if the folder has write permissions to group or other.
+  if ((etserverStat.st_mode & (S_IWGRP | S_IWOTH)) != 0) {
+    LOG(FATAL) << "Server fifo directory must not provide write access to "
+                  "group/other: "
+               << etserverDir;
+  }
+}
+
+string ServerFifoPath::getPathForCreation() {
+  if (pathOverride) {
+    return pathOverride.value();
+  } else if (IsRoot()) {
+    return ROOT_ROUTER_FIFO_NAME;
+  } else {
+    return GetXdgRuntimeDir().value + string("/etserver/") +
+           ROUTER_FIFO_BASENAME;
+  }
+}
+
+optional<SocketEndpoint> ServerFifoPath::getEndpointForConnect() {
+  if (pathOverride) {
+    SocketEndpoint endpoint;
+    endpoint.set_name(pathOverride.value());
+    return endpoint;
+  } else {
+    return std::nullopt;
+  }
+}
+
+void reportConnectionError() {
+  const int localErrno = GetErrno();
+
+  if (localErrno == ECONNREFUSED) {
+    CLOG(INFO, "stdout")
+        << "Error:  The Eternal Terminal daemon is not running.  Please "
+           "(re)start the et daemon on the server."
+        << endl;
+  } else {
+    CLOG(INFO, "stdout")
+        << "Error:  Connection error communicating with et daemon: "
+        << strerror(localErrno) << "." << endl;
+  }
+  exit(1);
+}
+
+int ServerFifoPath::detectAndConnect(
+    const optional<SocketEndpoint> specificRouterEndpoint,
+    const shared_ptr<SocketHandler>& socketHandler) {
+  int routerFd = -1;
+  if (specificRouterEndpoint) {
+    routerFd = socketHandler->connect(specificRouterEndpoint.value());
+    if (routerFd < 0) {
+      reportConnectionError();
+    }
+  } else {
+    SocketEndpoint rootRouterEndpoint;
+    rootRouterEndpoint.set_name(ROOT_ROUTER_FIFO_NAME);
+    routerFd = socketHandler->connect(rootRouterEndpoint);
+    if (routerFd >= 0) {
+      // Successfully connected.
+      return routerFd;
+    }
+
+    if (!IsRoot()) {
+      // Fallback to trying the non-root location.
+      SocketEndpoint nonRootRouterEndpoint;
+      nonRootRouterEndpoint.set_name(GetXdgRuntimeDir().value +
+                                     string("/etserver/") +
+                                     ROUTER_FIFO_BASENAME);
+      routerFd = socketHandler->connect(nonRootRouterEndpoint);
+    }
+
+    if (routerFd < 0) {
+      reportConnectionError();
+    }
+  }
+
+  return routerFd;
+}
+
+}  // namespace et
+#endif

--- a/src/terminal/ServerFifoPath.hpp
+++ b/src/terminal/ServerFifoPath.hpp
@@ -1,0 +1,89 @@
+#ifndef __ET_SERVER_FIFO_PATH__
+#define __ET_SERVER_FIFO_PATH__
+
+#include <optional>
+
+#include "Headers.hpp"
+#include "SocketHandler.hpp"
+
+namespace et {
+
+/**
+ * A helper class to handle creating and detecting the server fifo path.
+ *
+ * The default fifo path location varies based on which user the etserver
+ * process is running as, and it may also be overridden from a command line
+ * flag.
+ *
+ * This class aggregates that logic, both on the server and client side.
+ *
+ * To use:
+ * - Create the class, and optionally call \ref setPathOverride.
+ * - On the creation side, call \ref createDirectoriesIfRequired and \ref
+ *   getPathForCreation.
+ * - On the client side, call \ref getEndpointForConnect and \ref
+ *   detectAndConnect, which will either connect to the overridden path or try
+ *   both the root location, followed by the non-root location of the fifo to
+ *   connect. Since a broken fifo file can be left behind when the process
+ *   exits, this tries to connect to each pipe in sequence and performs a
+ *   graceful fallback.
+ *
+ * For root, the fifo is placed in the root-accessible directory /var/run.
+ *
+ * For non-root, this is placed in the user directory, under $HOME/.local/share,
+ * following the XDG spec.  This class contains logic to create the
+ * $HOME/.local/share directory structure if required.  This means that if the
+ * server runs as a non-root user, it may only be connected by the same user.
+ */
+class ServerFifoPath {
+ public:
+  ServerFifoPath();
+
+  /**
+   * Overrides the fifo path to a user-specified location. Note that this
+   * disables the auto-detection behavior.
+   *
+   * @param path User-specified path to the serverfifo.
+   */
+  void setPathOverride(string path);
+
+  /**
+   * Based on the current uid, create the directory structure required to store
+   * the fifo once it is created.  If XDG_DATA_HOME is not set and the processes
+   * user cannot access /var/run, this will ensure that $HOME/.local/share
+   * exists.
+   */
+  void createDirectoriesIfRequired();
+
+  /**
+   * Get the computed fifo path to use when creating the fifo. This will return
+   * the override path, or a location in either /var/run as root or
+   * $HOME/.local/share otherwise.
+   */
+  string getPathForCreation();
+
+  /**
+   * Return an SocketEndpoint or nullopt based on the current configuration,
+   * which may later be passed to \ref detectAndConnect to connect to the
+   * relevant endpoint.
+   */
+  optional<SocketEndpoint> getEndpointForConnect();
+
+  /**
+   * Either connect to the specific router endpoint, if provided, or detect and
+   * connect to the default root or non-root location of the endpoint.
+   *
+   * @return fd of the connected pipe, always valid. Exits internally if the
+   *   pipe cannot be connected.
+   */
+  static int detectAndConnect(
+      const optional<SocketEndpoint> specificRouterEndpoint,
+      const shared_ptr<SocketHandler>& socketHandler);
+
+ private:
+  optional<string> pathOverride;
+};
+
+}  // namespace et
+
+#endif  // __ET_SERVER_FIFO_PATH__

--- a/src/terminal/UserJumphostHandler.hpp
+++ b/src/terminal/UserJumphostHandler.hpp
@@ -10,7 +10,7 @@ class UserJumphostHandler {
                       const string &_idpasskey,
                       const SocketEndpoint &_dstSocketEndpoint,
                       shared_ptr<SocketHandler> routerSocketHandler,
-                      const SocketEndpoint &routerEndpoint);
+                      const optional<SocketEndpoint> routerEndpoint);
 
   void run();
   void shutdown() {

--- a/src/terminal/UserTerminalHandler.cpp
+++ b/src/terminal/UserTerminalHandler.cpp
@@ -4,19 +4,18 @@
 #include "ETerminal.pb.h"
 #include "RawSocketUtils.hpp"
 #include "ServerConnection.hpp"
+#include "ServerFifoPath.hpp"
 #include "UserTerminalRouter.hpp"
 
 namespace et {
 UserTerminalHandler::UserTerminalHandler(
     shared_ptr<SocketHandler> _socketHandler, shared_ptr<UserTerminal> _term,
-    bool _noratelimit, const SocketEndpoint &_routerEndpoint,
+    bool _noratelimit, const optional<SocketEndpoint> routerEndpoint,
     const string &idPasskey)
     : socketHandler(_socketHandler),
       term(_term),
       noratelimit(_noratelimit),
-      routerEndpoint(_routerEndpoint),
       shuttingDown(false) {
-  routerFd = socketHandler->connect(routerEndpoint);
   auto idpasskey_splited = split(idPasskey, '/');
   string id = idpasskey_splited[0];
   string passkey = idpasskey_splited[1];
@@ -26,19 +25,7 @@ UserTerminalHandler::UserTerminalHandler(
   tui.set_uid(getuid());
   tui.set_gid(getgid());
 
-  if (routerFd < 0) {
-    if (GetErrno() == ECONNREFUSED) {
-      CLOG(INFO, "stdout")
-          << "Error:  The Eternal Terminal daemon is not running.  Please "
-             "(re)start the et daemon on the server."
-          << endl;
-    } else {
-      CLOG(INFO, "stdout")
-          << "Error:  Connection error communicating with et daemon: "
-          << strerror(GetErrno()) << "." << endl;
-    }
-    exit(1);
-  }
+  routerFd = ServerFifoPath::detectAndConnect(routerEndpoint, socketHandler);
 
   try {
     socketHandler->writePacket(

--- a/src/terminal/UserTerminalHandler.cpp
+++ b/src/terminal/UserTerminalHandler.cpp
@@ -34,7 +34,7 @@ UserTerminalHandler::UserTerminalHandler(
           << endl;
     } else {
       CLOG(INFO, "stdout")
-          << "Error:  Connection error communicating with et deamon: "
+          << "Error:  Connection error communicating with et daemon: "
           << strerror(GetErrno()) << "." << endl;
     }
     exit(1);

--- a/src/terminal/UserTerminalHandler.hpp
+++ b/src/terminal/UserTerminalHandler.hpp
@@ -11,7 +11,7 @@ class UserTerminalHandler {
  public:
   UserTerminalHandler(shared_ptr<SocketHandler> _socketHandler,
                       shared_ptr<UserTerminal> _term, bool noratelimit,
-                      const SocketEndpoint &_routerEndpoint,
+                      const optional<SocketEndpoint> _routerEndpoint,
                       const string &idPasskey);
   void run();
   void shutdown() {
@@ -24,7 +24,6 @@ class UserTerminalHandler {
   shared_ptr<SocketHandler> socketHandler;
   shared_ptr<UserTerminal> term;
   bool noratelimit;
-  SocketEndpoint routerEndpoint;
   bool shuttingDown;
   recursive_mutex shutdownMutex;
 

--- a/src/terminal/UserTerminalRouter.cpp
+++ b/src/terminal/UserTerminalRouter.cpp
@@ -18,7 +18,7 @@ UserTerminalRouter::UserTerminalRouter(
 IdKeyPair UserTerminalRouter::acceptNewConnection() {
   lock_guard<recursive_mutex> guard(routerMutex);
   LOG(INFO) << "Listening to id/key FIFO";
-  int terminalFd = socketHandler->accept(serverFd);
+  const int terminalFd = socketHandler->accept(serverFd);
   if (terminalFd < 0) {
     if (GetErrno() != EAGAIN && GetErrno() != EWOULDBLOCK) {
       FATAL_FAIL(-1);  // STFATAL with the error
@@ -39,7 +39,15 @@ IdKeyPair UserTerminalRouter::acceptNewConnection() {
     }
     TerminalUserInfo tui = stringToProto<TerminalUserInfo>(packet.getPayload());
     tui.set_fd(terminalFd);
-    idInfoMap[tui.id()] = tui;
+
+    const bool inserted =
+        idInfoMap.insert(std::make_pair(tui.id(), tui)).second;
+    if (!inserted) {
+      LOG(ERROR) << "Rejecting duplicate terminal connection for " << tui.id();
+      socketHandler->close(terminalFd);
+      return IdKeyPair({"", ""});
+    }
+
     return IdKeyPair({tui.id(), tui.passkey()});
   } catch (const std::runtime_error &re) {
     LOG(ERROR) << "Router can't talk to terminal: " << re.what();
@@ -51,13 +59,24 @@ IdKeyPair UserTerminalRouter::acceptNewConnection() {
   return IdKeyPair({"", ""});
 }
 
-TerminalUserInfo UserTerminalRouter::getInfoForId(const string &id) {
+std::optional<TerminalUserInfo> UserTerminalRouter::tryGetInfoForConnection(
+    const shared_ptr<ServerClientConnection> &serverClientState) {
   lock_guard<recursive_mutex> guard(routerMutex);
-  auto it = idInfoMap.find(id);
+  auto it = idInfoMap.find(serverClientState->getId());
   if (it == idInfoMap.end()) {
     STFATAL << " Tried to read from an id that no longer exists";
   }
+
+  // While both the id and passkey are randomly generated, do an extra
+  // verification that the passkey matches to ensure that this is the intended
+  // serverClientState.
+  if (!serverClientState->verifyPasskey(it->second.passkey())) {
+    LOG(ERROR) << "Failed to verify passkey for client id: " << it->second.id();
+    return std::nullopt;
+  }
+
   return it->second;
 }
+
 }  // namespace et
 #endif

--- a/src/terminal/UserTerminalRouter.hpp
+++ b/src/terminal/UserTerminalRouter.hpp
@@ -1,6 +1,8 @@
 #ifndef __ET_USER_TERMINAL_ROUTER__
 #define __ET_USER_TERMINAL_ROUTER__
 
+#include <optional>
+
 #include "Headers.hpp"
 #include "PipeSocketHandler.hpp"
 #include "ServerConnection.hpp"
@@ -14,7 +16,10 @@ class UserTerminalRouter {
                      const SocketEndpoint& _routerEndpoint);
   inline int getServerFd() { return serverFd; }
   IdKeyPair acceptNewConnection();
-  TerminalUserInfo getInfoForId(const string& id);
+
+  std::optional<TerminalUserInfo> tryGetInfoForConnection(
+      const shared_ptr<ServerClientConnection>& serverClientState);
+
   inline shared_ptr<PipeSocketHandler> getSocketHandler() {
     return socketHandler;
   }

--- a/src/terminal/UserTerminalRouter.hpp
+++ b/src/terminal/UserTerminalRouter.hpp
@@ -8,7 +8,6 @@
 #include "ServerConnection.hpp"
 
 namespace et {
-const string ROUTER_FIFO_NAME = GetTempDirectory() + "etserver.idpasskey.fifo";
 
 class UserTerminalRouter {
  public:

--- a/test/ServerFifoPathTest.cpp
+++ b/test/ServerFifoPathTest.cpp
@@ -1,0 +1,230 @@
+#include <ftw.h>
+
+#include <filesystem>
+#include <optional>
+
+#include "ServerFifoPath.hpp"
+#include "TestHeaders.hpp"
+
+using namespace et;
+
+namespace {
+
+struct FileInfo {
+  bool exists = false;
+  mode_t mode = 0;
+
+  mode_t fileMode() const { return mode & 0777; }
+
+  // Codespaces and similar environments may enforce additional ACLs, so verify
+  // that the permissions are less than a certain maximum. See
+  // https://github.community/t/bug-umask-does-not-seem-to-be-respected/129638
+  void requireFileModeLessPrivilegedThan(mode_t highestMode) const {
+    INFO("fileMode()=" << fileMode() << ", highestMode=" << highestMode);
+    REQUIRE((fileMode() & highestMode) == fileMode());
+  }
+};
+
+int RemoveDirectory(const char* path) {
+  // Use posix file tree walk to traverse the directory and remove the contents.
+  return nftw(
+      path,
+      [](const char* fpath, const struct stat* sb, int typeflag,
+         struct FTW* ftwbuf) { return ::remove(fpath); },
+      64,  // Maximum open fds.
+      FTW_DEPTH | FTW_PHYS);
+}
+
+class TestEnvironment {
+ public:
+  string createTempDir() {
+    string tmpPath = GetTempDirectory() + string("et_test_XXXXXXXX");
+    const string dir = string(mkdtemp(&tmpPath[0]));
+
+    temporaryDirs.push_back(dir);
+    return dir;
+  }
+
+  FileInfo getFileInfo(const string& name) {
+    struct stat fileStat;
+    const int statResult = ::stat(name.c_str(), &fileStat);
+    if (statResult != 0) {
+      return FileInfo{};
+    }
+
+    FileInfo result;
+    result.exists = true;
+    result.mode = fileStat.st_mode;
+    return result;
+  }
+
+  void setEnv(const char* name, const string& value) {
+    if (!savedEnvs.count(name)) {
+      const char* previousValue = ::getenv(name);
+      if (previousValue) {
+        savedEnvs[name] = string(previousValue);
+      } else {
+        savedEnvs[name] = std::nullopt;
+      }
+    }
+
+    const int replace = 1;  // non-zero to replace.
+    ::setenv(name, value.c_str(), replace);
+  }
+
+  ~TestEnvironment() {
+    // Remove temporary dirs.
+    for (const string& dir : temporaryDirs) {
+      const int removeResult = RemoveDirectory(dir.c_str());
+      if (removeResult == -1) {
+        LOG(ERROR) << "Error when removing dir: " << dir;
+        FATAL_FAIL(removeResult);
+      }
+    }
+
+    // Restore env.
+    for (const auto& [key, value] : savedEnvs) {
+      if (value) {
+        const int replace = 1;  // non-zero to replace.
+        ::setenv(key.c_str(), value->c_str(), replace);
+      } else {
+        ::unsetenv(key.c_str());
+      }
+    }
+  }
+
+ private:
+  vector<string> temporaryDirs;
+  map<string, optional<string>> savedEnvs;
+};
+
+}  // namespace
+
+TEST_CASE("Creation", "[ServerFifoPath]") {
+  TestEnvironment env;
+
+  const string homeDir = env.createTempDir();
+  env.setEnv("HOME", homeDir.c_str());
+  INFO("homeDir = " << homeDir);
+
+  const string expectedFifoPath =
+      homeDir + "/.local/share/etserver/etserver.idpasskey.fifo";
+
+  ServerFifoPath serverFifo;
+  REQUIRE(serverFifo.getPathForCreation() == expectedFifoPath);
+  REQUIRE(serverFifo.getEndpointForConnect() ==
+          std::nullopt);  // Expected to be null unless the path is overridden.
+
+  SECTION("Create all directories") {
+    REQUIRE(!env.getFileInfo(homeDir + "/.local/share/etserver").exists);
+    serverFifo.createDirectoriesIfRequired();
+
+    // Verify the entire tree is created with the correct permissions.
+    env.getFileInfo(homeDir + "/.local")
+        .requireFileModeLessPrivilegedThan(0755);
+    env.getFileInfo(homeDir + "/.local/share")
+        .requireFileModeLessPrivilegedThan(0755);
+    env.getFileInfo(homeDir + "/.local/share/etserver")
+        .requireFileModeLessPrivilegedThan(0700);
+  }
+
+  const string localDir = homeDir + "/.local";
+  const mode_t localDirMode = 0777;  // Create with different permissions so
+                                     // we can check that this hasn't changed.
+  const string shareDir = homeDir + "/.local/share";
+  const mode_t shareDirMode = 0770;  // Another non-default mode.
+  const string etserverDir = homeDir + "/.local/share/etserver";
+
+  SECTION(".local already exists") {
+    const int oldMask = ::umask(0);
+    FATAL_FAIL(::mkdir(localDir.c_str(), localDirMode));
+    ::umask(oldMask);
+
+    serverFifo.createDirectoriesIfRequired();
+
+    env.getFileInfo(homeDir + "/.local")
+        .requireFileModeLessPrivilegedThan(localDirMode);
+    env.getFileInfo(homeDir + "/.local/share")
+        .requireFileModeLessPrivilegedThan(0755);
+    env.getFileInfo(homeDir + "/.local/share/etserver")
+        .requireFileModeLessPrivilegedThan(0700);
+  }
+
+  SECTION(".local/share already exists") {
+    const int oldMask = ::umask(0);
+    FATAL_FAIL(::mkdir(localDir.c_str(), localDirMode));
+    FATAL_FAIL(::mkdir(shareDir.c_str(), shareDirMode));
+    ::umask(oldMask);
+
+    serverFifo.createDirectoriesIfRequired();
+
+    env.getFileInfo(homeDir + "/.local")
+        .requireFileModeLessPrivilegedThan(localDirMode);
+    env.getFileInfo(homeDir + "/.local/share")
+        .requireFileModeLessPrivilegedThan(shareDirMode);
+    env.getFileInfo(homeDir + "/.local/share/etserver")
+        .requireFileModeLessPrivilegedThan(0700);
+  }
+
+  SECTION(".local/share/etserver already exists") {
+    const mode_t etserverDirMode = 0750;  // Use slightly different permissions,
+                                          // but still without write access.
+
+    const int oldMask = ::umask(0);
+    FATAL_FAIL(::mkdir(localDir.c_str(), localDirMode));
+    FATAL_FAIL(::mkdir(shareDir.c_str(), shareDirMode));
+    FATAL_FAIL(::mkdir(etserverDir.c_str(), etserverDirMode));
+    ::umask(oldMask);
+
+    serverFifo.createDirectoriesIfRequired();
+
+    env.getFileInfo(homeDir + "/.local")
+        .requireFileModeLessPrivilegedThan(localDirMode);
+    env.getFileInfo(homeDir + "/.local/share")
+        .requireFileModeLessPrivilegedThan(shareDirMode);
+    env.getFileInfo(homeDir + "/.local/share/etserver")
+        .requireFileModeLessPrivilegedThan(etserverDirMode);
+  }
+
+  SECTION("Override XDG_RUNTIME_DIR") {
+    const string xdgRuntimeDir = env.createTempDir();
+    env.setEnv("XDG_RUNTIME_DIR", xdgRuntimeDir);
+
+    const string xdgRuntimeDirFifoPath =
+        xdgRuntimeDir + "/etserver/etserver.idpasskey.fifo";
+    REQUIRE(serverFifo.getPathForCreation() == xdgRuntimeDirFifoPath);
+
+    // Test creation of the etserver subdirectory.
+    const string xdgRuntimeDirEtserver = xdgRuntimeDir + "/etserver";
+    REQUIRE(!env.getFileInfo(xdgRuntimeDirEtserver).exists);
+
+    serverFifo.createDirectoriesIfRequired();
+
+    env.getFileInfo(xdgRuntimeDirEtserver)
+        .requireFileModeLessPrivilegedThan(0700);
+  }
+}
+
+TEST_CASE("Override", "[ServerFifoPath]") {
+  TestEnvironment env;
+
+  const string homeDir = env.createTempDir();
+  env.setEnv("HOME", homeDir.c_str());
+
+  const string expectedFifoPath =
+      homeDir + "/.local/share/etserver/etserver.idpasskey.fifo";
+
+  ServerFifoPath serverFifo;
+  REQUIRE(serverFifo.getPathForCreation() == expectedFifoPath);
+  REQUIRE(serverFifo.getEndpointForConnect() == std::nullopt);
+
+  // Override and re-test.
+  const string pathOverride = env.createTempDir() + "/etserver.idpasskey.fifo";
+  serverFifo.setPathOverride(pathOverride);
+
+  REQUIRE(serverFifo.getPathForCreation() == pathOverride);
+
+  const optional<SocketEndpoint> endpoint = serverFifo.getEndpointForConnect();
+  REQUIRE(endpoint != std::nullopt);
+  REQUIRE(endpoint.value().name() == pathOverride);
+}


### PR DESCRIPTION
Add additional verification when connecting terminals to etserver:
* Reject more than one terminal connecting per launch.
* Ensure that the launched terminal's passkey matches on connect.
* Fix race condition if more than one terminal launches.

To protect the router fifo path, move it to either /var/run, $XDG_RUNTIME_DIR (with a fallback to $HOME/.local/share), depending on if the etserver process is running as root.

If the $HOME/.local/share directory does not exist, it will be created. Note that as a side effect of this change, if etserver is running as a non-root user it may only be connected by the same user, since it now places the fifo in the user-specific $XDG_RUNTIME_DIR or $HOME directory.

For connecting to the pipe, update etterminal to probe to detect the pipe to use, first trying the root location and then falling back to the user-specific location.

Note that this is *not* a breaking change. Since this detects appropriate location, and since both affected binaries are on the server side (etserver and etterminal), existing clients can connect to the server as long as they did not override --serverfifo back to its original location.

Unittests have been added for both the terminal connection path and server fifo fallback logic, but the server fifo path can also be manually verified by:
- Launching etserver as root, and verify connecting.
- Launching etserver as a non-root user, and verify connecting. Also verify that the pipe is located in either $XDG_RUNTIME_DIR/etserver, or $HOME/.local/share/etserver if $XDG_RUNTIME_DIR is not set.
- Rename $HOME/.local/share and verify it gets recreated. (It is convenient to do this on the devcontainer)
- Rename $HOME/.local and verify it gets recreated.
