### PR TITLE
Fix multi-session log file race on startup

### DIFF
--- a/src/base/LogHandler.cpp
+++ b/src/base/LogHandler.cpp
@@ -33,7 +33,7 @@ void LogHandler::setupLogFiles(el::Configurations *defaultConf,
   char buffer[80];
   time(&rawtime);
   timeinfo = localtime(&rawtime);
-  strftime(buffer, sizeof(buffer), "%Y-%m-%d_%H-%M-%S", timeinfo);
+  strftime(buffer, sizeof(buffer), "%Y-%m-%d_%H-%M-%S.%f", timeinfo);
   string current_time(buffer);
   string logFilename = filenamePrefix + "-" + current_time;
   string stderrFilename = filenamePrefix + "-stderr-" + current_time;


### PR DESCRIPTION
Fix multi-session log file race on startup

- Fixes https://github.com/MisterTea/EternalTerminal/issues/599

- Starting multiple sessions simultaneously fails with:
```
2024-11-14 08:20:32,278 FATAL [default] Stack Trace:
[0] 0x0000000104486cab et::LogHandler::createLogFile(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&)
[1] 0x000000010448666d et::LogHandler::setupLogFiles(el::Configurations*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, bool, bool, bool, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>)
[2] 0x00000001043ce52b main
[3] 0x0000000204776345 start
Error: (2): No such file or directory
2024-11-14 08:20:32,278 WARNING [default] Aborting application. Reason: Fatal log at [/tmp/nix-build-eternal-terminal-6.2.8.drv-0/source/src/base/LogHandler.cpp:97]
```

`LogHandler::createLogFile` expects to be the sole owner of the log file and thus [creates the file with `O_EXCL`](https://github.com/MisterTea/EternalTerminal/blob/204612857d233496e7a9c146fd540b7a45599ec7/src/base/LogHandler.cpp#L97). Adding `%f` (microseconds) to `strftime` reduces the probablity of conflict. We don't want to relax the `O_EXCL` constraint (unique log per instance).

Alternative approaches not taken, but could be followed instead:
- Always force `appendPid`
- Append a non-time-based nonce to the path name
