### PR TITLE
Fix missing console output mode causing tmux scroll artifacts

### DIFF
--- a/src/terminal/PseudoTerminalConsole.hpp
+++ b/src/terminal/PseudoTerminalConsole.hpp
@@ -31,8 +31,10 @@ class PseudoTerminalConsole : public Console {
 #ifdef WIN32
     auto hstdin = GetStdHandle(STD_INPUT_HANDLE);
     SetConsoleMode(hstdin, ENABLE_VIRTUAL_TERMINAL_INPUT);
-    // auto hstdout = GetStdHandle(STD_OUTPUT_HANDLE);
-    // SetConsoleMode(hstdout, 0/*ENABLE_VIRTUAL_TERMINAL_PROCESSING*/);
+    auto hstdout = GetStdHandle(STD_OUTPUT_HANDLE);
+    SetConsoleMode(hstdout, ENABLE_PROCESSED_OUTPUT |
+                                ENABLE_VIRTUAL_TERMINAL_PROCESSING |
+                                DISABLE_NEWLINE_AUTO_RETURN);
 #else
     termios terminal_local;
     tcgetattr(0, &terminal_local);


### PR DESCRIPTION
The stdout console mode was never configured on Windows. The code had commented-out lines that would have set the mode to 0 (disabling VT processing entirely), which is also incorrect.
Without ENABLE_VIRTUAL_TERMINAL_PROCESSING, ConPTY doesn't properly interpret cursor-positioning and scroll-region VT sequences from tmux. Without DISABLE_NEWLINE_AUTO_RETURN, cursor auto-returns to column 0 when text reaches the right edge, causing the tmux status indicator to "leak" downward and clip subsequent lines.
The fix sets the correct output mode flags:
ENABLE_PROCESSED_OUTPUT: basic output processing
ENABLE_VIRTUAL_TERMINAL_PROCESSING: interpret VT escape sequences DISABLE_NEWLINE_AUTO_RETURN: prevent auto carriage return on wrap This matches the Unix path which uses cfmakeraw() to put both input and output in raw mode.

Repro/test procedure:
Connect from windows to linux using ET
tmux
ls -- help
scroll up
The "status" indicator gets duplicated on every line and some text gets clipped.