### PR TITLE
Update Dockerfiles to use a modern distro and the offical package

### DIFF
--- a/docker/Dockerfile.client
+++ b/docker/Dockerfile.client
@@ -12,7 +12,7 @@ RUN --mount=type=cache,mode=0755,target=/var/lib/apt/lists,sharing=locked \
     apt-get install -y ca-certificates && \
     echo "deb https://github.com/MisterTea/debian-et/raw/master/debian-source/ bookworm main" > /etc/apt/sources.list.d/et.list && \
     apt-get update -qq && \
-    apt-get install -y et
+    apt-get install -y et openssh-server
 
 COPY --chmod=755 container-entrypoint /bin/container-entrypoint
 

--- a/docker/Dockerfile.client
+++ b/docker/Dockerfile.client
@@ -1,13 +1,16 @@
 FROM debian:bookworm-slim
 
+# Use ADD to avoid having to install curl
+ADD --chmod=644 https://github.com/MisterTea/debian-et/raw/master/et.gpg /etc/apt/trusted.gpg.d/et.gpg
+
+# Use a run cache to speed up rebuilding and avoid having to remove the cache when we're done
 RUN --mount=type=cache,mode=0755,target=/var/lib/apt/lists,sharing=locked \
     --mount=type=cache,mode=0755,target=/var/cache/apt,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
-    apt-get update -qq && \
-    apt-get install -y curl && \
     echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache && \
+    apt-get update -qq && \
+    apt-get install -y ca-certificates && \
     echo "deb https://github.com/MisterTea/debian-et/raw/master/debian-source/ bookworm main" > /etc/apt/sources.list.d/et.list && \
-    curl -sSL https://github.com/MisterTea/debian-et/raw/master/et.gpg > /etc/apt/trusted.gpg.d/et.gpg && \
     apt-get update -qq && \
     apt-get install -y et
 

--- a/docker/Dockerfile.client
+++ b/docker/Dockerfile.client
@@ -1,30 +1,16 @@
-FROM centos:8 as base
+FROM debian:bookworm-slim
 
-ENV BUILD_REPOS="epel-release centos-release-scl" \
-    BUILD_DEPS="cmake3 boost-devel libsodium-devel protobuf-devel \
-    protobuf-compiler gflags-devel protobuf-lite-devel git \
-    perl-IPC-Cmd perl-Data-Dumper libunwind-devel libutempter-devel \
-    devtoolset-11 devtoolset-11-libatomic-devel rh-git227"
+RUN --mount=type=cache,mode=0755,target=/var/lib/apt/lists,sharing=locked \
+    --mount=type=cache,mode=0755,target=/var/cache/apt,sharing=locked \
+    rm -f /etc/apt/apt.conf.d/docker-clean && \
+    apt-get update -qq && \
+    apt-get install -y curl && \
+    echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache && \
+    echo "deb https://github.com/MisterTea/debian-et/raw/master/debian-source/ bookworm main" > /etc/apt/sources.list.d/et.list && \
+    curl -sSL https://github.com/MisterTea/debian-et/raw/master/et.gpg > /etc/apt/trusted.gpg.d/et.gpg && \
+    apt-get update -qq && \
+    apt-get install -y et
 
-
-WORKDIR /
-
-RUN yum install -y $BUILD_REPOS && \
-    yum install -y $BUILD_DEPS && \
-    git clone --recurse-submodules https://github.com/MisterTea/EternalTerminal.git && \
-    cd EternalTerminal && \
-    mkdir build && \
-    cd build && \
-    bash -c "scl enable devtoolset-11 rh-git227 'cmake3 ../'" && \
-    bash -c "scl enable devtoolset-11 'make -j $(grep ^processor /proc/cpuinfo |wc -l) && make install'"
-
-FROM centos:8
-
-RUN yum install -y epel-release && \
-    yum install -y protobuf-lite libsodium libatomic libunwind
-
-COPY --from=base /usr/bin/etserver /usr/bin/etterminal /usr/bin/htm /usr/bin/htmd  /usr/bin/
-COPY --from=base /EternalTerminal/etc/et.cfg /etc/et.cfg
 COPY --chmod=755 container-entrypoint /bin/container-entrypoint
 
 ENTRYPOINT ["/bin/container-entrypoint", "client"]

--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -12,7 +12,7 @@ RUN --mount=type=cache,mode=0755,target=/var/lib/apt/lists,sharing=locked \
     apt-get install -y ca-certificates && \
     echo "deb https://github.com/MisterTea/debian-et/raw/master/debian-source/ bookworm main" > /etc/apt/sources.list.d/et.list && \
     apt-get update -qq && \
