### PR TITLE
etserver - disconnects clients after sleep

### DIFF
--- a/src/terminal/TerminalServer.cpp
+++ b/src/terminal/TerminalServer.cpp
@@ -310,7 +310,8 @@ void TerminalServer::runTerminal(
           sleep(1);
           continue;
         } else {
-          LOG(ERROR) << "Error reading from socket: " << errno << " " << strerror(errno);
+          LOG(ERROR) << "Error reading from socket: " << errno << " "
+                     << strerror(errno);
           run = false;
           break;
         }


### PR DESCRIPTION
Running etserver on a mac and closing & reopening the lid results in the client sessions ending with the read erroring out with a "resource temporarily unavailable". Retry in this case.

https://man7.org/linux/man-pages/man2/read.2.html
       EAGAIN or EWOULDBLOCK
              The file descriptor fd refers to a socket and has been
              marked nonblocking (O_NONBLOCK), and the read would block.
              POSIX.1-2001 allows either error to be returned for this
              case, and does not require these constants to have the same
              value, so a portable application should check for both
              possibilities.

Resolves #541, #695