### PR TITLE
Handle EINTR exit codes from `select`

### DIFF
--- a/src/base/Headers.hpp
+++ b/src/base/Headers.hpp
@@ -331,6 +331,12 @@ inline string protoToString(const T& t) {
   return s;
 }
 
+/**
+ * Wait on a fd to have data available.
+ *
+ * @return true if the fd has data, or false if the timeout (of 1 second) is
+ *   reached or if the call is interrupted by a syscall.
+ */
 inline bool waitOnSocketData(int fd) {
   fd_set fdset;
   FD_ZERO(&fdset);
@@ -339,8 +345,17 @@ inline bool waitOnSocketData(int fd) {
   tv.tv_sec = 1;
   tv.tv_usec = 0;
   VLOG(4) << "Before selecting sockFd";
-  FATAL_FAIL(select(fd + 1, &fdset, NULL, NULL, &tv));
-  return FD_ISSET(fd, &fdset);
+  const int selectResult = select(fd + 1, &fdset, NULL, NULL, &tv);
+  if (selectResult < 0) {
+    if (errno == EINTR) {
+      // Interrupted by the signal, the caller will retry.
+      return false;
+    } else {
+      FATAL_FAIL(selectResult);
+    }
+  } else {
+    return FD_ISSET(fd, &fdset);
+  }
 }
 
 inline string genRandomAlphaNum(int len) {

--- a/src/terminal/TerminalMain.cpp
+++ b/src/terminal/TerminalMain.cpp
@@ -93,11 +93,14 @@ int main(int argc, char** argv) {
 
       FD_SET(STDIN_FILENO, &readfds);
 
-      int res = select(1, &readfds, NULL, NULL, &timeout);
-      if (res < 0) {
-        FATAL_FAIL(res);
-      }
-      if (res == 0) {
+      int selectResult = 0;
+      do {
+        // Repeatedly calls when interrupted, up to the timeout.
+        selectResult = select(1, &readfds, NULL, NULL, &timeout);
+      } while (selectResult < 0 && errno == EINTR);
+
+      FATAL_FAIL(selectResult);
+      if (selectResult == 0) {
         CLOG(INFO, "stdout")
             << "Call etterminal with --idpasskey or --idpasskeyfile, or feed "
                "this information on stdin\n";

--- a/src/terminal/TerminalServer.cpp
+++ b/src/terminal/TerminalServer.cpp
@@ -59,7 +59,15 @@ void TerminalServer::run() {
 
     tv.tv_sec = 0;
     tv.tv_usec = 10000;
-    int numFdsSet = select(maxFd + 1, &rfds, NULL, NULL, &tv);
+
+    const int numFdsSet = select(maxFd + 1, &rfds, NULL, NULL, &tv);
+    if (numFdsSet < 0 && errno == EINTR) {
+      // If EINTR was returned, then the syscall was interrupted by a signal.
+      // This is not an error, but can be a signal that the program is being
+      // shutdown, so restart the loop to check for the halt condition.
+      continue;
+    }
+
     FATAL_FAIL(numFdsSet);
     if (numFdsSet == 0) {
       continue;


### PR DESCRIPTION
This fixes #503, where etserver crashed if select returned an EINTR error code. This is apparently normal behavior, and the caller is expected to retry when this occurs.

For codepaths that `FATAL_FAIL` on the select results, add special handling to retry instead of crashing. Note that the specific approach varies for each callsite.

Doing this impacts SIGINT, however, so to keep Ctrl-C working to exit the process fix, update the Sentry SIGINT handler so that it calls `et::InterruptSignalHandler`, enabling the process to exit semi-gracefully (however it still prints a callstack).

# Testing

To test, first call `etterminal` and do not provide any input:
```
$ ./etterminal
Call etterminal with --idpasskey or --idpasskeyfile, or feed this information on stdin
```

Then launch `etserver` and verify it exits with Ctrl-C (or equivalent)
```
$ ./etserver --logtostdout -v 9
[INFO 2022-04-30 19:46:54,927 etserver-main TerminalServerMain.cpp:185] In child, about to start server.
[INFO 2022-04-30 19:46:54,928 etserver-main TcpSocketHandler.cpp:224] Listening on 0.0.0.0:2022/2/1/6
[INFO 2022-04-30 19:46:54,928 etserver-main TcpSocketHandler.cpp:224] Listening on 0.0.0.0:2022/10/1/6
[INFO 2022-04-30 19:46:54,928 etserver-main TerminalServer.cpp:23] Creating server
^CShutting down sentry
[ERROR 2022-04-30 19:46:57,863 etserver-main Headers.hpp:411] Stack Trace:
[0] 0x1b788f el::base::Writer& el::base::Writer::operator<< <ust::StackTrace>(ust::StackTrace const&) (easylogging++.h:3215)
[1] 0x1d05a3 et::TelemetryService::TelemetryService(bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)::{lambda(int)#2}::_FUN(int) (TelemetryService.cpp:190)
[2] 0x7f019558a210
[3] 0x7f019565c12b __select
[4] 0x1be4bf et::TerminalServer::run() (TerminalServer.cpp:63)
[5] 0x175a9f main (TerminalServerMain.cpp:195)
[6] 0x7f019556b0b3 __libc_start_main
[7] 0x17840e _start
Got interrupt

Got interrupt (perhaps ctrl+c?).  Exiting.

Shutting down sentry
```