### PR TITLE
Update compiling instructions for Apple Silicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ git clone --recurse-submodules https://github.com/MisterTea/EternalTerminal.git
 cd EternalTerminal
 mkdir build
 cd build
-# Make it work on Apple Silicon:
+# Add if it doesn't work on Apple Silicon but should work without it
 if [[ $(uname -a | grep arm) ]]; then export VCPKG_FORCE_SYSTEM_BINARIES=1; fi
 cmake ../
 make && sudo make install


### PR DESCRIPTION
Setting this variable actually breaking build on my Macbook with Apple Silicon.

I get this error:
```
Detecting compiler hash for triplet arm64-osx...
error: while detecting compiler information:
The log file content at "/Users/sayfutdinov/Project/github/EternalTerminal/external/vcpkg/buildtrees/detect_compiler/stdout-arm64-osx.log" is:
-- Configuring arm64-osx-rel
CMake Error at scripts/cmake/vcpkg_execute_required_process.cmake:112 (message):
    Command failed: /opt/homebrew/Cellar/cmake/3.27.7/bin/cmake /Users/sayfutdinov/Project/github/EternalTerminal/external/vcpkg/scripts/detect_compiler -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/Users/sayfutdinov/Project/github/EternalTerminal/external/vcpkg/packages/detect_compiler_arm64-osx -DCMAKE_SYSTEM_NAME=Darwin -DBUILD_SHARED_LIBS=OFF -DVCPKG_CHAINLOAD_TOOLCHAIN_FILE=/Users/sayfutdinov/Project/github/EternalTerminal/external/vcpkg/scripts/toolchains/osx.cmake -DVCPKG_TARGET_TRIPLET=arm64-osx -DVCPKG_SET_CHARSET_FLAG=ON -DVCPKG_PLATFORM_TOOLSET=external -DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON -DCMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY=ON -DCMAKE_FIND_PACKAGE_NO_SYSTEM_PACKAGE_REGISTRY=ON -DCMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP=TRUE -DCMAKE_VERBOSE_MAKEFILE=ON -DVCPKG_APPLOCAL_DEPS=OFF -DCMAKE_TOOLCHAIN_FILE=/Users/sayfutdinov/Project/github/EternalTerminal/external/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_ERROR_ON_ABSOLUTE_INSTALL_DESTINATION=ON -DVCPKG_CXX_FLAGS= -DVCPKG_CXX_FLAGS_RELEASE= -DVCPKG_CXX_FLAGS_DEBUG= -DVCPKG_C_FLAGS= -DVCPKG_C_FLAGS_RELEASE= -DVCPKG_C_FLAGS_DEBUG= -DVCPKG_CRT_LINKAGE=dynamic -DVCPKG_LINKER_FLAGS= -DVCPKG_LINKER_FLAGS_RELEASE= -DVCPKG_LINKER_FLAGS_DEBUG= -DVCPKG_TARGET_ARCHITECTURE=arm64 -DCMAKE_INSTALL_LIBDIR:STRING=lib -DCMAKE_INSTALL_BINDIR:STRING=bin -D_VCPKG_ROOT_DIR=/Users/sayfutdinov/Project/github/EternalTerminal/external/vcpkg -DZ_VCPKG_ROOT_DIR=/Users/sayfutdinov/Project/github/EternalTerminal/external/vcpkg -D_VCPKG_INSTALLED_DIR=/Users/sayfutdinov/Project/github/EternalTerminal/build/vcpkg_installed -DVCPKG_MANIFEST_INSTALL=OFF -DCMAKE_OSX_ARCHITECTURES=arm64
    Working Directory: /Users/sayfutdinov/Project/github/EternalTerminal/external/vcpkg/buildtrees/detect_compiler/arm64-osx-rel
    Error code: 1
    See logs for more information:
      /Users/sayfutdinov/Project/github/EternalTerminal/external/vcpkg/buildtrees/detect_compiler/config-arm64-osx-rel-CMakeCache.txt.log
      /Users/sayfutdinov/Project/github/EternalTerminal/external/vcpkg/buildtrees/detect_compiler/config-arm64-osx-rel-out.log
      /Users/sayfutdinov/Project/github/EternalTerminal/external/vcpkg/buildtrees/detect_compiler/config-arm64-osx-rel-err.log

Call Stack (most recent call first):
  scripts/cmake/vcpkg_configure_cmake.cmake:340 (vcpkg_execute_required_process)
  scripts/detect_compiler/portfile.cmake:18 (vcpkg_configure_cmake)
  scripts/ports.cmake:147 (include)



error: vcpkg was unable to detect the active compiler's information. See above for the CMake failure output.

```

Without this variable it builds fine.