### PR TITLE
Parse LocalForward from SSH config

### DIFF
--- a/src/base/TcpSocketHandler.cpp
+++ b/src/base/TcpSocketHandler.cpp
@@ -204,6 +204,9 @@ set<int> TcpSocketHandler::listen(const SocketEndpoint &endpoint) {
       LOG(WARNING) << "Error binding " << p->ai_family << "/" << p->ai_socktype
                    << "/" << p->ai_protocol << ": " << localErrno << " "
                    << strerror(localErrno);
+      CLOG(INFO, "stdout") << "Error binding " << p->ai_family << "/"
+                           << p->ai_socktype << "/" << p->ai_protocol << ": "
+                           << localErrno << " " << strerror(localErrno) << endl;
       stringstream oss;
       oss << "Error binding port " << port << ": " << localErrno << " "
           << strerror(localErrno);

--- a/src/base/TcpSocketHandler.cpp
+++ b/src/base/TcpSocketHandler.cpp
@@ -204,9 +204,6 @@ set<int> TcpSocketHandler::listen(const SocketEndpoint &endpoint) {
       LOG(WARNING) << "Error binding " << p->ai_family << "/" << p->ai_socktype
                    << "/" << p->ai_protocol << ": " << localErrno << " "
                    << strerror(localErrno);
-      CLOG(INFO, "stdout") << "Error binding " << p->ai_family << "/"
-                           << p->ai_socktype << "/" << p->ai_protocol << ": "
-                           << localErrno << " " << strerror(localErrno) << endl;
       stringstream oss;
       oss << "Error binding port " << port << ": " << localErrno << " "
           << strerror(localErrno);

--- a/src/terminal/TerminalClient.cpp
+++ b/src/terminal/TerminalClient.cpp
@@ -30,7 +30,11 @@ TerminalClient::TerminalClient(
         auto pfsresponse =
             portForwardHandler->createSource(pfsr, nullptr, -1, -1);
         if (pfsresponse.has_error()) {
-          throw std::runtime_error(pfsresponse.error());
+          LOG(WARNING) << "Failed to establish port forward "
+                       << pfsr.source().port() << ":"
+                       << pfsr.destination().port() << " - "
+                       << pfsresponse.error();
+          continue;
         }
 #endif
       }

--- a/src/terminal/TerminalClientMain.cpp
+++ b/src/terminal/TerminalClientMain.cpp
@@ -75,7 +75,8 @@ int main(int argc, char** argv) {
       NULL,  // gss_client_identity
       0,     // gss_delegate_creds
       0,     // forward_agent
-      NULL   // identity_agent
+      NULL,  // identity_agent
+      {}     // local_forwards (empty vector)
   };
 
   // Parse command line arguments
@@ -380,6 +381,19 @@ int main(int argc, char** argv) {
         extractSingleOptionWithDefault<string>(result, options, "tunnel", "");
     string r_tunnel_arg = extractSingleOptionWithDefault<string>(
         result, options, "reversetunnel", "");
+
+    for (const auto& localForward : sshConfigOptions.local_forwards) {
+      string tunnelEntry =
+          to_string(localForward.first) + ":" + to_string(localForward.second);
+      LOG(INFO) << "Adding tunnel from SSH config LocalForward: "
+                << tunnelEntry;
+      if (tunnel_arg.empty()) {
+        tunnel_arg = tunnelEntry;
+      } else {
+        tunnel_arg += "," + tunnelEntry;
+      }
+    }
+
     TerminalClient terminalClient(clientSocket, clientPipeSocket,
                                   socketEndpoint, id, passkey, console,
                                   is_jumphost, tunnel_arg, r_tunnel_arg,


### PR DESCRIPTION
Even though EternalTerminal supports port forwarding by default, it doesn't understand the `LocalForward` directive from ssh config:


>   LocalForward
               Specifies that a TCP port on the local machine be
               forwarded over the secure channel to the specified host
               and port from the remote machine.  The first argument
               specifies the listener and may be [bind_address:]port or a
               Unix domain socket path.  The second argument is the
               destination and may be host:hostport or a Unix domain
               socket path if the remote host supports it.

https://man7.org/linux/man-pages/man5/ssh_config.5.html

This is a very crude implementation that simply parses those configs in a straightforward (and incomplete) way and turns all errors into warnings, just like `ssh` does by default.