### PR TITLE
Fix build on CentOS 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,13 +256,14 @@ Install dependencies:
 ```
 sudo yum install epel-release
 sudo yum install cmake3 boost-devel libsodium-devel ncurses-devel protobuf-devel \
-     protobuf-compiler gflags-devel protobuf-lite-devel libcurl-devel
+     protobuf-compiler gflags-devel protobuf-lite-devel libcurl-devel \
+     perl-IPC-Cmd perl-Data-Dumper libunwind-devel libutempter-deve
 ```
 
 Install scl dependencies
 ```
 sudo yum install centos-release-scl
-sudo yum install devtoolset-8
+sudo yum install devtoolset-11 devtoolset-11-libatomic-devel rh-git227
 ```
 
 Download and install from source ([see #238 for details](https://github.com/MisterTea/EternalTerminal/issues/238)):
@@ -271,8 +272,8 @@ git clone --recurse-submodules https://github.com/MisterTea/EternalTerminal.git
 cd EternalTerminal
 mkdir build
 cd build
-scl enable devtoolset-8 'cmake3 ../'
-scl enable devtoolset-8 'make && sudo make install'
+scl enable devtoolset-11 rh-git227 'cmake3 ../'
+scl enable devtoolset-11 'make && sudo make install'
 sudo cp ../systemctl/et.service /etc/systemd/system/
 sudo cp ../etc/et.cfg /etc/
 ```

--- a/docker/Dockerfile.client
+++ b/docker/Dockerfile.client
@@ -2,7 +2,10 @@ FROM centos:7 as base
 
 ENV BUILD_REPOS="epel-release centos-release-scl" \
     BUILD_DEPS="cmake3 boost-devel libsodium-devel ncurses-devel protobuf-devel \
-        protobuf-compiler gflags-devel protobuf-lite-devel git devtoolset-8"
+    protobuf-compiler gflags-devel protobuf-lite-devel git \
+    perl-IPC-Cmd perl-Data-Dumper libunwind-devel libutempter-devel \
+    devtoolset-11 devtoolset-11-libatomic-devel rh-git227"
+
 
 WORKDIR /
 
@@ -12,16 +15,16 @@ RUN yum install -y $BUILD_REPOS && \
     cd EternalTerminal && \
     mkdir build && \
     cd build && \
-    bash -c "scl enable devtoolset-8 'cmake3 ../'" && \
-    bash -c "scl enable devtoolset-8 'make -j $(grep ^processor /proc/cpuinfo |wc -l) && make install'"
+    bash -c "scl enable devtoolset-11 rh-git227 'cmake3 ../'" && \
+    bash -c "scl enable devtoolset-11 'make -j $(grep ^processor /proc/cpuinfo |wc -l) && make install'"
 
 FROM centos:7
 
 RUN yum install -y epel-release && \
-    yum install -y protobuf-lite libsodium
+    yum install -y protobuf-lite libsodium libatomic libunwind
 
-COPY --from=base /usr/local/bin/etserver /usr/local/bin/etterminal /usr/local/bin/htm /usr/local/bin/htmd  /usr/local/bin/
+COPY --from=base /usr/bin/etserver /usr/bin/etterminal /usr/bin/htm /usr/bin/htmd  /usr/bin/
 COPY --from=base /EternalTerminal/etc/et.cfg /etc/et.cfg
-COPY container-entrypoint /bin/container-entrypoint
+COPY --chmod=755 container-entrypoint /bin/container-entrypoint
 
 ENTRYPOINT ["/bin/container-entrypoint", "client"]

--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -2,7 +2,10 @@ FROM centos:7 as base
 
 ENV BUILD_REPOS="epel-release centos-release-scl" \
     BUILD_DEPS="cmake3 boost-devel libsodium-devel ncurses-devel protobuf-devel \
-    protobuf-compiler gflags-devel protobuf-lite-devel git devtoolset-8"
+    protobuf-compiler gflags-devel protobuf-lite-devel git \
+    perl-IPC-Cmd perl-Data-Dumper libunwind-devel libutempter-devel \
+    devtoolset-11 devtoolset-11-libatomic-devel rh-git227"
+
 
 WORKDIR /
 
@@ -12,17 +15,17 @@ RUN yum install -y $BUILD_REPOS && \
     cd EternalTerminal && \
     mkdir build && \
     cd build && \
-    bash -c "scl enable devtoolset-8 'cmake3 ../'" && \
-    bash -c "scl enable devtoolset-8 'make -j $(grep ^processor /proc/cpuinfo |wc -l) && make install'"
+    bash -c "scl enable devtoolset-11 rh-git227 'cmake3 ../'" && \
+    bash -c "scl enable devtoolset-11 'make -j $(grep ^processor /proc/cpuinfo |wc -l) && make install'"
 
 FROM centos:7
 
 RUN yum install -y epel-release && \
-    yum install -y protobuf-lite libsodium openssh-server
+    yum install -y protobuf-lite libsodium openssh-server libatomic libunwind
 
-COPY --from=base /usr/local/bin/etserver /usr/local/bin/etterminal /usr/local/bin/htm /usr/local/bin/htmd  /usr/local/bin/
+COPY --from=base /usr/bin/etserver /usr/bin/etterminal /usr/bin/htm /usr/bin/htmd  /usr/bin/
 COPY --from=base /EternalTerminal/etc/et.cfg /etc/et.cfg
-COPY container-entrypoint /bin/container-entrypoint
+COPY --chmod=755 container-entrypoint /bin/container-entrypoint
 
 EXPOSE 2022 2222
 


### PR DESCRIPTION
I got some compile errors when buiding ET on CentOS 7

```
- CMake Error: CMake was unable to find a build program corresponding to "Unix Makefiles".  CMAKE_MAKE_PROGRAM is not set.  You probably need to select a different build tool.
- A suitable version of git was not found (required v2.7.4) and unable to automatically download a portable one. Please install a newer version of git.
- Can't locate IPC/Cmd.pm
- Can't locate Data/Dumper.pm
- Could NOT find Unwind (missing: Unwind_INCLUDE_DIR Unwind_LIBRARY Unwind_PLATFORM_LIBRARY)
- Could NOT find UTempter (missing: UTEMPTER_INCLUDE_DIR UTEMPTER_LIBRARIES)
- cannot find -latomic
```


Seems docs are too old for building ET on CentOS 7.
So I fix it.


