### PR TITLE
Telemetry service directory override.

### DIFF
--- a/docs/creating_release.md
+++ b/docs/creating_release.md
@@ -2,14 +2,14 @@
 
 1. Increment the project(...) version in CMakeLists.txt and push to master.
 2. Switch to the release branch
-3. Pull in the lastest changes: `git merge master`
+3. Pull in the latest changes: `git merge master`
 4. Run `git submodule update --recursive --init` to ensure that the submodules are updated to the latest master/release commit.
 5. Run `import_submodules.sh` to create an in-repo copy of the submodules
 6. `git add external_imported` and commit/push any changes
 7. Create a github release using the latest commit and tag it with `et-vA.B.C` where A/B/C is the major/minor/patch version.
 8. Switch to the deployment branch
 9. Edit the `deployment/debian_SOURCE/changelog` file and add a entry for the new release.
-10. Copy id_rsa / id_rsa.pub / .gnupg to the deploymen directory.  The rsa key needs to have write access to the debian-et github repo and the gnupg key needs to have write access to launchpad
+10. Copy id_rsa / id_rsa.pub / .gnupg to the deployment directory.  The rsa key needs to have write access to the debian-et github repo and the gnupg key needs to have write access to launchpad
 11. Build and run a docker image interactively from ubuntu.Dockerfile
 12. inside the docker image, run deploy_ubuntu_ppa.sh
 13. Exit the docker image and create a vagrant VM for debian

--- a/src/terminal/TerminalServerMain.cpp
+++ b/src/terminal/TerminalServerMain.cpp
@@ -79,7 +79,7 @@ int main(int argc, char **argv) {
 
     int port = 0;
     string bindIp = "";
-    bool telemetry = false;
+    bool enableTelemetry = false;
     string logDirectory = GetTempDirectory();
     if (result.count("cfgfile")) {
       // Load the config file
@@ -101,7 +101,7 @@ int main(int argc, char **argv) {
           }
         }
 
-        telemetry = ini.GetBoolValue("Debug", "telemetry", false);
+        enableTelemetry = ini.GetBoolValue("Debug", "telemetry", false);
         // read verbose level (prioritize command line option over cfgfile)
         const char *vlevel = ini.GetValue("Debug", "verbose", NULL);
         if (result.count("verbose")) {
@@ -155,7 +155,7 @@ int main(int argc, char **argv) {
     }
 
     if (result.count("telemetry")) {
-      telemetry = result["telemetry"].as<bool>();
+      enableTelemetry = result["telemetry"].as<bool>();
     }
 
     if (result.count("logdir")) {
@@ -181,7 +181,7 @@ int main(int argc, char **argv) {
     el::Helpers::installPreRollOutCallback(LogHandler::rolloutHandler);
 
     TelemetryService::create(
-        telemetry, GetTempDirectory() + "/.sentry-native-etserver", "Server");
+        enableTelemetry, logDirectory + "/.sentry-native-etserver", "Server");
 
     serverFifo.createDirectoriesIfRequired();
 


### PR DESCRIPTION
In addition to opt-in for telemetry (see #553) this uses the log directory override from #556 to place the sentry/telemetry logs.