### PR TITLE
update actions and docker images

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -11,9 +11,9 @@ jobs:
           - 'test'
           - 'proto'
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Run clang-format style check for C/C++/Protobuf source code.
-      uses: jidicula/clang-format-action@v4.9.0
+      uses: jidicula/clang-format-action@v4.11.0
       with:
         clang-format-version: '13'
         check-path: ${{ matrix.path }}

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -17,6 +17,6 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Codespell
         uses: codespell-project/actions-codespell@v2

--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -8,10 +8,10 @@ on:
 
 jobs:
   ubsan_linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup
         shell: bash
         run: |
@@ -25,7 +25,7 @@ jobs:
 
       # Restore both vcpkg and its artifacts from the GitHub cache service.
       - name: Restore vcpkg and its artifacts.
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           # The first path is where vcpkg generates artifacts while consuming the vcpkg.json manifest file.
           # The second path is the location of vcpkg (it contains the vcpkg executable and data files).
@@ -53,10 +53,10 @@ jobs:
           rm -Rf build
 
   asan_linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup
         shell: bash
         run: |
@@ -70,7 +70,7 @@ jobs:
 
       # Restore both vcpkg and its artifacts from the GitHub cache service.
       - name: Restore vcpkg and its artifacts.
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           # The first path is where vcpkg generates artifacts while consuming the vcpkg.json manifest file.
           # The second path is the location of vcpkg (it contains the vcpkg executable and data files).
@@ -98,10 +98,10 @@ jobs:
           rm -Rf build
 
   msan_linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup
         shell: bash
         run: |
@@ -115,7 +115,7 @@ jobs:
 
       # Restore both vcpkg and its artifacts from the GitHub cache service.
       - name: Restore vcpkg and its artifacts.
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           # The first path is where vcpkg generates artifacts while consuming the vcpkg.json manifest file.
           # The second path is the location of vcpkg (it contains the vcpkg executable and data files).
@@ -143,10 +143,10 @@ jobs:
           rm -Rf build
 
   tsan_linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup
         shell: bash
         run: |
@@ -160,7 +160,7 @@ jobs:
 
       # Restore both vcpkg and its artifacts from the GitHub cache service.
       - name: Restore vcpkg and its artifacts.
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           # The first path is where vcpkg generates artifacts while consuming the vcpkg.json manifest file.
           # The second path is the location of vcpkg (it contains the vcpkg executable and data files).
@@ -188,10 +188,10 @@ jobs:
           rm -Rf build
 
   codecov:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup
         shell: bash
         run: |
@@ -205,7 +205,7 @@ jobs:
 
       # Restore both vcpkg and its artifacts from the GitHub cache service.
       - name: Restore vcpkg and its artifacts.
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           # The first path is where vcpkg generates artifacts while consuming the vcpkg.json manifest file.
           # The second path is the location of vcpkg (it contains the vcpkg executable and data files).

--- a/.github/workflows/mac_ci.yml
+++ b/.github/workflows/mac_ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup
         shell: bash
         run: |
@@ -24,7 +24,7 @@ jobs:
 
       # Restore both vcpkg and its artifacts from the GitHub cache service.
       - name: Restore vcpkg and its artifacts.
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           # The first path is where vcpkg generates artifacts while consuming the vcpkg.json manifest file.
           # The second path is the location of vcpkg (it contains the vcpkg executable and data files).
@@ -56,7 +56,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup
         shell: bash
         run: |
@@ -69,7 +69,7 @@ jobs:
 
       # Restore both vcpkg and its artifacts from the GitHub cache service.
       - name: Restore vcpkg and its artifacts.
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           # The first path is where vcpkg generates artifacts while consuming the vcpkg.json manifest file.
           # The second path is the location of vcpkg (it contains the vcpkg executable and data files).
@@ -100,7 +100,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup
         shell: bash
         run: |
@@ -113,7 +113,7 @@ jobs:
 
       # Restore both vcpkg and its artifacts from the GitHub cache service.
       - name: Restore vcpkg and its artifacts.
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           # The first path is where vcpkg generates artifacts while consuming the vcpkg.json manifest file.
           # The second path is the location of vcpkg (it contains the vcpkg executable and data files).
@@ -144,7 +144,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup
         shell: bash
         run: |
@@ -157,7 +157,7 @@ jobs:
 
       # Restore both vcpkg and its artifacts from the GitHub cache service.
       - name: Restore vcpkg and its artifacts.
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           # The first path is where vcpkg generates artifacts while consuming the vcpkg.json manifest file.
           # The second path is the location of vcpkg (it contains the vcpkg executable and data files).

