### PR TITLE
Fix devcontainer and update vcpkg for tests

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
 		"dockerfile": "Dockerfile",
 		// Update 'VARIANT' to pick an Debian / Ubuntu OS version: debian-11, debian-10, debian-9, ubuntu-21.04, ubuntu-20.04, ubuntu-18.04
 		// Use Debian 11, Debian 9, Ubuntu 18.04 or Ubuntu 21.04 on local arm64/Apple Silicon
-		"args": { "VARIANT": "ubuntu-21.04" }
+		"args": { "VARIANT": "debian-11" }
 	},
 	"runArgs": ["--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"],
 


### PR DESCRIPTION
Devcontainer: The original `ubuntu-21.04` image was failing to build, so I switched it to `debian-11` which works out of the box.

Tests: They were failing because `libwinpthread < 10.0` is not available on the `https://repo.msys2.org` anymore. See for example the 404 not found errors [here](https://github.com/MisterTea/EternalTerminal/actions/runs/7741605598/job/21108940236#step:12:165).

So what I did for testing is I updated `vcpkg` one month at the time until the tests started passing and ended up on vcpkg commit [4a3c366](https://github.com/microsoft/vcpkg/commit/4a3c366f2d0d0eaf034bfa649124768df7cfe813).