### PR TITLE
Change grep command in README for arm64 to also work with Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ cd EternalTerminal
 mkdir build
 cd build
 # Add if it doesn't work on Apple Silicon but should work without it
-if [[ $(uname -a | grep arm) ]]; then export VCPKG_FORCE_SYSTEM_BINARIES=1; fi
+if [[ $(uname -a | grep 'arm\|aarch64') ]]; then export VCPKG_FORCE_SYSTEM_BINARIES=1; fi
 cmake ../
 make && sudo make install
 ```
@@ -240,7 +240,7 @@ cd EternalTerminal
 mkdir build
 cd build
 # For ARM (including OS/X with apple silicon):
-if [[ $(uname -a | grep arm) ]]; then export VCPKG_FORCE_SYSTEM_BINARIES=1; fi
+if [[ $(uname -a | grep 'arm\|aarch64') ]]; then export VCPKG_FORCE_SYSTEM_BINARIES=1; fi
 cmake ../
 make package
 sudo dpkg --install *.deb


### PR DESCRIPTION
Linux does not use arm64 for uname, so grep does not work, leading in a resulting confusing error.

MacOS (Ventura):

```
Darwin foo 22.6.0 Darwin Kernel Version 22.6.0: Mon Feb 19 19:43:13 PST
2024; root:xnu-8796.141.3.704.6~1/RELEASE_ARM64_T6020 arm64 arm Darwin
```

Linux aarch64 (OrangePi, Ubuntu 22.04):
```
Linux foo 5.10.160-rockchip #37 SMP Fri Apr 26 05:16:30 UTC 2024 aarch64
aarch64 aarch64 GNU/Linux
```

Linux aarch64 (AWS, Ubuntu 24.04):
```
Linux foo 6.8.0-1008-aws #8-Ubuntu SMP Sat Apr 20 02:43:14 UTC 2024
aarch64 aarch64 aarch64 GNU/Linux
```

Tested with both system grep and grep 3.11 installed via Homebrew for MacOS:

```
grep (BSD grep, GNU compatible) 2.6.0-FreeBSD
```

Homebrew:
```
grep (GNU grep) 3.11
Packaged by Homebrew
Copyright (C) 2023 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later
<https://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by Mike Haertel and others; see
<https://git.savannah.gnu.org/cgit/grep.git/tree/AUTHORS>.

grep -P uses PCRE2 10.43 2024-02-16
```

Consistency, yay.