### PR TITLE
fix: etterminal_path is the incorrect option name

### DIFF
--- a/src/terminal/TerminalClientMain.cpp
+++ b/src/terminal/TerminalClientMain.cpp
@@ -306,7 +306,7 @@ int main(int argc, char** argv) {
     if (result.count("macserver") > 0) {
       etterminal_path = "/usr/local/bin/etterminal";
     }
-    if (result.count("etterminal_path")) {
+    if (result.count("terminal-path")) {
       etterminal_path = result["terminal-path"].as<string>();
     }
     string idpasskeypair = SshSetupHandler::SetupSsh(


### PR DESCRIPTION
Caused by https://github.com/MisterTea/EternalTerminal/commit/c1d54e71304fe435eb7bf14bcfa62cf783100314

Should fix https://github.com/MisterTea/EternalTerminal/issues/357#issuecomment-1452357927