### PR TITLE
Fix tunnel parsing exception handling.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -384,6 +384,8 @@ add_library(
   src/base/WinsockContext.hpp
   src/base/SubprocessToString.hpp
   src/base/SubprocessToString.cpp
+  src/base/TunnelUtils.hpp
+  src/base/TunnelUtils.cpp
 
   ${ET_HDRS}
   ${ET_SRCS}

--- a/codecov.yml
+++ b/codecov.yml
@@ -7,6 +7,7 @@ ignore:
   - "src/terminal/TelemetryService*"
   - "src/terminal/PsuedoTerminalConsole.hpp"
   - "src/terminal/PsuedoUserTerminal.hpp"
+  - "src/terminal/*Main.cpp"
   - "src/base/TcpSocketHandler*"
   - "src/base/SubprocessToString*"
 coverage:

--- a/src/base/TunnelUtils.cpp
+++ b/src/base/TunnelUtils.cpp
@@ -1,0 +1,66 @@
+#include "TunnelUtils.hpp"
+
+namespace et {
+vector<PortForwardSourceRequest> parseRangesToRequests(const string& input) {
+  vector<PortForwardSourceRequest> pfsrs;
+  auto j = split(input, ',');
+  for (auto& pair : j) {
+    vector<string> sourceDestination = split(pair, ':');
+    if (sourceDestination.size() < 2) {
+      throw TunnelParseException(
+          "Tunnel argument must have source and destination between a ':'");
+    }
+    try {
+      if (sourceDestination[0].find_first_not_of("0123456789-") !=
+              string::npos &&
+          sourceDestination[1].find_first_not_of("0123456789-") !=
+              string::npos) {
+        PortForwardSourceRequest pfsr;
+        pfsr.set_environmentvariable(sourceDestination[0]);
+        pfsr.mutable_destination()->set_name(sourceDestination[1]);
+        pfsrs.push_back(pfsr);
+      } else if (sourceDestination[0].find('-') != string::npos &&
+                 sourceDestination[1].find('-') != string::npos) {
+        vector<string> sourcePortRange = split(sourceDestination[0], '-');
+        int sourcePortStart = stoi(sourcePortRange[0]);
+        int sourcePortEnd = stoi(sourcePortRange[1]);
+
+        vector<string> destinationPortRange = split(sourceDestination[1], '-');
+        int destinationPortStart = stoi(destinationPortRange[0]);
+        int destinationPortEnd = stoi(destinationPortRange[1]);
+
+        if (sourcePortEnd - sourcePortStart !=
+            destinationPortEnd - destinationPortStart) {
+          throw TunnelParseException(
+              "source/destination port range must have same length");
+        } else {
+          int portRangeLength = sourcePortEnd - sourcePortStart + 1;
+          for (int i = 0; i < portRangeLength; ++i) {
+            PortForwardSourceRequest pfsr;
+            pfsr.mutable_source()->set_port(sourcePortStart + i);
+            pfsr.mutable_destination()->set_port(destinationPortStart + i);
+            pfsrs.push_back(pfsr);
+          }
+        }
+      } else if (sourceDestination[0].find('-') != string::npos ||
+                 sourceDestination[1].find('-') != string::npos) {
+        throw TunnelParseException(
+            "Invalid port range syntax: if source is a range, "
+            "destination must be a range (and vice versa)");
+      } else {
+        PortForwardSourceRequest pfsr;
+        pfsr.mutable_source()->set_port(stoi(sourceDestination[0]));
+        pfsr.mutable_destination()->set_port(stoi(sourceDestination[1]));
+        pfsrs.push_back(pfsr);
+      }
+    } catch (const TunnelParseException& e) {
+      throw e;
+    } catch (const std::logic_error& lr) {
+      throw TunnelParseException("Invalid tunnel argument '" + input +
+                                 "': " + lr.what());
+    }
+  }
+  return pfsrs;
+}
+
+}  // namespace et

--- a/src/base/TunnelUtils.hpp
+++ b/src/base/TunnelUtils.hpp
@@ -1,0 +1,20 @@
+#ifndef __ET_TUNNEL_UTILS__
+#define __ET_TUNNEL_UTILS__
+
+#include "ETerminal.pb.h"
+
+namespace et {
+
+vector<PortForwardSourceRequest> parseRangesToRequests(const string& input);
+
+class TunnelParseException : public std::exception {
+ public:
+  TunnelParseException(const string& msg) : message(msg) {}
+  const char* what() const noexcept override { return message.c_str(); }
+
+ private:
+  std::string message = " ";
+};
+
+}  // namespace et
+#endif  // __ET_TUNNEL_UTILS__

--- a/src/terminal/TerminalClient.cpp
+++ b/src/terminal/TerminalClient.cpp
@@ -1,62 +1,9 @@
 #include "TerminalClient.hpp"
 
 #include "TelemetryService.hpp"
+#include "TunnelUtils.hpp"
 
 namespace et {
-vector<PortForwardSourceRequest> parseRangesToRequests(const string& input) {
-  vector<PortForwardSourceRequest> pfsrs;
-  auto j = split(input, ',');
-  for (auto& pair : j) {
-    vector<string> sourceDestination = split(pair, ':');
-    try {
-      if (sourceDestination[0].find_first_not_of("0123456789-") !=
-              string::npos &&
-          sourceDestination[1].find_first_not_of("0123456789-") !=
-              string::npos) {
-        PortForwardSourceRequest pfsr;
-        pfsr.set_environmentvariable(sourceDestination[0]);
-        pfsr.mutable_destination()->set_name(sourceDestination[1]);
-        pfsrs.push_back(pfsr);
-      } else if (sourceDestination[0].find('-') != string::npos &&
-                 sourceDestination[1].find('-') != string::npos) {
-        vector<string> sourcePortRange = split(sourceDestination[0], '-');
-        int sourcePortStart = stoi(sourcePortRange[0]);
-        int sourcePortEnd = stoi(sourcePortRange[1]);
-
-        vector<string> destinationPortRange = split(sourceDestination[1], '-');
-        int destinationPortStart = stoi(destinationPortRange[0]);
-        int destinationPortEnd = stoi(destinationPortRange[1]);
-
-        if (sourcePortEnd - sourcePortStart !=
-            destinationPortEnd - destinationPortStart) {
-          STFATAL << "source/destination port range mismatch";
-          exit(1);
-        } else {
-          int portRangeLength = sourcePortEnd - sourcePortStart + 1;
-          for (int i = 0; i < portRangeLength; ++i) {
-            PortForwardSourceRequest pfsr;
-            pfsr.mutable_source()->set_port(sourcePortStart + i);
-            pfsr.mutable_destination()->set_port(destinationPortStart + i);
-            pfsrs.push_back(pfsr);
-          }
-        }
-      } else if (sourceDestination[0].find('-') != string::npos ||
-                 sourceDestination[1].find('-') != string::npos) {
-        STFATAL << "Invalid port range syntax: if source is range, "
-                   "destination must be range";
-      } else {
-        PortForwardSourceRequest pfsr;
-        pfsr.mutable_source()->set_port(stoi(sourceDestination[0]));
-        pfsr.mutable_destination()->set_port(stoi(sourceDestination[1]));
-        pfsrs.push_back(pfsr);
-      }
-    } catch (const std::logic_error& lr) {
-      STFATAL << "Logic error: " << lr.what();
-      exit(1);
-    }
-  }
-  return pfsrs;
-}
 
 TerminalClient::TerminalClient(
     shared_ptr<SocketHandler> _socketHandler,


### PR DESCRIPTION
Rather than using STFATAL and exiting, bubble up tunnel parsing exception to main and display the responsible option arg and print help menu so the user need not dig into /tmp/etclient-* to determine why et aborted.

Fixes #491

Testing:

```
 ❯ ./et -p abc localhost:8080 --macserver                                                                                                                                                                                     14:57:23  12.02.22
Exception: Argument ‘abc’ failed to parse


Remote shell for the busy and impatient
Usage:
  et [OPTION...] [user@]host[:port]

  Note that 'host' can be a hostname or ipv4 address with or without a port
  or an ipv6 address. If the ipv6 address is abbreviated with :: then it must
  be specified without a port (use -p,--port).

  -h, --help                 Print help
      --version              Print version
  -u, --username             Username
      --host arg             Remote host name
  -p, --port arg             Remote machine etserver port (default: 2022)
  -c, --command arg          Run command on connect
      --terminal-path arg    Path to etterminal on server side. Use if
                             etterminal is not on the system path.
  -t, --tunnel arg           Tunnel: Array of source:destination ports or
                             srcStart-srcEnd:dstStart-dstEnd (inclusive) port
                             ranges (e.g. 10080:80,10443:443,
                             10090-10092:8000-8002)
  -r, --reversetunnel arg    Reverse Tunnel: Array of source:destination
                             ports or srcStart-srcEnd:dstStart-dstEnd (inclusive)
                             port ranges
      --jumphost arg         jumphost between localhost and destination
      --jport arg            Jumphost machine port (default: 2022)
  -x, --kill-other-sessions  kill all old sessions belonging to the user
      --macserver            Set when connecting to an macOS server.  Sets
                             --terminal-path=/usr/local/bin/etterminal
  -v, --verbose arg          Enable verbose logging (default: 0)
  -k, --keepalive arg        Client keepalive duration in seconds
      --logtostdout          Write log to stdout
      --silent               Disable logging
  -N, --no-terminal          Do not create a terminal
  -f, --forward-ssh-agent    Forward ssh-agent socket
      --ssh-socket arg       The ssh-agent socket to forward
      --telemetry            Allow et to anonymously send errors to guide
                             future improvements (default: true)
      --serverfifo arg       If set, communicate to etserver on the matching
                             fifo name (default: )
      --ssh-option arg       Options to pass down to `ssh -o`


 ↵ 1  ⚙  jwshort@MAC-DESKTOP  ~/gitworkspaces/EternalTerminal/build   master ● ⍟2 
 ❯ ./et -t 6010 localhost:8080 --macserver                                                                                                                                                                                    14:57:34  12.02.22
Exception: Invalid tunnel argument: 6010


Remote shell for the busy and impatient
Usage:
  et [OPTION...] [user@]host[:port]

  Note that 'host' can be a hostname or ipv4 address with or without a port
  or an ipv6 address. If the ipv6 address is abbreviated with :: then it must
  be specified without a port (use -p,--port).

  -h, --help                 Print help
      --version              Print version
  -u, --username             Username
      --host arg             Remote host name
  -p, --port arg             Remote machine etserver port (default: 2022)
  -c, --command arg          Run command on connect
      --terminal-path arg    Path to etterminal on server side. Use if
                             etterminal is not on the system path.
  -t, --tunnel arg           Tunnel: Array of source:destination ports or
                             srcStart-srcEnd:dstStart-dstEnd (inclusive) port
                             ranges (e.g. 10080:80,10443:443,
                             10090-10092:8000-8002)
  -r, --reversetunnel arg    Reverse Tunnel: Array of source:destination
                             ports or srcStart-srcEnd:dstStart-dstEnd (inclusive)
                             port ranges
      --jumphost arg         jumphost between localhost and destination
      --jport arg            Jumphost machine port (default: 2022)
  -x, --kill-other-sessions  kill all old sessions belonging to the user
      --macserver            Set when connecting to an macOS server.  Sets
                             --terminal-path=/usr/local/bin/etterminal
  -v, --verbose arg          Enable verbose logging (default: 0)
  -k, --keepalive arg        Client keepalive duration in seconds
      --logtostdout          Write log to stdout
      --silent               Disable logging
  -N, --no-terminal          Do not create a terminal
  -f, --forward-ssh-agent    Forward ssh-agent socket
      --ssh-socket arg       The ssh-agent socket to forward
      --telemetry            Allow et to anonymously send errors to guide
                             future improvements (default: true)
      --serverfifo arg       If set, communicate to etserver on the matching
                             fifo name (default: )
      --ssh-option arg       Options to pass down to `ssh -o`


 ↵ 1  ⚙  jwshort@MAC-DESKTOP  ~/gitworkspaces/EternalTerminal/build   master ● ⍟2 
 ❯ ./et -t 6010:6000 localhost:8080 --macserver                                                                                                                                                                               14:57:55  12.02.22

####################################################################################
Welcome to your MacOS Desktop.
####################################################################################
```