### PR TITLE
docs: write gpg key to `trusted.gpg.d` for APT

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ For debian, use our deb repo. For buster:
 
 ```
 echo "deb https://github.com/MisterTea/debian-et/raw/master/debian-source/ buster main" | sudo tee -a /etc/apt/sources.list.d/et.list
-curl -sSL https://github.com/MisterTea/debian-et/raw/master/et.gpg | sudo apt-key add -
+curl -sSL https://github.com/MisterTea/debian-et/raw/master/et.gpg | sudo tee /etc/apt/trusted.gpg.d/et.gpg >/dev/null
 sudo apt update
 sudo apt install et
 ```


### PR DESCRIPTION
`apt-key` has been deprecated since Debian 11 and will be removed in 12. Writing the GPG key to `/etc/apt/trusted.gpg.d` gets rid of this problem and works entirely the same as `apt-key add`.