--- a/.github/workflows/novcpkg_build_master.yml
+++ b/.github/workflows/novcpkg_build_master.yml
@@ -58,7 +58,7 @@ jobs:
         run: brew update && brew install ninja cmake pkg-config curl openssl protobuf libsodium
         if: matrix.os == 'macos-latest'
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -90,7 +90,7 @@ jobs:
         run: |
           cmake --build "${{ env.CMAKE_BUILD_DIR }}"
       
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
-          name: et-client-${{matrix.os}}
+          name: et-client-${{matrix.os}}-gcc${{matrix.gcc}}
           path: ${{ env.CMAKE_BUILD_DIR }}/et${{matrix.extension}}

--- a/.github/workflows/novcpkg_build_release.yml
+++ b/.github/workflows/novcpkg_build_release.yml
@@ -60,7 +60,7 @@ jobs:
         run: brew update && brew install ninja cmake pkg-config curl openssl protobuf libsodium
         if: matrix.os == 'macos-latest'
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: false
 
@@ -92,7 +92,7 @@ jobs:
         run: |
           cmake --build "${{ env.CMAKE_BUILD_DIR }}"
       
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
-          name: et-client-${{matrix.os}}
+          name: et-client-${{matrix.os}}-gcc${{matrix.gcc}}
           path: ${{ env.CMAKE_BUILD_DIR }}/et${{matrix.extension}}

--- a/.github/workflows/vcpkg_build_master.yml
+++ b/.github/workflows/vcpkg_build_master.yml
@@ -66,7 +66,7 @@ jobs:
         run: brew update && brew install ninja cmake
         if: matrix.os == 'macos-latest'
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -79,7 +79,7 @@ jobs:
   
       # Restore both vcpkg and its artifacts from the GitHub cache service.
       - name: Restore vcpkg and its artifacts.
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ${{ env.VCPKG_ROOT }}
@@ -122,7 +122,7 @@ jobs:
         run: |
           cmake --build "${{ env.CMAKE_BUILD_DIR }}"
       
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
-          name: et-client-${{matrix.os}}
+          name: et-client-${{matrix.os}}-gcc${{matrix.gcc}}
           path: ${{ env.CMAKE_BUILD_DIR }}/et${{matrix.extension}}

--- a/.github/workflows/vcpkg_build_release.yml
+++ b/.github/workflows/vcpkg_build_release.yml
@@ -68,7 +68,7 @@ jobs:
         run: brew update && brew install ninja cmake
         if: matrix.os == 'macos-latest'
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: false
 
@@ -81,7 +81,7 @@ jobs:
 
       # Restore both vcpkg and its artifacts from the GitHub cache service.
       - name: Restore vcpkg and its artifacts.
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ${{ env.VCPKG_ROOT }}
@@ -124,7 +124,7 @@ jobs:
         run: |
           cmake --build "${{ env.CMAKE_BUILD_DIR }}"
       
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
-          name: et-client-${{matrix.os}}
+          name: et-client-${{matrix.os}}-gcc${{matrix.gcc}}
           path: ${{ env.CMAKE_BUILD_DIR }}/et${{matrix.extension}}

--- a/docker/Dockerfile.client
+++ b/docker/Dockerfile.client
@@ -1,4 +1,4 @@
-FROM centos:7 as base
+FROM centos:8 as base
 
 ENV BUILD_REPOS="epel-release centos-release-scl" \
     BUILD_DEPS="cmake3 boost-devel libsodium-devel ncurses-devel protobuf-devel \
@@ -18,7 +18,7 @@ RUN yum install -y $BUILD_REPOS && \
     bash -c "scl enable devtoolset-11 rh-git227 'cmake3 ../'" && \
     bash -c "scl enable devtoolset-11 'make -j $(grep ^processor /proc/cpuinfo |wc -l) && make install'"
 
-FROM centos:7
+FROM centos:8
 
 RUN yum install -y epel-release && \
     yum install -y protobuf-lite libsodium libatomic libunwind

--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -1,4 +1,4 @@
-FROM centos:7 as base
+FROM centos:8 as base
 
 ENV BUILD_REPOS="epel-release centos-release-scl" \
     BUILD_DEPS="cmake3 boost-devel libsodium-devel ncurses-devel protobuf-devel \
@@ -18,7 +18,7 @@ RUN yum install -y $BUILD_REPOS && \
     bash -c "scl enable devtoolset-11 rh-git227 'cmake3 ../'" && \
     bash -c "scl enable devtoolset-11 'make -j $(grep ^processor /proc/cpuinfo |wc -l) && make install'"
 
-FROM centos:7
+FROM centos:8
 
 RUN yum install -y epel-release && \
     yum install -y protobuf-lite libsodium openssh-server libatomic libunwind


### PR DESCRIPTION
The only non-trivial change is updating `actions/upload-artifact` from `v2` to `v4`, [source](https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes). They don't allow for artifacts with the same name being uploaded and overwriting each other. This happened in the linux-ci workflow where different gcc versions were used but the artifact they produced had the same name, making the `v4` action fail. I fixed it by creating a unique name for each gcc version.

        -  name: et-client-${{matrix.os}}
        +  name: et-client-${{matrix.os}}-gcc${{matrix.gcc}}