### PR TITLE
Update utempter designation to be 'etterminal' plus misspelling update.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,8 +5,8 @@ ignore:
   - "src/htm" # HTM not tested yet
   - "src/terminal/ParseConfigFile.hpp"
   - "src/terminal/TelemetryService*"
-  - "src/terminal/PsuedoTerminalConsole.hpp"
-  - "src/terminal/PsuedoUserTerminal.hpp"
+  - "src/terminal/PseudoTerminalConsole.hpp"
+  - "src/terminal/PseudoUserTerminal.hpp"
   - "src/terminal/*Main.cpp"
   - "src/base/Headers.hpp"
   - "src/base/TcpSocketHandler*"

--- a/src/terminal/PseudoTerminalConsole.hpp
+++ b/src/terminal/PseudoTerminalConsole.hpp
@@ -6,9 +6,9 @@
 #include "RawSocketUtils.hpp"
 
 namespace et {
-class PsuedoTerminalConsole : public Console {
+class PseudoTerminalConsole : public Console {
  public:
-  PsuedoTerminalConsole() {
+  PseudoTerminalConsole() {
 #ifdef WIN32
     auto hstdin = GetStdHandle(STD_INPUT_HANDLE);
     GetConsoleMode(hstdin, &inputMode);
@@ -21,7 +21,7 @@ class PsuedoTerminalConsole : public Console {
 #endif
   }
 
-  virtual ~PsuedoTerminalConsole() {}
+  virtual ~PseudoTerminalConsole() {}
 
   virtual void setup() {
 #ifdef WIN32

--- a/src/terminal/PseudoUserTerminal.hpp
+++ b/src/terminal/PseudoUserTerminal.hpp
@@ -22,9 +22,9 @@
 #include "UserTerminal.hpp"
 
 namespace et {
-class PsuedoUserTerminal : public UserTerminal {
+class PseudoUserTerminal : public UserTerminal {
  public:
-  virtual ~PsuedoUserTerminal() {}
+  virtual ~PseudoUserTerminal() {}
 
   virtual int setup(int routerFd) {
     pid_t pid = forkpty(&masterFd, NULL, NULL, NULL);
@@ -46,7 +46,7 @@ class PsuedoUserTerminal : public UserTerminal {
 #ifdef WITH_UTEMPTER
     {
       char buf[1024];
-      sprintf(buf, "et [%lld]", (long long)getpid());
+      sprintf(buf, "etterminal [%lld]", (long long)getpid());
       utempter_add_record(masterFd, buf);
     }
 #endif

--- a/src/terminal/TerminalClientMain.cpp
+++ b/src/terminal/TerminalClientMain.cpp
@@ -3,7 +3,7 @@
 #include "Headers.hpp"
 #include "ParseConfigFile.hpp"
 #include "PipeSocketHandler.hpp"
-#include "PsuedoTerminalConsole.hpp"
+#include "PseudoTerminalConsole.hpp"
 #include "TelemetryService.hpp"
 #include "TerminalClient.hpp"
 #include "TunnelUtils.hpp"
@@ -361,7 +361,7 @@ int main(int argc, char** argv) {
     }
     shared_ptr<Console> console;
     if (!result.count("N")) {
-      console.reset(new PsuedoTerminalConsole());
+      console.reset(new PseudoTerminalConsole());
     }
 
     bool forwardAgent = result.count("f") > 0;

--- a/src/terminal/TerminalMain.cpp
+++ b/src/terminal/TerminalMain.cpp
@@ -4,7 +4,7 @@
 #include "LogHandler.hpp"
 #include "ParseConfigFile.hpp"
 #include "PipeSocketHandler.hpp"
-#include "PsuedoUserTerminal.hpp"
+#include "PseudoUserTerminal.hpp"
 #include "ServerFifoPath.hpp"
 #include "TcpSocketHandler.hpp"
 #include "UserJumphostHandler.hpp"
@@ -74,7 +74,7 @@ int main(int argc, char** argv) {
     }
 
     shared_ptr<SocketHandler> ipcSocketHandler(new PipeSocketHandler());
-    shared_ptr<PsuedoUserTerminal> term(new PsuedoUserTerminal());
+    shared_ptr<PseudoUserTerminal> term(new PseudoUserTerminal());
 
     string idpasskey;
     if (result.count("idpasskey") == 0 && result.count("idpasskeyfile") == 0) {


### PR DESCRIPTION
The actual process that defines the wtmp session is etterminal, so let's make that very clear in the utempter record.

ex before:

```
❯ last | head
jwshort  pts/8        et [275430]      Fri Dec  5 10:20    gone - no logout
```

ex after:

```
❯ last -w | head
jwshort  pts/8        etterminal [4036829]     Fri Dec  5 10:03 - 10:20  (00:17)
```