### PR TITLE
Support for bind_address in tunnel/reverse tunnel args.

### DIFF
--- a/src/base/TunnelUtils.cpp
+++ b/src/base/TunnelUtils.cpp
@@ -1,65 +1,134 @@
 #include "TunnelUtils.hpp"
 
 namespace et {
+void processEtStyleTunnelArg(vector<PortForwardSourceRequest>& pfsrs,
+                             const vector<string> sourceDestination,
+                             const string& input) {
+  if (sourceDestination.size() < 2) {
+    throw TunnelParseException(
+        "Tunnel argument must have source and destination between a ':'");
+  }
+  try {
+    if (sourceDestination[0].find_first_not_of("0123456789-") != string::npos &&
+        sourceDestination[1].find_first_not_of("0123456789-") != string::npos) {
+      // forwarding named pipes with environment variables (don't set source)
+      PortForwardSourceRequest pfsr;
+      pfsr.set_environmentvariable(sourceDestination[0]);
+      pfsr.mutable_destination()->set_name(sourceDestination[1]);
+      pfsrs.push_back(pfsr);
+    } else if (sourceDestination[0].find('-') != string::npos &&
+               sourceDestination[1].find('-') != string::npos) {
+      // ranges
+      vector<string> sourcePortRange = split(sourceDestination[0], '-');
+      int sourcePortStart = stoi(sourcePortRange[0]);
+      int sourcePortEnd = stoi(sourcePortRange[1]);
+
+      vector<string> destinationPortRange = split(sourceDestination[1], '-');
+      int destinationPortStart = stoi(destinationPortRange[0]);
+      int destinationPortEnd = stoi(destinationPortRange[1]);
+
+      if (sourcePortEnd - sourcePortStart !=
+          destinationPortEnd - destinationPortStart) {
+        throw TunnelParseException(
+            "source/destination port range must have same length");
+      } else {
+        int portRangeLength = sourcePortEnd - sourcePortStart + 1;
+        for (int i = 0; i < portRangeLength; ++i) {
+          PortForwardSourceRequest pfsr;
+          pfsr.mutable_source()->set_name("localhost");
+          pfsr.mutable_source()->set_port(sourcePortStart + i);
+          pfsr.mutable_destination()->set_port(destinationPortStart + i);
+          pfsrs.push_back(pfsr);
+        }
+      }
+    } else if (sourceDestination[0].find('-') != string::npos ||
+               sourceDestination[1].find('-') != string::npos) {
+      throw TunnelParseException(
+          "Invalid port range syntax: if source is a range, "
+          "destination must be a range (and vice versa)");
+    } else {
+      // normal port:port
+      PortForwardSourceRequest pfsr;
+      pfsr.mutable_source()->set_name("localhost");
+      pfsr.mutable_source()->set_port(stoi(sourceDestination[0]));
+      pfsr.mutable_destination()->set_port(stoi(sourceDestination[1]));
+      pfsrs.push_back(pfsr);
+    }
+  } catch (const TunnelParseException& e) {
+    throw e;
+  } catch (const std::logic_error& lr) {
+    throw TunnelParseException("Invalid tunnel argument '" + input +
+                               "': " + lr.what());
+  }
+}
+
+// This is necessary rather than using simply split with ":" due to the fact
+// that ipv6 addresses must be within square brackets for the ssh-style
+// tunneling args
+vector<string> parseSshTunnelArg(const string& input) {
+  const char colon = ':';
+  const char l_bracket = '[';
+  const char r_bracket = ']';
+
+  bool inBrackets = false;
+  string currentPart;
+  vector<string> sshArgParts;
+
+  for (char c : input) {
+    if (c == l_bracket) {
+      inBrackets = true;
+    } else if (c == r_bracket) {
+      inBrackets = false;
+    } else if (c == colon && !inBrackets) {
+      sshArgParts.push_back(currentPart);
+      currentPart.clear();
+    } else {
+      currentPart += c;
+    }
+  }
+  // pushback last part
+  sshArgParts.push_back(currentPart);
+  if (sshArgParts.size() < 4) {
+    throw TunnelParseException(
+        "The 4 part ssh-style tunneling arg (bind_address:port:host:hostport) "
+        "must be supplied.");
+  }
+  if (sshArgParts.size() > 4) {
+    throw TunnelParseException(
+        "Ipv6 addresses must be inside of square brackets, ie "
+        "[::1]:8080:[::]:9090");
+  }
+  return sshArgParts;
+}
+
 vector<PortForwardSourceRequest> parseRangesToRequests(const string& input) {
   vector<PortForwardSourceRequest> pfsrs;
-  auto j = split(input, ',');
-  for (auto& pair : j) {
-    vector<string> sourceDestination = split(pair, ':');
-    if (sourceDestination.size() < 2) {
-      throw TunnelParseException(
-          "Tunnel argument must have source and destination between a ':'");
+  auto splitByComma = split(input, ',');
+  if (splitByComma.size() > 1) {
+    for (auto& element : splitByComma) {
+      vector<string> sourceDestination = split(element, ':');
+      processEtStyleTunnelArg(pfsrs, sourceDestination, input);
     }
-    try {
-      if (sourceDestination[0].find_first_not_of("0123456789-") !=
-              string::npos &&
-          sourceDestination[1].find_first_not_of("0123456789-") !=
-              string::npos) {
-        PortForwardSourceRequest pfsr;
-        pfsr.set_environmentvariable(sourceDestination[0]);
-        pfsr.mutable_destination()->set_name(sourceDestination[1]);
-        pfsrs.push_back(pfsr);
-      } else if (sourceDestination[0].find('-') != string::npos &&
-                 sourceDestination[1].find('-') != string::npos) {
-        vector<string> sourcePortRange = split(sourceDestination[0], '-');
-        int sourcePortStart = stoi(sourcePortRange[0]);
-        int sourcePortEnd = stoi(sourcePortRange[1]);
-
-        vector<string> destinationPortRange = split(sourceDestination[1], '-');
-        int destinationPortStart = stoi(destinationPortRange[0]);
-        int destinationPortEnd = stoi(destinationPortRange[1]);
-
-        if (sourcePortEnd - sourcePortStart !=
-            destinationPortEnd - destinationPortStart) {
-          throw TunnelParseException(
-              "source/destination port range must have same length");
-        } else {
-          int portRangeLength = sourcePortEnd - sourcePortStart + 1;
-          for (int i = 0; i < portRangeLength; ++i) {
-            PortForwardSourceRequest pfsr;
-            pfsr.mutable_source()->set_name("localhost");
-            pfsr.mutable_source()->set_port(sourcePortStart + i);
-            pfsr.mutable_destination()->set_port(destinationPortStart + i);
-            pfsrs.push_back(pfsr);
-          }
-        }
-      } else if (sourceDestination[0].find('-') != string::npos ||
-                 sourceDestination[1].find('-') != string::npos) {
-        throw TunnelParseException(
-            "Invalid port range syntax: if source is a range, "
-            "destination must be a range (and vice versa)");
-      } else {
-        PortForwardSourceRequest pfsr;
-        pfsr.mutable_source()->set_name("localhost");
-        pfsr.mutable_source()->set_port(stoi(sourceDestination[0]));
-        pfsr.mutable_destination()->set_port(stoi(sourceDestination[1]));
-        pfsrs.push_back(pfsr);
-      }
-    } catch (const TunnelParseException& e) {
-      throw e;
-    } catch (const std::logic_error& lr) {
-      throw TunnelParseException("Invalid tunnel argument '" + input +
-                                 "': " + lr.what());
+  } else {
+    // no commas
+    auto tunnelArg = splitByComma[0];
+    vector<string> sourceDestination = split(tunnelArg, ':');
+    if (sourceDestination.size() <= 2) {
+      // et style tunnel arg
+      processEtStyleTunnelArg(pfsrs, sourceDestination, input);
+    } else {
+      // ssh style tunnel arg
+      // -L [bind_address:]port:host:hostport (supported with bind_address)
+      // -L [bind_address:]port:remote_socket (not supported yet)
+      // -L local_socket:host:hostport (not supported yet)
+      // -L local_socket:remote_socket (not supported yet)
+      auto sshStyleArgParts = parseSshTunnelArg(tunnelArg);
+      PortForwardSourceRequest pfsr;
+      pfsr.mutable_source()->set_name(sshStyleArgParts[0]);
+      pfsr.mutable_source()->set_port(stoi(sshStyleArgParts[1]));
+      pfsr.mutable_destination()->set_name(sshStyleArgParts[2]);
+      pfsr.mutable_destination()->set_port(stoi(sshStyleArgParts[3]));
+      pfsrs.push_back(pfsr);
     }
   }
   return pfsrs;

--- a/src/base/TunnelUtils.hpp
+++ b/src/base/TunnelUtils.hpp
@@ -11,6 +11,8 @@ namespace et {
  */
 vector<PortForwardSourceRequest> parseRangesToRequests(const string& input);
 
+vector<string> parseSshTunnelArg(const string& input);
+
 /**
  * @brief Thrown when an invalid tunnel source/destination string is
  * encountered.

--- a/src/terminal/TerminalClientMain.cpp
+++ b/src/terminal/TerminalClientMain.cpp
@@ -109,11 +109,11 @@ int main(int argc, char** argv) {
         ("t,tunnel",
          "Tunnel: Array of source:destination ports or "
          "srcStart-srcEnd:dstStart-dstEnd (inclusive) port ranges (e.g. "
-         "10080:80,10443:443, 10090-10092:8000-8002)",
+         "10080:80,10443:443, 10090-10092:8000-8002) or ssh-style -L/-R "
+         "argument. Defaults to localhost for bind address unless ssh-style "
+         "tunnel argument is used.",
          cxxopts::value<std::string>())  //
-        ("r,reversetunnel",
-         "Reverse Tunnel: Array of source:destination ports or "
-         "srcStart-srcEnd:dstStart-dstEnd (inclusive) port ranges",
+        ("r,reversetunnel", "Reverse Tunnel: See doc for -t/--tunnel.",
          cxxopts::value<std::string>())  //
         ("jumphost", "jumphost between localhost and destination",
          cxxopts::value<std::string>())  //


### PR DESCRIPTION
In https://github.com/MisterTea/EternalTerminal/pull/600 (solved https://github.com/MisterTea/EternalTerminal/issues/587), a security hole was fixed where we bind tunnels to
localhost rather than the default wildcard address (0.0.0.0/::).
However, there might be cases where users want to be explicit with their
bind address (and possibly even proactively specifiy 0.0.0.0, which is
their choice and the networking/security logistics of that should be
well understood). This allows the --tunnel and --reversetunnel et client
options to support ssh-style (-L/-R) arguments while maintaining
backwards compat with the 'et-style' args (port1:port2 or
porta-portb:portc-portd or named pipe arg1:arg2).

Note, it only currently supports the 4 part style -L/-R argument:

```
-L [bind_address:]port:host:hostport
```

Fixes #604

Testing:

Unit tests:

```
./et-test
....
===============================================================================
All tests passed (418 assertions in 38 test cases)
```

Default (--tunnel):
```
 ❯ ./et dev:8080 -t 8888:9999
 ❯ sudo lsof -i -P | grep LISTEN | grep 8888                                                                                                                                 13:54:00  12.18.25  100% █
et        49472        jwshort   12u  IPv6 0x72d6e5e66faae59d      0t0    TCP localhost:8888 (LISTEN)
et        49472        jwshort   13u  IPv4 0xae1c4d56c496e8b5      0t0    TCP localhost:8888 (LISTEN)
```

Default (--reversetunnel):
```
 ❯ ./et dev:8080 -r 8888:9999
  ❯ sudo ss -lptn | grep 8888                                                                                                                                                          13:55:59  12.18.25
LISTEN 0      32                                  127.0.0.1:8888       0.0.0.0:*    users:(("etserver",pid=2336619,fd=30))
LISTEN 0      32                                      [::1]:8888          [::]:*    users:(("etserver",pid=2336619,fd=29))
```

ssh style ipv4 (--tunnel):
```
 ❯ ./et dev:8080 -t 0.0.0.0:8888:localhost:9999
❯ sudo lsof -i -P | grep LISTEN | grep 8888                                                                                                                                 13:54:04  12.18.25  100% █
et        51762        jwshort   11u  IPv4 0x639f7a544999ea02      0t0    TCP *:8888 (LISTEN)
```

ssh style ipv6 (--tunnel):
```
 ❯ ./et dev:8080 -t "[::]:8888:localhost:9999"
 ❯ sudo lsof -i -P | grep LISTEN | grep 8888                                                                                                                                 13:57:24  12.18.25  100% █
et        52376        jwshort   11u  IPv6 0x589a8053e09a0608      0t0    TCP *:8888 (LISTEN)
```

ssh style ipv4 (--reversetunnel):
```
 ❯ ./et dev:8080 -r "0.0.0.0:8888:localhost:9999"
 ❯ sudo ss -lptn | grep 8888                                                                                                                                                          13:59:51  12.18.25
LISTEN 0      32                                    0.0.0.0:8888       0.0.0.0:*    users:(("etserver",pid=2336619,fd=32))
```

ssh style ipv6 (--reversetunnel):
```
 ❯ ./et dev:8080 -r "[::]:8888:localhost:9999"
 ❯ sudo ss -lptn | grep 8888                                                                                                                                                          14:00:49  12.18.25
LISTEN 0      32                                       [::]:8888          [::]:*    users:(("etserver",pid=2336619,fd=33))
```