### PR TITLE
fix libcurl for ubuntu in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Debian/Ubuntu Dependencies:
 
 ```
 sudo apt install libboost-dev libsodium-dev libncurses5-dev \
-	libprotobuf-dev protobuf-compiler libgflags-dev libutempter-dev libcurl-dev \
+	libprotobuf-dev protobuf-compiler libgflags-dev libutempter-dev libcurl4-openssl-dev \
     build-essential ninja-build cmake git zip
 ```
 


### PR DESCRIPTION
libcurl-dev was moved to libcurl4-openssl-dev