### PR TITLE
Fix errno corruption causing spurious ENOENT crashes in et client

### DIFF
--- a/src/terminal/TerminalClient.cpp
+++ b/src/terminal/TerminalClient.cpp
@@ -252,7 +252,7 @@ void TerminalClient::run(const string& command, const bool noexit) {
 #else
           if (console) {
             int rc = ::read(consoleFd, b, BUF_SIZE);
-            FATAL_FAIL(rc);
+            int savedErrno = errno;  // Save errno before any logging
             if (rc > 0) {
               // VLOG(1) << "Sending byte: " << int(b) << " " << char(b) << " "
               // << connection->getWriter()->getSequenceNumber();
@@ -263,6 +263,17 @@ void TerminalClient::run(const string& command, const bool noexit) {
               connection->writePacket(Packet(
                   TerminalPacketType::TERMINAL_BUFFER, protoToString(tb)));
               keepaliveTime = time(NULL) + keepaliveDuration;
+            } else if (rc == 0) {
+              LOG(INFO) << "Console EOF";
+              break;
+            } else {
+              if (savedErrno == EAGAIN || savedErrno == EWOULDBLOCK) {
+                // Transient error, retry
+              } else {
+                LOG(INFO) << "Console read error: (" << savedErrno
+                          << "): " << strerror(savedErrno);
+                break;
+              }
             }
           }
 #endif


### PR DESCRIPTION
## Summary

Fixes the client-side twin of #726. `TerminalClient::run()` has the same `FATAL_FAIL(rc)` pattern after `read(consoleFd)` that was fixed server-side in `UserTerminalHandler::runUserTerminal()`.

- `et -c "command"` crashes with `FATAL ... Error: (2): No such file or directory`
- The ENOENT comes from the easylogging++ logging library corrupting errno, not from the actual `read()` failure
- Sessions using `-c` cannot complete; the client aborts before output is returned

## The Bug

In `TerminalClient.cpp` (non-Windows path):

```cpp
int rc = ::read(consoleFd, b, BUF_SIZE);
FATAL_FAIL(rc);  // ← errno already corrupted by this point
```

When `read()` returns -1 (e.g. during connection teardown after a `-c` command completes), `FATAL_FAIL` reads errno — but the logging infrastructure has already overwritten it with ENOENT from internal file operations.

**Reproduction:** `et hostname -c "echo hello"` → crashes every time on macOS (tested with 6.2.11 client, 6.2.10 server, both arm64).

## The Fix

Same pattern as #726:

1. **Save errno immediately** after `read()` before any logging
2. **Handle errors gracefully** instead of `FATAL_FAIL`:
   - `rc > 0`: success, process data (unchanged)
   - `rc == 0`: EOF, clean session end
   - `rc == -1` with `EAGAIN`/`EWOULDBLOCK`: transient, retry
   - `rc == -1` with other errors: log correct errno, clean shutdown

## Testing

- Built and tested on macOS arm64 (Sequoia 15.5)
- `et host -c "echo hello"` exits cleanly instead of crashing
- Plain `et host` interactive sessions unaffected
- `-c` with `-e` (noexit) works correctly