### PR TITLE
Add packaging information

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ Circle: [![CircleCI](https://circleci.com/gh/MisterTea/EternalTerminal/tree/mast
 
 Linux: ![Linux CI](https://github.com/MisterTea/EternalTerminal/workflows/Linux%20CI/badge.svg?branch=master)
 
+## Packaging status
+
+[![Packaging
+status](https://repology.org/badge/vertical-allrepos/eternalterminal.svg)](https://repology.org/project/eternalterminal/versions)
+
 ## Installing
 
 ### macOS


### PR DESCRIPTION
To see which distributions package et.

We could also use a smaller badge like:
https://repology.org/badge/tiny-repos/eternalterminal.svg

What do you prefer?