### PR TITLE
Fix test failures that started appearing in CI

### DIFF
--- a/src/base/ServerConnection.cpp
+++ b/src/base/ServerConnection.cpp
@@ -127,14 +127,16 @@ void ServerConnection::clientHandler(int clientSocketFd) {
     LOG(WARNING) << "Error handling new client: " << err.what();
     if (createdClientConnection) {
       destroyPartialConnection(clientId);
+    } else {
+      socketHandler->close(clientSocketFd);
     }
-    socketHandler->close(clientSocketFd);
   } catch (const std::exception& e) {
     LOG(ERROR) << "Got an unexpected error handling new client: " << e.what();
     if (createdClientConnection) {
       destroyPartialConnection(clientId);
+    } else {
+      socketHandler->close(clientSocketFd);
     }
-    socketHandler->close(clientSocketFd);
   }
 }
 

--- a/test/ServerFifoPathTest.cpp
+++ b/test/ServerFifoPathTest.cpp
@@ -25,6 +25,8 @@ struct FileInfo {
   }
 };
 
+bool IsRoot() { return ::geteuid() == 0; }
+
 int RemoveDirectory(const char* path) {
   // Use posix file tree walk to traverse the directory and remove the contents.
   return nftw(
@@ -101,6 +103,11 @@ class TestEnvironment {
 }  // namespace
 
 TEST_CASE("Creation", "[ServerFifoPath]") {
+  if (IsRoot()) {
+    WARN("Test running as root: Skipping test");
+    return;
+  }
+
   TestEnvironment env;
 
   const string homeDir = env.createTempDir();
@@ -206,6 +213,11 @@ TEST_CASE("Creation", "[ServerFifoPath]") {
 }
 
 TEST_CASE("Override", "[ServerFifoPath]") {
+  if (IsRoot()) {
+    WARN("Test running as root: Skipping test");
+    return;
+  }
+
   TestEnvironment env;
 
   const string homeDir = env.createTempDir();


### PR DESCRIPTION
Fix failures likely from CI environment and timing changes

Fix a double-socket-close in ServerConnection, which triggers an STFATAL in UnixSocketHandler, which was showing up on the flaky socket tests.  To fix, if `destroyPartialConnection` is called don't call `close`, since `destroyPartialConnection` already closes the socket.

Unset XDG_RUNTIME_DIR before running tests, since it changes the test behavior, and this appears to now be set by the CI system.

Disable ServerFifoPath tests when run as root, since the creation behavior it is testing is disabled as root, and it leads to a REQUIRE failure.
