### PR TITLE
Don't strip username from `jumphost`, add it if it's missing

### DIFF
--- a/src/terminal/SshSetupHandler.cpp
+++ b/src/terminal/SshSetupHandler.cpp
@@ -60,7 +60,7 @@ string SshSetupHandler::SetupSsh(const string& user, const string& host,
   if (!jumphost.empty()) {
     ssh_args = {
         "-J",
-        SSH_USER_PREFIX + jumphost,
+        jumphost,
     };
   }
 

--- a/src/terminal/TerminalClientMain.cpp
+++ b/src/terminal/TerminalClientMain.cpp
@@ -259,11 +259,7 @@ int main(int argc, char** argv) {
       string proxyjump = string(sshConfigOptions.ProxyJump);
       size_t colonIndex = proxyjump.find(":");
       if (colonIndex != string::npos) {
-        string userhostpair = proxyjump.substr(0, colonIndex);
-        size_t atIndex = userhostpair.find("@");
-        if (atIndex != string::npos) {
-          jumphost = userhostpair.substr(atIndex + 1);
-        }
+        jumphost = proxyjump.substr(0, colonIndex);
       } else {
         jumphost = proxyjump;
       }
@@ -275,7 +271,13 @@ int main(int argc, char** argv) {
     if (!jumphost.empty()) {
       is_jumphost = true;
       LOG(INFO) << "Setting port to jumphost port";
-      socketEndpoint.set_name(jumphost);
+      size_t atIndex = jumphost.find("@");
+      if (atIndex != string::npos) {
+        socketEndpoint.set_name(jumphost.substr(atIndex + 1));
+      } else {
+        socketEndpoint.set_name(jumphost);
+        jumphost = username + "@" + jumphost;
+      }
       socketEndpoint.set_port(result["jport"].as<int>());
     } else {
       socketEndpoint.set_name(destinationHost);


### PR DESCRIPTION
Don't strip username from `jumphost`, add it if it's missing.

Fix a bug when connecting with two different usernames for server and jumphost.
Fix command line parsing bug when including username in jumphost.
Fix a bug when `ProxyJump` is set in `~/.ssh/config` with a username but without port.

Fix #532