### PR TITLE
Fix ProxyJump to support SSH ports and host aliases

### DIFF
--- a/src/terminal/HostParsing.hpp
+++ b/src/terminal/HostParsing.hpp
@@ -1,0 +1,58 @@
+#ifndef __ET_HOST_PARSING__
+#define __ET_HOST_PARSING__
+
+#include "Headers.hpp"
+
+namespace et {
+
+// Parsed components of a [user@]host[:port] string
+struct ParsedHostString {
+  string user;
+  string host;
+  string portSuffix;  // includes colon, e.g. ":22"
+};
+
+// Parse a host string in [user@]host[:port] format
+// Handles IPv6 addresses in bracket notation: [::1], [::1]:22, user@[::1]:22
+inline ParsedHostString parseHostString(const string& hostString) {
+  ParsedHostString result;
+  string remaining = hostString;
+
+  // Extract user@ prefix if present
+  size_t atIndex = remaining.find("@");
+  if (atIndex != string::npos) {
+    result.user = remaining.substr(0, atIndex);
+    remaining = remaining.substr(atIndex + 1);
+  }
+
+  // Handle IPv6 addresses in bracket notation: [ipv6]:port
+  if (!remaining.empty() && remaining[0] == '[') {
+    size_t closeBracket = remaining.find(']');
+    if (closeBracket != string::npos) {
+      // Extract IPv6 address including brackets
+      result.host = remaining.substr(0, closeBracket + 1);
+      // Check for :port after the closing bracket
+      if (closeBracket + 1 < remaining.length() &&
+          remaining[closeBracket + 1] == ':') {
+        result.portSuffix = remaining.substr(closeBracket + 1);
+      }
+    } else {
+      // Malformed: opening bracket without closing, treat as-is
+      result.host = remaining;
+    }
+  } else {
+    // Non-IPv6: extract :port suffix if present
+    size_t colonIndex = remaining.find(":");
+    if (colonIndex != string::npos) {
+      result.portSuffix = remaining.substr(colonIndex);  // ":port"
+      remaining = remaining.substr(0, colonIndex);
+    }
+    result.host = remaining;
+  }
+
+  return result;
+}
+
+}  // namespace et
+
+#endif  // __ET_HOST_PARSING__

--- a/src/terminal/ParseConfigFile.hpp
+++ b/src/terminal/ParseConfigFile.hpp
@@ -158,6 +158,19 @@ struct Options {
   vector<pair<string, string>> env_vars;
 };
 
+// Free all allocated fields in an Options struct
+inline void freeOptionsFields(Options *opts) {
+  SAFE_FREE(opts->username);
+  SAFE_FREE(opts->host);
+  SAFE_FREE(opts->sshdir);
+  SAFE_FREE(opts->knownhosts);
+  SAFE_FREE(opts->ProxyCommand);
+  SAFE_FREE(opts->ProxyJump);
+  SAFE_FREE(opts->gss_server_identity);
+  SAFE_FREE(opts->gss_client_identity);
+  SAFE_FREE(opts->identity_agent);
+}
+
 /**
  * @brief Maps keyword strings to their opcodes for parser lookup.
  */

--- a/src/terminal/SshSetupHandler.cpp
+++ b/src/terminal/SshSetupHandler.cpp
@@ -1,5 +1,8 @@
 #include "SshSetupHandler.hpp"
 
