### PR TITLE
[website] Fix the broken GitHub ribbon image

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,5 +1,5 @@
 <nav class="navbar navbar-default navbar-fixed-top navbar-custom">
-  <a href="https://github.com/MisterTea/EternalTerminal"><img style="position: absolute; top: 0; left: 0; border: 0;" src="https://camo.githubusercontent.com/567c3a48d796e2fc06ea80409cc9dd82bf714434/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f6c6566745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_left_darkblue_121621.png"></a>
+  <a href="https://github.com/MisterTea/EternalTerminal"><img style="position: absolute; top: 0; left: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_left_darkblue_121621.png?resize=149%2C149" alt="Fork me on GitHub" decoding="async" loading="lazy" data-recalc-dims="1"></a>
 
   <div class="container-fluid">
     <div class="navbar-header">


### PR DESCRIPTION
The image link is broken. I changed it to the same one (which seems to be the most official one), and it is the same size. See https://web.archive.org/web/20210107045132/https://eternalterminal.dev/ for a reference.