-    apt-get install -y et
+    apt-get install -y et openssh-server
 
 COPY --chmod=755 container-entrypoint /bin/container-entrypoint
 

--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -1,13 +1,16 @@
 FROM debian:bookworm-slim
 
+# Use ADD to avoid having to install curl
+ADD --chmod=644 https://github.com/MisterTea/debian-et/raw/master/et.gpg /etc/apt/trusted.gpg.d/et.gpg
+
+# Use a run cache to speed up rebuilding and avoid having to remove the cache when we're done
 RUN --mount=type=cache,mode=0755,target=/var/lib/apt/lists,sharing=locked \
     --mount=type=cache,mode=0755,target=/var/cache/apt,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
-    apt-get update -qq && \
-    apt-get install -y curl && \
     echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache && \
+    apt-get update -qq && \
+    apt-get install -y ca-certificates && \
     echo "deb https://github.com/MisterTea/debian-et/raw/master/debian-source/ bookworm main" > /etc/apt/sources.list.d/et.list && \
-    curl -sSL https://github.com/MisterTea/debian-et/raw/master/et.gpg > /etc/apt/trusted.gpg.d/et.gpg && \
     apt-get update -qq && \
     apt-get install -y et
 

--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -1,34 +1,16 @@
-FROM centos:8 as base
+FROM debian:bookworm-slim
 
-ENV BUILD_REPOS="epel-release centos-release-scl" \
-    BUILD_DEPS="cmake3 boost-devel libsodium-devel protobuf-devel \
-    protobuf-compiler gflags-devel protobuf-lite-devel git \
-    perl-IPC-Cmd perl-Data-Dumper libunwind-devel libutempter-devel \
-    devtoolset-11 devtoolset-11-libatomic-devel rh-git227"
+RUN --mount=type=cache,mode=0755,target=/var/lib/apt/lists,sharing=locked \
+    --mount=type=cache,mode=0755,target=/var/cache/apt,sharing=locked \
+    rm -f /etc/apt/apt.conf.d/docker-clean && \
+    apt-get update -qq && \
+    apt-get install -y curl && \
+    echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache && \
+    echo "deb https://github.com/MisterTea/debian-et/raw/master/debian-source/ bookworm main" > /etc/apt/sources.list.d/et.list && \
+    curl -sSL https://github.com/MisterTea/debian-et/raw/master/et.gpg > /etc/apt/trusted.gpg.d/et.gpg && \
+    apt-get update -qq && \
+    apt-get install -y et
 
-
-WORKDIR /
-
-RUN yum install -y $BUILD_REPOS && \
-    yum install -y $BUILD_DEPS && \
-    git clone --recurse-submodules https://github.com/MisterTea/EternalTerminal.git && \
-    cd EternalTerminal && \
-    mkdir build && \
-    cd build && \
-    bash -c "scl enable devtoolset-11 rh-git227 'cmake3 ../'" && \
-    bash -c "scl enable devtoolset-11 'make -j $(grep ^processor /proc/cpuinfo |wc -l) && make install'"
-
-FROM centos:8
-
-RUN yum install -y epel-release && \
-    yum install -y protobuf-lite libsodium openssh-server libatomic libunwind
-
-COPY --from=base /usr/bin/etserver /usr/bin/etterminal /usr/bin/htm /usr/bin/htmd  /usr/bin/
-COPY --from=base /EternalTerminal/etc/et.cfg /etc/et.cfg
 COPY --chmod=755 container-entrypoint /bin/container-entrypoint
 
-EXPOSE 2022 2222
-
 ENTRYPOINT ["/bin/container-entrypoint", "server"]
-
-CMD ["--cfgfile=/etc/et.cfg"]

--- a/docker/container-entrypoint
+++ b/docker/container-entrypoint
@@ -3,6 +3,11 @@
 set -x
 
 if [ "$1" == server ]; then
+    if [ ! -d /run/sshd ]; then
+        mkdir /run/sshd
+        chmod 0755 /run/sshd
+    fi
+
     /usr/sbin/sshd
     shift
     exec etserver --logtostdout -v 1 "$@"


### PR DESCRIPTION
Currently, the Dockerfiles in the offical repo are non-functional, because CentOS is no longer a thing and the official package repository has been taken offline.  As such, this pull request updates them to use Debian 12 and uses the official EternalTerminal repository to install the ET binaries into the container.