### PR TITLE
Explicitly set verbosity from cxxopts value.

### DIFF
--- a/src/terminal/TerminalClientMain.cpp
+++ b/src/terminal/TerminalClientMain.cpp
@@ -97,16 +97,19 @@ int main(int argc, char** argv) {
          cxxopts::value<std::vector<std::string>>());
 
     options.parse_positional({"host"});
-
     auto result = options.parse(argc, argv);
+
     if (result.count("help")) {
       CLOG(INFO, "stdout") << options.help({}) << endl;
       exit(0);
     }
+
     if (result.count("version")) {
       CLOG(INFO, "stdout") << "et version " << ET_VERSION << endl;
       exit(0);
     }
+
+    el::Loggers::setVerboseLevel(result["verbose"].as<int>());
 
     if (result.count("logtostdout")) {
       defaultConf.setGlobally(el::ConfigurationType::ToStandardOutput, "true");

--- a/src/terminal/TerminalMain.cpp
+++ b/src/terminal/TerminalMain.cpp
@@ -61,6 +61,8 @@ int main(int argc, char** argv) {
       exit(0);
     }
 
+    el::Loggers::setVerboseLevel(result["verbose"].as<int>());
+
     if (result.count("logtostdout")) {
       defaultConf.setGlobally(el::ConfigurationType::ToStandardOutput, "true");
     } else {

--- a/src/terminal/TerminalServerMain.cpp
+++ b/src/terminal/TerminalServerMain.cpp
@@ -62,6 +62,8 @@ int main(int argc, char **argv) {
       exit(0);
     }
 
+    el::Loggers::setVerboseLevel(result["verbose"].as<int>());
+
     if (result.count("daemon")) {
       if (DaemonCreator::create(true, result["pidfile"].as<string>()) == -1) {
         STFATAL << "Error creating daemon: " << strerror(GetErrno());


### PR DESCRIPTION
While investigating #541, I ran `et` with `--verbose=9` but realized that the logs created by `et` and `etterminal` were not verbose.  It turns out that the default argv parsing that easyloggingpp does via START_EASYLOGGINGPP(argc, argv) does not mesh well with the cxxopts style options so instead of relying on the default handling of argv/argc in ELPP, let's just explicitly set the verbose level from the cxxopts option argument.  Note that a value greater than 9 defaults to 9 in ELPP so no handling in et/etterminal/etserver is required.

Examples of the discrepancies:

* `et --verbose=5` (cxxopts 5, ELPP 0) 
  * ELPP doesn't check for long opt style arg values for `--verbose` (I have PR out for this)
* `et --verbose 5` (cxxopts 5, ELPP 9) 
  * ELPP doesn't detect the arg for --verbose so sets to max verbosity
* `et -v 5`        (cxxopts 5, ELPP 9)
  * ELPP doesn't detect the arg for -v so sets to max verbosity
* `et --v=5`       (cxxopts exception, ELPP 5)
  * ELPP would accept this, but cxxopts fails since we don't have a
'long' opt of `v`