### PR TITLE
Fix launchd plist config to remove daemonization.

### DIFF
--- a/init/launchd/homebrew.mxcl.et.plist
+++ b/init/launchd/homebrew.mxcl.et.plist
@@ -9,7 +9,6 @@
       <string>/usr/local/bin/etserver</string>
       <string>--cfgFile</string>
       <string>/usr/local/etc/et.conf</string>
-      <string>--daemon</string>
     </array>
     <key>RunAtLoad</key>
     <true/>


### PR DESCRIPTION
For launchd to properly manage the process you do *not* want to daemonize and bg the process otherwise launchd 'loses' the process.

After loading the plist, `sudo launchd list` now shows the et server service with the correct pid and unloading the server kills the process(es).