### PR TITLE
Fix parsing bug where includes are skipped

### DIFF
--- a/src/terminal/ParseConfigFile.hpp
+++ b/src/terminal/ParseConfigFile.hpp
@@ -1245,7 +1245,7 @@ static int ssh_config_parse_line(const char *targethost,
     case SOC_INCLUDE: /* recursive include of other files */
 
       p = ssh_config_get_str_tok(&s, NULL);
-      if (p && *parsing) {
+      if (p) {
         char *filename = ssh_path_expand_tilde(p);
         if (filename) {
           local_parse_file(targethost, options, filename, parsing, seen);


### PR DESCRIPTION
The SSH config parser avoids parsing everything inside a `Host` block that does not match the host we are trying to connect to.

This makes sense, but the implementation fails on some cases. Consider the following:

`et host.company`

```
Host other.company
    User someone
Include ~/.ssh/host.company
```

And inside `~/.ssh/host.company` we have:

```
Host host.company
    User gabriel
```

The way the parser works now is:

* Sees the `Host other.company` and sets `parsing = 0` because it does not match the target `host.company`.
* Skips processing the `Include` completely because `parsing = 0`.
* Misses the actual configs defined for `Host host.company`.

This PR simply does not ignore `Include` directives to avoid such cases.