### PR TITLE
Always return a value from waitOnSocketData()

### DIFF
--- a/src/base/Headers.hpp
+++ b/src/base/Headers.hpp
@@ -353,9 +353,8 @@ inline bool waitOnSocketData(int fd) {
     } else {
       FATAL_FAIL(selectResult);
     }
-  } else {
-    return FD_ISSET(fd, &fdset);
   }
+  return FD_ISSET(fd, &fdset);
 }
 
 inline string genRandomAlphaNum(int len) {


### PR DESCRIPTION
My guess is that the else part is what we will want to return if no
other case catches.

In any case we need a return value to prevent:
`error: control reaches end of non-void function [-Werror=return-type]`