+
+#include "HostParsing.hpp"
+
 namespace et {
 const string SshSetupHandler::ETTERMINAL_BIN = "etterminal";
 
@@ -122,8 +125,36 @@ pair<string, string> SshSetupHandler::SetupSsh(
     string SSH_SCRIPT_JUMP = genCommand(passkey, id, clientTerm, user, kill,
                                         cmd_prefix, jump_cmdoptions);
 
-    string sshLinkBuffer = subprocessUtils_->SubprocessToStringInteractive(
-        "ssh", {jumphost, SSH_SCRIPT_JUMP});
+    // Parse jumphost to extract port for -p flag (ssh destination doesn't
+    // support user@host:port, only -J does)
+    ParsedHostString parsedJump = parseHostString(jumphost);
+
+    // Strip brackets from IPv6 addresses for ssh destination
+    // (ssh [::1] fails, but ssh ::1 works)
+    string jumphostAddr = parsedJump.host;
+    if (jumphostAddr.length() >= 2 && jumphostAddr.front() == '[' &&
+        jumphostAddr.back() == ']') {
+      jumphostAddr = jumphostAddr.substr(1, jumphostAddr.length() - 2);
+    }
+
+    string jumphostDest = parsedJump.user.empty()
+                              ? jumphostAddr
+                              : parsedJump.user + "@" + jumphostAddr;
+
+    std::vector<std::string> jump_ssh_args;
+    if (!parsedJump.portSuffix.empty()) {
+      // portSuffix includes the colon, e.g. ":22"
+      jump_ssh_args.push_back("-p");
+      jump_ssh_args.push_back(parsedJump.portSuffix.substr(1));
+    }
+    for (const auto& opt : ssh_options) {
+      jump_ssh_args.push_back("-o" + opt);
+    }
+    jump_ssh_args.push_back(jumphostDest);
+    jump_ssh_args.push_back(SSH_SCRIPT_JUMP);
+
+    string sshLinkBuffer =
+        subprocessUtils_->SubprocessToStringInteractive("ssh", jump_ssh_args);
     if (sshLinkBuffer.length() <= 0) {
       // At this point "ssh -J jumphost dst" already works.
       CLOG(INFO, "stdout") << "etserver jumpclient failed to start" << endl;

--- a/src/terminal/SshSetupHandler.cpp
+++ b/src/terminal/SshSetupHandler.cpp
@@ -1,6 +1,5 @@
 #include "SshSetupHandler.hpp"
 
-
 #include "HostParsing.hpp"
 
 namespace et {

--- a/src/terminal/TerminalClientMain.cpp
+++ b/src/terminal/TerminalClientMain.cpp
@@ -1,6 +1,7 @@
 #include <cxxopts.hpp>
 
 #include "Headers.hpp"
+#include "HostParsing.hpp"
 #include "ParseConfigFile.hpp"
 #include "PipeSocketHandler.hpp"
 #include "PseudoTerminalConsole.hpp"
@@ -46,54 +47,6 @@ T extractSingleOptionWithDefault(const cxxopts::ParseResult& result,
                        << " must be specified only once\n";
   CLOG(INFO, "stdout") << options.help({}) << endl;
   exit(0);
-}
-
-// Parsed components of a [user@]host[:port] string
-struct ParsedHostString {
-  string user;
-  string host;
-  string portSuffix;  // includes colon, e.g. ":22"
-};
-
-// Parse a host string in [user@]host[:port] format
-// Handles IPv6 addresses in bracket notation: [::1], [::1]:22, user@[::1]:22
-ParsedHostString parseHostString(const string& hostString) {
-  ParsedHostString result;
-  string remaining = hostString;
-
-  // Extract user@ prefix if present
-  size_t atIndex = remaining.find("@");
-  if (atIndex != string::npos) {
-    result.user = remaining.substr(0, atIndex);
-    remaining = remaining.substr(atIndex + 1);
-  }
-
-  // Handle IPv6 addresses in bracket notation: [ipv6]:port
-  if (!remaining.empty() && remaining[0] == '[') {
-    size_t closeBracket = remaining.find(']');
-    if (closeBracket != string::npos) {
-      // Extract IPv6 address including brackets
-      result.host = remaining.substr(0, closeBracket + 1);
-      // Check for :port after the closing bracket
-      if (closeBracket + 1 < remaining.length() &&
-          remaining[closeBracket + 1] == ':') {
-        result.portSuffix = remaining.substr(closeBracket + 1);
-      }
-    } else {
-      // Malformed: opening bracket without closing, treat as-is
-      result.host = remaining;
-    }
-  } else {
-    // Non-IPv6: extract :port suffix if present
-    size_t colonIndex = remaining.find(":");
-    if (colonIndex != string::npos) {
-      result.portSuffix = remaining.substr(colonIndex);  // ":port"
-      remaining = remaining.substr(0, colonIndex);
-    }
-    result.host = remaining;
-  }
-
-  return result;
 }
 
 // Resolved SSH config information for a host

--- a/test/HostParsingTest.cpp
+++ b/test/HostParsingTest.cpp
@@ -1,0 +1,111 @@
+#include "HostParsing.hpp"
+#include "TestHeaders.hpp"
+
+using namespace et;
+
+TEST_CASE("parseHostString", "[HostParsing]") {
+  SECTION("Simple hostname") {
+    auto result = parseHostString("example.com");
+    REQUIRE(result.user == "");
+    REQUIRE(result.host == "example.com");
+    REQUIRE(result.portSuffix == "");
+  }
+
+  SECTION("Hostname with port") {
+    auto result = parseHostString("example.com:22");
+    REQUIRE(result.user == "");
+    REQUIRE(result.host == "example.com");
+    REQUIRE(result.portSuffix == ":22");
+  }
+
+  SECTION("User and hostname") {
+    auto result = parseHostString("user@example.com");
+    REQUIRE(result.user == "user");
+    REQUIRE(result.host == "example.com");
+    REQUIRE(result.portSuffix == "");
+  }
+
+  SECTION("User, hostname, and port") {
+    auto result = parseHostString("user@example.com:2222");
+    REQUIRE(result.user == "user");
+    REQUIRE(result.host == "example.com");
+    REQUIRE(result.portSuffix == ":2222");
+  }
+
+  SECTION("IPv4 address") {
+    auto result = parseHostString("192.168.1.1");
+    REQUIRE(result.user == "");
+    REQUIRE(result.host == "192.168.1.1");
+    REQUIRE(result.portSuffix == "");
+  }
+
+  SECTION("IPv4 address with port") {
+    auto result = parseHostString("192.168.1.1:22");
+    REQUIRE(result.user == "");
+    REQUIRE(result.host == "192.168.1.1");
+    REQUIRE(result.portSuffix == ":22");
+  }
+
+  SECTION("IPv6 address in brackets") {
+    auto result = parseHostString("[::1]");
+    REQUIRE(result.user == "");
+    REQUIRE(result.host == "[::1]");
+    REQUIRE(result.portSuffix == "");
+  }
+
+  SECTION("IPv6 address with port") {
+    auto result = parseHostString("[::1]:22");
+    REQUIRE(result.user == "");
+    REQUIRE(result.host == "[::1]");
+    REQUIRE(result.portSuffix == ":22");
+  }
+
+  SECTION("User and IPv6 address") {
+    auto result = parseHostString("user@[::1]");
+    REQUIRE(result.user == "user");
+    REQUIRE(result.host == "[::1]");
+    REQUIRE(result.portSuffix == "");
+  }
+
+  SECTION("User, IPv6 address, and port") {
+    auto result = parseHostString("user@[::1]:2222");
+    REQUIRE(result.user == "user");
+    REQUIRE(result.host == "[::1]");
+    REQUIRE(result.portSuffix == ":2222");
+  }
+
+  SECTION("Full IPv6 address with port") {
+    auto result = parseHostString("[2001:db8::1]:22");
+    REQUIRE(result.user == "");
+    REQUIRE(result.host == "[2001:db8::1]");
+    REQUIRE(result.portSuffix == ":22");
+  }
+
+  SECTION("User with full IPv6 and port") {
+    auto result = parseHostString("admin@[fe80::1%eth0]:22");
+    REQUIRE(result.user == "admin");
+    REQUIRE(result.host == "[fe80::1%eth0]");
+    REQUIRE(result.portSuffix == ":22");
+  }
+
+  SECTION("Empty string") {
+    auto result = parseHostString("");
+    REQUIRE(result.user == "");
+    REQUIRE(result.host == "");
+    REQUIRE(result.portSuffix == "");
+  }
+
+  SECTION("Malformed IPv6 - missing close bracket") {
+    auto result = parseHostString("[::1");
+    REQUIRE(result.user == "");
+    REQUIRE(result.host == "[::1");  // treated as literal
+    REQUIRE(result.portSuffix == "");
+  }
+
+  SECTION("User with malformed IPv6") {
+    auto result = parseHostString("user@[::1");
+    REQUIRE(result.user == "user");
+    REQUIRE(result.host == "[::1");
+    REQUIRE(result.portSuffix == "");
+  }
+}

--- a/test/system_tests/connect_with_jumphost.sh
+++ b/test/system_tests/connect_with_jumphost.sh
@@ -23,5 +23,65 @@ build/et -c "echo 'Hello World 2!'" --serverfifo=/tmp/etserver.idpasskey.fifo2 -
 
 build/et -c "echo 'Hello World 3!'" --serverfifo=/tmp/etserver.idpasskey.fifo2 --logtostdout --terminal-path $PWD/build/etterminal --jumphost localhost --jport 9900 --jserverfifo=/tmp/etserver.idpasskey.fifo1 127.0.0.1:9901 # We can't use 'localhost' for both the jumphost and the destination because ssh doesn't support keeping them the same.
 
+# Test SSH config ProxyJump with alias and port specification
+# Backup existing SSH config if present, or track that we created it
+mkdir -p ~/.ssh
+SSH_CONFIG_BACKUP=""
+SSH_CONFIG_CREATED=false
+if [ -f ~/.ssh/config ]; then
+  SSH_CONFIG_BACKUP=$(mktemp)
+  cp ~/.ssh/config "$SSH_CONFIG_BACKUP"
+else
+  SSH_CONFIG_CREATED=true
+fi
+
+# Cleanup function to restore SSH config on exit (including failures)
+cleanup_ssh_config() {
+  if [ -n "$SSH_CONFIG_BACKUP" ]; then
+    mv "$SSH_CONFIG_BACKUP" ~/.ssh/config
+  elif [ "$SSH_CONFIG_CREATED" = true ]; then
+    rm -f ~/.ssh/config
+  fi
+}
+trap cleanup_ssh_config EXIT
+
+# Append test configuration to SSH config
+cat >> ~/.ssh/config <<EOF
+
+# Temporary ET test configuration
+Host et_test_jumphost_alias
+    HostName localhost
+    Port 22
+    User $USER
+
+Host et_test_destination_with_port
+    HostName 127.0.0.1
+    ProxyJump et_test_jumphost_alias:22
+    User $USER
+EOF
+
+# Test 4: ProxyJump with alias resolution and explicit SSH port
+# This tests that the alias "et_test_jumphost_alias:22" is resolved to "localhost:22"
+# and that the port specification is preserved in the ssh -J command
+echo "Test 4: ProxyJump with alias and explicit SSH port (testing alias resolution + port preservation)"
+TEST4_OUTPUT=$(mktemp)
+if build/et -c "echo 'Hello World 4!'" --serverfifo=/tmp/etserver.idpasskey.fifo2 --logtostdout --terminal-path $PWD/build/etterminal --jport 9900 --jserverfifo=/tmp/etserver.idpasskey.fifo1 et_test_destination_with_port 2>&1 | tee "$TEST4_OUTPUT" | grep -q "Hello World 4!"; then
+  # Verify alias was resolved in logs
+  if grep -q "Resolved jumphost alias 'et_test_jumphost_alias' to hostname: localhost" "$TEST4_OUTPUT"; then
+    echo "Test 4 passed: Alias resolution confirmed"
+  else
+    echo "Test 4 failed: Connection succeeded but alias resolution log not found"
+    cat "$TEST4_OUTPUT"
+    rm -f "$TEST4_OUTPUT"
+    exit 1
+  fi
+else
+  echo "Test 4 failed: Connection or output verification failed"
+  cat "$TEST4_OUTPUT"
+  rm -f "$TEST4_OUTPUT"
+  exit 1
+fi
+rm -f "$TEST4_OUTPUT"
+
 kill -9 $first_server_pid
 kill -9 $second_server_pid

--- a/test/system_tests/connect_with_jumphost.sh
+++ b/test/system_tests/connect_with_jumphost.sh
@@ -70,7 +70,7 @@ EOF
 # and that the port specification is preserved in the ssh -J command
 echo "Test 4: ProxyJump with alias and explicit SSH port (testing alias resolution + port preservation)"
 TEST4_OUTPUT=$(mktemp)
-if build/et -c "echo 'Hello World 4!'" --serverfifo=/tmp/etserver.idpasskey.fifo2 --logtostdout --terminal-path $PWD/build/etterminal --jport 9900 --jserverfifo=/tmp/etserver.idpasskey.fifo1 et_test_destination_with_port 2>&1 | tee "$TEST4_OUTPUT" | grep -q "Hello World 4!"; then
+if build/et -c "echo 'Hello World 4!'" --port 9901 --serverfifo=/tmp/etserver.idpasskey.fifo2 --logtostdout --terminal-path $PWD/build/etterminal --jport 9900 --jserverfifo=/tmp/etserver.idpasskey.fifo1 et_test_destination_with_port 2>&1 | tee "$TEST4_OUTPUT" | grep -q "Hello World 4!"; then
   # Verify alias was resolved in logs
   if grep -q "Resolved jumphost alias 'et_test_jumphost_alias' to hostname: localhost" "$TEST4_OUTPUT"; then
     echo "Test 4 passed: Alias resolution confirmed"


### PR DESCRIPTION
ET currently fails to connect through jump hosts when the jump host uses a non-standard SSH port or when ProxyJump references an SSH config Host alias.

For example, with this SSH config:
```ssh
Host jumphost
  HostName jump.example.com
  Port 2222

Host destination
  HostName dest.example.com
  ProxyJump jumphost
```

Running `et destination` fails with `Could not reach the ET server: jumphost:2022`

The issue is that the ProxyJump parsing code was stripping SSH ports from the jump host value:
```cpp
if (colonIndex != string::npos) {
  jumphost = proxyjump.substr(0, colonIndex);  // Strips :2222
}
```

Additionally, Host aliases like "jumphost" weren't being resolved to actual hostnames, so ET tried to connect to the alias name instead of the configured hostname.

This PR fixes both issues by:
- Preserving the full ProxyJump value `[user@]host[:port]` when passing to SSH via `-J` flag
- Extracting just the hostname from the ProxyJump value for ET socket connections
- Looking up Host aliases in SSH config to get the actual hostname

Tested with the config above. Before the fix `et destination` fails, after it successfully connects via jump.example.com:2222 (SSH) -> destination (ET).

No breaking changes expected - existing ProxyJump configurations should continue to work, though I don't currently have a working jumphost setup to verify backwards compatibility directly.
