### PR TITLE
Recommend `--logtostdout` in systemd installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ Alternatively, open the file /etc/systemd/system/et.service in an editor and cor
 
 
 ```
-ExecStart=/usr/local/bin/etserver --cfgfile=/etc/et.cfg
+ExecStart=/usr/local/bin/etserver --cfgfile=/etc/et.cfg --logtostdout
 ```
 
 Reload systemd configs:

--- a/systemctl/et.service
+++ b/systemctl/et.service
@@ -5,7 +5,7 @@ After=syslog.target network.target
 [Service]
 Type=simple
 Restart=on-failure
-ExecStart=/usr/bin/etserver --cfgfile=/etc/et.cfg
+ExecStart=/usr/bin/etserver --cfgfile=/etc/et.cfg --logtostdout
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This lets the logs from etserver go to the systemd journal, instead of `/tmp`; it's a lot nicer when running under systemd.