### PR TITLE
ipv6 abbreviated address support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,12 @@ jobs:
           name: Connect new -> old (ipv6 with port in host)
           command: build/et -c "ls" 0:0:0:0:0:0:0:1:2022 --logtostdout --verbose=9
       - run:
+          name: Connect new -> old (ipv6 abbreviated)
+          command: build/et -c "ls" ::1 --logtostdout --verbose=9
+      - run:
+          name: Connect new -> old (ipv6 abbreviated with port arg)
+          command: build/et -c "ls" ::1 --port 2022 --logtostdout --verbose=9
+      - run:
           name: Kill server
           command: sudo pkill etserver
       - run:


### PR DESCRIPTION
This will support ipv6 addresses that are abbreviated with `::` such as
`::1` (for `0:0:0:0:0:0:0:1`) with some caveats around specifying the port
in the host positional argument.

Help output:

```
$> ./et --help
Remote shell for the busy and impatient
Usage:
  et [OPTION...] [user@]host[:port]

  Note that 'host' can be a hostname or ipv4 address with or without a port
  or an ipv6 address. If the ipv6 address is abbreviated with :: then it must
  be specfied without a port (use -p,--port).

  -h, --help                 Print help
      --version              Print version
  -u, --username             Username
      --host arg             Remote host name
  ...
```
Tests:

```
$> ./et ::1 -p 8080 --macserver
$> ./et 0:0:0:0:0:0:0:1 -p 8080 --macserver
$> ./et 0:0:0:0:0:0:0:1:8080 --macserver
$> ./et ::1 -p 8080 --macserver # fails because defaults to port 2022
```
Fixes #537