### PR TITLE
Parse telemetry ini config as boolean and make telemetry opt-in.

### DIFF
--- a/etc/et.cfg
+++ b/etc/et.cfg
@@ -9,4 +9,4 @@ port = 2022
 verbose = 0
 silent = 0
 logsize = 20971520
-telemetry = 1
+telemetry = true

--- a/src/terminal/TerminalServerMain.cpp
+++ b/src/terminal/TerminalServerMain.cpp
@@ -85,7 +85,7 @@ int main(int argc, char **argv) {
 
     int port = 0;
     string bindIp = "";
-    bool telemetry = true;
+    bool telemetry = false;
     if (result.count("cfgfile")) {
       // Load the config file
       CSimpleIniA ini(true, false, false);
@@ -106,7 +106,7 @@ int main(int argc, char **argv) {
           }
         }
 
-        telemetry = bool(stoi(ini.GetValue("Debug", "Telemetry", "1")));
+        telemetry = ini.GetBoolValue("Debug", "telemetry", false);
         // read verbose level (prioritize command line option over cfgfile)
         const char *vlevel = ini.GetValue("Debug", "verbose", NULL);
         if (result.count("verbose")) {


### PR DESCRIPTION
In issue #504, it was brought to attention that while the command line arg for enabling telemetry was boolean, the ini config in et.cfg needed to be an int to change the value.  SimpleIni has a GetBoolValue function that treats the strings "0", "off", "no", "false" as boolean false and "1", "on", "true" as boolean true.

Also, this will make telemetry opt-in as opposed to opt-out as has been requested by multiple users.  The supplied et.cfg file will still have telemetry on.