### PR TITLE
Add Nix flake support and a NixOS module

### DIFF
--- a/2026-03-28-pr.md
+++ b/2026-03-28-pr.md
@@ -1,0 +1,23 @@
+# PR Title
+
+Add Nix flake support and fix musl build configuration
+
+# PR Body
+
+## Summary
+
+- add a Nix flake with a default package, dev shell, portable musl build, and exported NixOS module
+- add a NixOS module plus README and maintainer docs for running `etserver` from declarative config
+- fix the non-vcpkg and musl build path by gating Catch2 on `BUILD_TESTING`, adding protobuf/absl/`utf8_range` link handling, and improving static `libunwind` linking
+- make `format.sh` work in Nix environments by falling back to `clang-format` or `nix run` when `clang-format-18` is not present
+
+## Testing
+
+- `bash format.sh`
+- `nix develop path:. --command bash -lc 'cmake -S . -B build -GNinja -DDISABLE_VCPKG=ON -DDISABLE_TELEMETRY=ON'`
+- `nix develop path:. --command bash -lc 'cmake --build build -j"$(nproc)"'`
+- `nix develop path:. --command bash -lc 'ctest --test-dir build --parallel "$(nproc)"'`
+
+## Notes
+
+- this keeps the Nix and musl work without reintroducing generated `build-musl/` artifacts or oversized binaries

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,10 +128,13 @@ find_package(Sanitizers REQUIRED)
 find_package(Threads REQUIRED)
 find_package(sodium REQUIRED)
 find_package(Protobuf REQUIRED)
+find_package(utf8_range CONFIG REQUIRED)
 find_package(Unwind)
 
 if(DISABLE_VCPKG)
-  add_subdirectory(${EXTERNAL_DIR}/Catch2)
+  if(BUILD_TESTING)
+    add_subdirectory(${EXTERNAL_DIR}/Catch2)
+  endif()
   add_subdirectory(${EXTERNAL_DIR}/cxxopts)
   add_subdirectory(${EXTERNAL_DIR}/cpp-httplib)
   add_subdirectory(${EXTERNAL_DIR}/json)
@@ -144,7 +147,9 @@ if(DISABLE_VCPKG)
     ${EXTERNAL_DIR}/cxxopts/include
   )
 else()
-  find_package(Catch2 CONFIG REQUIRED)
+  if(BUILD_TESTING)
+    find_package(Catch2 CONFIG REQUIRED)
+  endif()
   find_package(httplib CONFIG REQUIRED)
   find_package(cxxopts CONFIG REQUIRED)
   find_package(nlohmann_json CONFIG REQUIRED)
@@ -260,8 +265,57 @@ set(PROTOBUF_LIBS protobuf::libprotobuf)
 
 if(Protobuf_VERSION VERSION_GREATER_EQUAL 4)
   find_package(absl REQUIRED)
+  set(PROTOBUF_ABSL_LIBS
+    absl::absl_check
+    absl::absl_log
+    absl::algorithm
+    absl::base
+    absl::bind_front
+    absl::bits
+    absl::btree
+    absl::cleanup
+    absl::cord
+    absl::core_headers
+    absl::debugging
+    absl::die_if_null
+    absl::dynamic_annotations
+    absl::flags
+    absl::flat_hash_map
+    absl::flat_hash_set
+    absl::function_ref
+    absl::hash
+    absl::layout
+    absl::log_globals
+    absl::log_initialize
+    absl::log_internal_check_op
+    absl::log_severity
+    absl::memory
+    absl::node_hash_map
+    absl::node_hash_set
+    absl::optional
+    absl::random_distributions
+    absl::random_random
+    absl::span
+    absl::status
+    absl::statusor
+    absl::strings
+    absl::synchronization
+    absl::time
+    absl::utility
+    utf8_range::utf8_validity
+    utf8_range::utf8_range
+  )
 
-  set(PROTOBUF_LIBS ${PROTOBUF_LIBS} absl::log_internal_check_op)
+  if(Protobuf_USE_STATIC_LIBS)
+    set(PROTOBUF_LIBS
+      -Wl,--start-group
+      ${PROTOBUF_LIBS}
+      ${PROTOBUF_ABSL_LIBS}
+      -Wl,--end-group
+    )
+  else()
+    set(PROTOBUF_LIBS ${PROTOBUF_LIBS} ${PROTOBUF_ABSL_LIBS})
+  endif()
 endif()
 
 if(SELINUX_FOUND)
@@ -321,7 +375,6 @@ else()
     resolv
     atomic
     stdc++fs
-    anl
   )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -266,57 +266,8 @@ set(PROTOBUF_LIBS protobuf::libprotobuf)
 if(Protobuf_VERSION VERSION_GREATER_EQUAL 4)
   find_package(absl REQUIRED)
   find_package(utf8_range CONFIG REQUIRED)
-  set(PROTOBUF_ABSL_LIBS
-    absl::absl_check
-    absl::absl_log
-    absl::algorithm
-    absl::base
-    absl::bind_front
-    absl::bits
-    absl::btree
-    absl::cleanup
-    absl::cord
-    absl::core_headers
-    absl::debugging
-    absl::die_if_null
-    absl::dynamic_annotations
-    absl::flags
-    absl::flat_hash_map
-    absl::flat_hash_set
-    absl::function_ref
-    absl::hash
-    absl::layout
-    absl::log_globals
-    absl::log_initialize
-    absl::log_internal_check_op
-    absl::log_severity
-    absl::memory
-    absl::node_hash_map
-    absl::node_hash_set
-    absl::optional
-    absl::random_distributions
-    absl::random_random
-    absl::span
-    absl::status
-    absl::statusor
-    absl::strings
-    absl::synchronization
-    absl::time
-    absl::utility
-    utf8_range::utf8_validity
-    utf8_range::utf8_range
-  )
 
-  if(Protobuf_USE_STATIC_LIBS)
-    set(PROTOBUF_LIBS
-      -Wl,--start-group
-      ${PROTOBUF_LIBS}
-      ${PROTOBUF_ABSL_LIBS}
-      -Wl,--end-group
-    )
-  else()
-    set(PROTOBUF_LIBS ${PROTOBUF_LIBS} ${PROTOBUF_ABSL_LIBS})
-  endif()
+  set(PROTOBUF_LIBS ${PROTOBUF_LIBS} absl::log_internal_check_op utf8_range::utf8_validity utf8_range::utf8_range)
 endif()
 
 if(SELINUX_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,8 @@ project(EternalTCP VERSION 6.2.11 LANGUAGES C CXX)
 
 include(CMakeFindDependencyMacro)
 
+option(BUILD_TESTING "Build tests" ON)
+
 # Add cmake script directory.
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 set(CMAKE_MODULE_PATH "${EXTERNAL_DIR}/sanitizers-cmake/cmake" ${CMAKE_MODULE_PATH})
@@ -215,7 +217,6 @@ endif()
 
 option(CODE_COVERAGE "Enable code coverage" OFF)
 option(FUZZING "Enable builds for fuzz testing" OFF)
-option(BUILD_TESTING "Build tests" ON)
 option(DISABLE_CRASH_LOG "Disable installing easylogging crash handler" OFF)
 option(INSTALL_BASH_COMPLETION "Install bash completion script" ON)
 option(INSTALL_ZSH_COMPLETION "Install zsh completion script" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,6 @@ find_package(Sanitizers REQUIRED)
 find_package(Threads REQUIRED)
 find_package(sodium REQUIRED)
 find_package(Protobuf REQUIRED)
-find_package(utf8_range CONFIG REQUIRED)
 find_package(Unwind)
 
 if(DISABLE_VCPKG)
@@ -266,6 +265,7 @@ set(PROTOBUF_LIBS protobuf::libprotobuf)
 
 if(Protobuf_VERSION VERSION_GREATER_EQUAL 4)
   find_package(absl REQUIRED)
+  find_package(utf8_range CONFIG REQUIRED)
   set(PROTOBUF_ABSL_LIBS
     absl::absl_check
     absl::absl_log

--- a/NIXOS-readme.md
+++ b/NIXOS-readme.md
@@ -1,0 +1,481 @@
+# EternalTerminal on NixOS
+
+This file captures the NixOS-specific knowledge gathered while bringing
+EternalTerminal up in a Nix development shell, turning that shell into a real
+package, and adding a NixOS module.
+
+## What was added
+
+- `flake.nix`
+  - dev shell
+  - package output
+  - NixOS module export
+- `default.nix`
+  - NixOS module for `etserver`
+- `README.md`
+  - short NixOS usage snippet
+- `CMakeLists.txt`
+  - small packaging fix so Catch2 is only required when `BUILD_TESTING=ON`
+
+## Main outcomes
+
+- The repo now has a working Nix dev shell.
+- The repo now has a buildable flake package.
+- The repo now exports a NixOS module.
+- The package build works without vcpkg.
+- The package installs the expected binaries and shell completions.
+- The module generates `/etc/et.cfg` and runs the packaged `etserver` binary.
+
+## Build facts discovered from the repo
+
+The CMake build depends on these main tools and libraries on Linux:
+
+- `cmake`
+- `ninja`
+- `pkg-config`
+- `openssl`
+- `zlib`
+- `libsodium`
+- `protobuf` and `protoc`
+- `libunwind`
+- `libutempter`
+- `libselinux`
+
+Other tools that were useful in the dev shell:
+
+- `autoconf`
+- `automake`
+- `libtool`
+- `curl`
+- `git`
+- `zip`
+- `unzip`
+- `gdb`
+- `llvmPackages_18.clang-tools`
+- `bash-completion`
+
+Important CMake details:
+
+- `-DDISABLE_VCPKG=ON` is the right path for Nix.
+- `-DDISABLE_TELEMETRY=ON` was used for local build verification.
+- `-DDISABLE_SENTRY=ON` is used in the package build.
+- `protobuf_generate_cpp` is used for `proto/ET.proto` and `proto/ETerminal.proto`.
+- Vendored submodules are used for `Catch2`, `cxxopts`, `cpp-httplib`, `json`, and other bundled code when vcpkg is disabled.
+
+## Problems hit during the run
+
+### 1. Untracked flake behavior
+
+Running `nix develop --command ...` against an untracked `flake.nix` inside a
+git repo failed.
+
+Working workaround during development:
+
+```bash
+nix develop path:. --command <command>
+```
+
+Using `path:.` lets Nix treat the repo as a path flake instead of insisting on a
+tracked git flake.
+
+### 2. Deprecated clang-tools attribute
+
+`clang-tools_18` is deprecated in current `nixpkgs`.
+
+Correct replacement:
+
+```nix
+pkgs.llvmPackages_18.clang-tools
+```
+
+### 3. Missing submodule content
+
+Early builds failed because the repo had incomplete submodule checkouts.
+Notable breakages:
+
+- missing `external/sanitizers-cmake`
+- missing `external/Catch2/CMakeLists.txt`
+- missing `external/easyloggingpp/src/easylogging++.h`
+- missing `external/ThreadPool/ThreadPool.h`
+- missing `external/base64/base64.h`
+
+Useful recovery commands:
+
+```bash
+git submodule sync --recursive
+git submodule update --init --recursive
+```
+
+Some submodules also needed their worktrees restored with:
+
+```bash
+git -C external/easyloggingpp reset --hard HEAD
+git -C external/ThreadPool reset --hard HEAD
+git -C external/base64 reset --hard HEAD
+```
+
+### 4. Bash completion warning
+
+CMake warned when `bash-completion` was missing from the shell. Adding
+`bash-completion` fixed completion install detection.
+
+### 5. Package build pulling in local build artifacts
+
+Using the repo directly as package source let local build outputs leak into the
+source tree view. The package now uses `lib.cleanSourceWith` to filter out:
+
+- `build/`
+- `cov_build/`
+- `result/`
+
+### 6. Catch2 being built in package mode
+
+Even with `BUILD_TESTING=OFF`, `CMakeLists.txt` still pulled in Catch2. That was
+slower and unnecessary for package builds. The fix was to gate Catch2 behind
+`BUILD_TESTING` in both the vendored and `find_package` paths.
+
+## Current `flake.nix` design
+
+The flake does three jobs.
+
+### Dev shell
+
+The dev shell is meant for local hacking and manual builds.
+
+Key points:
+
+- inherits the package inputs with `inputsFrom = [ eternalTerminal ];`
+- adds developer tools like clang-format tooling, git, curl, and gdb
+- exports:
+
+```bash
+OPENSSL_ROOT_DIR=${pkgs.openssl.dev}
+CMAKE_PREFIX_PATH=<dev outputs from package inputs>
+```
+
+That shell is enough to run the normal CMake build on NixOS.
+
+### Package output
+
+The package is `packages.default` and `packages.eternal-terminal`.
+
+Key settings:
+
+- `inputs.self.submodules = true`
+  - this matters so users of the flake also fetch git submodules
+- `src = cleanedSource`
+- `strictDeps = true`
+- `BUILD_TESTING=OFF`
+- `DISABLE_VCPKG=ON`
+- `DISABLE_SENTRY=ON`
+- `DISABLE_TELEMETRY=ON`
+- explicit completion install directories under `$out`
+
+The package build inputs are:
+
+- `abseil-cpp`
+- `libsodium`
+- `libunwind`
+- `openssl`
+- `protobuf`
+- `zlib`
+- `libselinux` on Linux
+- `libutempter` on Linux
+
+The native build inputs are:
+
+- `cmake`
+- `ninja`
+- `pkg-config`
+- `protobuf`
+
+### NixOS module export
+
+The flake exports:
+
+- `nixosModules.default`
+- `nixosModules.eternalTerminal`
+
+Both point at the same module from `default.nix`.
+
+## Current `default.nix` module design
+
+The module is focused on the server side.
+
+Options:
+
+- `services.eternalTerminal.enable`
+- `services.eternalTerminal.package`
+- `services.eternalTerminal.port`
+- `services.eternalTerminal.openFirewall`
+- `services.eternalTerminal.settings`
+
+Behavior:
+
+- generates `/etc/et.cfg` with `pkgs.formats.ini { }`
+- merges defaults with `services.eternalTerminal.settings`
+- forces `Networking.port` to follow `services.eternalTerminal.port`
+- opens the firewall when `openFirewall = true`
+- starts systemd service `eternal-terminal`
+
+Systemd service command:
+
+```bash
+${cfg.package}/bin/etserver --cfgfile=/etc/et.cfg --logtostdout
+```
+
+Why a custom NixOS service was needed:
+
+- the upstream Debian service file hardcodes `/usr/bin/etserver`
+- it also hardcodes `/etc/et.cfg`
+- Debian packaging also carries maintainer scripts and `/lib/systemd/system` / `/etc`
+  installation behavior that is not appropriate to reuse as-is in a NixOS module
+
+Current default INI settings from the module:
+
+```ini
+[Debug]
+logdirectory = /var/log/eternal-terminal
+logsize = 20971520
+silent = 0
+telemetry = false
+verbose = 0
+```
+
+The module also sets:
+
+- `Networking.port = cfg.port`
+
+Notes:
+
+- importing the module through the flake gives `services.eternalTerminal.package`
+  a sensible default
+- importing `./default.nix` directly requires setting `services.eternalTerminal.package`
+
+## Why the module does not reuse upstream service packaging directly
+
+Upstream packaging in CMake and Debian is install-oriented for classic systems:
+
+- installs binaries under `/usr/bin` or `/usr/local/bin`
+- installs shell completions into system directories
+- packages `systemctl/et.service` into `/lib/systemd/system`
+- packages `etc/et.cfg` into `/etc`
+
+That is fine for `.deb` packaging, but not for a NixOS module. The NixOS module
+instead:
+
+- uses the Nix store path for `etserver`
+- generates the config file from module options
+- lets NixOS own the systemd unit declaration
+
+## Install behavior discovered from upstream CMake
+
+On non-Windows systems, upstream CMake installs these binaries:
+
+- `et`
+- `etserver`
+- `etterminal`
+- `htm`
+- `htmd`
+
+Upstream also installs:
+
+- bash completion as `et`
+- zsh completion as `_et`
+
+Those completions only target the `et` client command.
+
+## Commands that worked during the run
+
+### Local dev shell build
+
+```bash
+nix develop path:. --command bash -lc 'cmake -S . -B build -GNinja -DDISABLE_VCPKG=ON -DDISABLE_TELEMETRY=ON && cmake --build build -j"$(nproc)"'
+```
+
+### Flake output inspection
+
+```bash
+nix flake show path:.
+```
+
+### Package build
+
+```bash
+nix build path:. --no-link
+```
+
+### Portable musl package build
+
+```bash
+nix build path:.#portable-musl -L
+```
+
+This produces a musl/static-flavored package build through the flake package
+output instead of a local CMake tree.
+
+### Manual musl development shell
+
+```bash
+nix develop path:.#portable-musl
+```
+
+This shell is meant for fast local iteration on the musl target without waiting
+for a full Nix package rebuild each time.
+
+### Manual musl configure and build
+
+```bash
+rm -rf build-musl
+cmake -S . -B build-musl -GNinja \
+  -DDISABLE_VCPKG=ON \
+  -DDISABLE_TELEMETRY=ON \
+  -DDISABLE_SENTRY=ON \
+  -DBUILD_TESTING=OFF \
+  -DBUILD_SHARED_LIBS=OFF \
+  -DCMAKE_DISABLE_FIND_PACKAGE_SELinux=TRUE \
+  -DCMAKE_DISABLE_FIND_PACKAGE_UTempter=TRUE \
+  -DOPENSSL_USE_STATIC_LIBS=TRUE \
+  -DProtobuf_USE_STATIC_LIBS=ON \
+  -Dsodium_USE_STATIC_LIBS=ON
+cmake --build build-musl -j"$(nproc)" --target et etserver
+```
+
+For repeated tries after a source change, use the incremental build command:
+
+```bash
+cmake --build build-musl -j"$(nproc)" --target et etserver
+```
+
+To print full linker commands during debugging:
+
+```bash
+ninja -C build-musl -v et etserver
+```
+
+### Rebuild and test in the dev shell
+
+```bash
+nix develop path:. --command bash -lc 'cmake -S . -B build -GNinja -DDISABLE_VCPKG=ON -DDISABLE_TELEMETRY=ON && cmake --build build -j"$(nproc)" && ctest --test-dir build --parallel "$(nproc)"'
+```
+
+## Verification completed in this run
+
+The following checks succeeded.
+
+### Flake evaluation
+
+- `nix flake show path:.` showed:
+  - `devShells.default`
+  - `packages.default`
+  - `packages.eternal-terminal`
+  - `nixosModules.default`
+  - `nixosModules.eternalTerminal`
+
+### Module shape
+
+- `default.nix` evaluates as a module function
+
+### Package build
+
+- `nix build path:. --no-link` produced a package successfully
+- `nix build path:.#portable-musl -L` produced the musl/static package successfully
+
+Installed binaries verified in the built output:
+
+- `et`
+- `etserver`
+- `etterminal`
+- `htm`
+- `htmd`
+
+Installed completions verified in the built output:
+
+- bash: `share/bash-completion/completions/et`
+- zsh: `share/zsh/site-functions/_et`
+
+### Manual musl build
+
+- `nix develop path:.#portable-musl` opened a working musl-oriented dev shell
+- local incremental build succeeded with `ninja et etserver` in `build-musl/`
+
+### Test run
+
+- `ctest` passed
+- result: `110/110` tests passed
+
+## Warnings seen but not blocking
+
+The codebase still emits warnings during builds.
+
+Notable ones:
+
+- `easylogging++` `wcstombs` warning with glibc fortify
+- ignored return value warnings in `DaemonCreator.cpp`
+- ignored return value warnings in `TerminalHandler.cpp`
+
+There was also repeated `pkg-config` chatter about `libsepol` while probing
+`libselinux`, but CMake still found SELinux and continued.
+
+## Current recommended NixOS usage
+
+Example flake-based NixOS integration:
+
+```nix
+{
+  inputs.et.url = "github:MisterTea/EternalTerminal";
+
+  outputs = { nixpkgs, et, ... }: {
+    nixosConfigurations.my-host = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      modules = [
+        et.nixosModules.default
+        ({ ... }: {
+          services.eternalTerminal = {
+            enable = true;
+            openFirewall = true;
+            port = 2022;
+            settings.Networking.bind_ip = "0.0.0.0";
+          };
+        })
+      ];
+    };
+  };
+}
+```
+
+After activation, manage it like any other NixOS service.
+
+Useful checks:
+
+```bash
+systemctl status eternal-terminal
+which et
+```
+
+## Maintainer notes
+
+- Keep `inputs.self.submodules = true` in the flake.
+- Keep using `path:.` for local one-off flake commands while files are untracked.
+- Keep the package source filtered so local build outputs do not contaminate Nix builds.
+- Keep Catch2 gated behind `BUILD_TESTING` so package builds stay smaller and faster.
+- Keep `devShells.portable-musl` aligned with the `packages.portable-musl` inputs so
+  local musl debugging matches the flake build.
+- The musl/static path needs explicit protobuf, absl, utf8_range, and libunwind static
+  link handling in CMake.
+- If a future package build fails on missing vendored code, check submodule state first.
+- If a future CMake configure warns about missing completion directories, check that
+  `bash-completion` is present and the completion install dirs are still passed in
+  `cmakeFlags`.
+
+## Current working tree note
+
+At the end of this run, the Nix-related working tree changes were:
+
+- modified `CMakeLists.txt`
+- new `flake.nix`
+- new `default.nix`
+- generated `flake.lock`
+- updated `README.md`
+
+This file was added afterward to capture the run.

--- a/NIXOS-readme.md
+++ b/NIXOS-readme.md
@@ -1,425 +1,45 @@
 # EternalTerminal on NixOS
 
-This file captures the NixOS-specific knowledge gathered while bringing
-EternalTerminal up in a Nix development shell, turning that shell into a real
-package, and adding a NixOS module.
+This repo adds Nix support on top of the upstream CMake and Debian-style packaging.
 
-## What was added
+## Changes from base
 
-- `flake.nix`
-  - dev shell
-  - package output
-  - NixOS module export
-- `default.nix`
-  - NixOS module for `etserver`
-- `README.md`
-  - short NixOS usage snippet
-- `CMakeLists.txt`
-  - small packaging fix so Catch2 is only required when `BUILD_TESTING=ON`
+- `flake.nix` adds:
+  - `packages.default` and `packages.eternal-terminal`
+  - `devShells.default`
+  - `nixosModules.default` and `nixosModules.eternalTerminal`
+- `default.nix` adds a NixOS module for running `etserver`
+- `CMakeLists.txt` gates Catch2 behind `BUILD_TESTING=ON` so Nix package builds do not pull test-only dependencies
 
-## Main outcomes
+## Nix behavior in this repo
 
-- The repo now has a working Nix dev shell.
-- The repo now has a buildable flake package.
-- The repo now exports a NixOS module.
-- The package build works without vcpkg.
-- The package installs the expected binaries and shell completions.
-- The module generates `/etc/et.cfg` and runs the packaged `etserver` binary.
+- Flake builds use `DISABLE_VCPKG=ON`, `DISABLE_SENTRY=ON`, `DISABLE_TELEMETRY=ON`, and `BUILD_TESTING=OFF`.
+- The flake uses `inputs.self.submodules = true`, so consumers fetch the vendored submodules needed by the build.
+- The package source is filtered with `lib.cleanSourceWith` so local `build/`, `cov_build/`, and `result/` directories do not leak into Nix builds.
 
-## Build facts discovered from the repo
+## Using it with Nix
 
-The CMake build depends on these main tools and libraries on Linux:
-
-- `cmake`
-- `ninja`
-- `pkg-config`
-- `openssl`
-- `zlib`
-- `libsodium`
-- `protobuf` and `protoc`
-- `libunwind`
-- `libutempter`
-- `libselinux`
-
-Other tools that were useful in the dev shell:
-
-- `autoconf`
-- `automake`
-- `libtool`
-- `curl`
-- `git`
-- `zip`
-- `unzip`
-- `gdb`
-- `llvmPackages_18.clang-tools`
-- `bash-completion`
-
-Important CMake details:
-
-- `-DDISABLE_VCPKG=ON` is the right path for Nix.
-- `-DDISABLE_TELEMETRY=ON` was used for local build verification.
-- `-DDISABLE_SENTRY=ON` is used in the package build.
-- `protobuf_generate_cpp` is used for `proto/ET.proto` and `proto/ETerminal.proto`.
-- Vendored submodules are used for `Catch2`, `cxxopts`, `cpp-httplib`, `json`, and other bundled code when vcpkg is disabled.
-
-## Problems hit during the run
-
-### 1. Untracked flake behavior
-
-Running `nix develop --command ...` against an untracked `flake.nix` inside a
-git repo failed.
-
-Working workaround during development:
-
-```bash
-nix develop path:. --command <command>
-```
-
-Using `path:.` lets Nix treat the repo as a path flake instead of insisting on a
-tracked git flake.
-
-### 2. Deprecated clang-tools attribute
-
-`clang-tools_18` is deprecated in current `nixpkgs`.
-
-Correct replacement:
-
-```nix
-pkgs.llvmPackages_18.clang-tools
-```
-
-### 3. Missing submodule content
-
-Early builds failed because the repo had incomplete submodule checkouts.
-Notable breakages:
-
-- missing `external/sanitizers-cmake`
-- missing `external/Catch2/CMakeLists.txt`
-- missing `external/easyloggingpp/src/easylogging++.h`
-- missing `external/ThreadPool/ThreadPool.h`
-- missing `external/base64/base64.h`
-
-Useful recovery commands:
-
-```bash
-git submodule sync --recursive
-git submodule update --init --recursive
-```
-
-Some submodules also needed their worktrees restored with:
-
-```bash
-git -C external/easyloggingpp reset --hard HEAD
-git -C external/ThreadPool reset --hard HEAD
-git -C external/base64 reset --hard HEAD
-```
-
-### 4. Bash completion warning
-
-CMake warned when `bash-completion` was missing from the shell. Adding
-`bash-completion` fixed completion install detection.
-
-### 5. Package build pulling in local build artifacts
-
-Using the repo directly as package source let local build outputs leak into the
-source tree view. The package now uses `lib.cleanSourceWith` to filter out:
-
-- `build/`
-- `cov_build/`
-- `result/`
-
-### 6. Catch2 being built in package mode
-
-Even with `BUILD_TESTING=OFF`, `CMakeLists.txt` still pulled in Catch2. That was
-slower and unnecessary for package builds. The fix was to gate Catch2 behind
-`BUILD_TESTING` in both the vendored and `find_package` paths.
-
-## Current `flake.nix` design
-
-The flake does three jobs.
-
-### Dev shell
-
-The dev shell is meant for local hacking and manual builds.
-
-Key points:
-
-- inherits the package inputs with `inputsFrom = [ eternalTerminal ];`
-- adds developer tools like clang-format tooling, git, curl, and gdb
-- exports:
-
-```bash
-OPENSSL_ROOT_DIR=${pkgs.openssl.dev}
-CMAKE_PREFIX_PATH=<dev outputs from package inputs>
-```
-
-That shell is enough to run the normal CMake build on NixOS.
-
-### Package output
-
-The package is `packages.default` and `packages.eternal-terminal`.
-
-Key settings:
-
-- `inputs.self.submodules = true`
-  - this matters so users of the flake also fetch git submodules
-- `src = cleanedSource`
-- `strictDeps = true`
-- `BUILD_TESTING=OFF`
-- `DISABLE_VCPKG=ON`
-- `DISABLE_SENTRY=ON`
-- `DISABLE_TELEMETRY=ON`
-- explicit completion install directories under `$out`
-
-The package build inputs are:
-
-- `abseil-cpp`
-- `libsodium`
-- `libunwind`
-- `openssl`
-- `protobuf`
-- `zlib`
-- `libselinux` on Linux
-- `libutempter` on Linux
-
-The native build inputs are:
-
-- `cmake`
-- `ninja`
-- `pkg-config`
-- `protobuf`
-
-### NixOS module export
-
-The flake exports:
-
-- `nixosModules.default`
-- `nixosModules.eternalTerminal`
-
-Both point at the same module from `default.nix`.
-
-## Current `default.nix` module design
-
-The module is focused on the server side.
-
-Options:
-
-- `services.eternalTerminal.enable`
-- `services.eternalTerminal.package`
-- `services.eternalTerminal.port`
-- `services.eternalTerminal.openFirewall`
-- `services.eternalTerminal.settings`
-
-Behavior:
-
-- generates `/etc/et.cfg` with `pkgs.formats.ini { }`
-- merges defaults with `services.eternalTerminal.settings`
-- forces `Networking.port` to follow `services.eternalTerminal.port`
-- opens the firewall when `openFirewall = true`
-- starts systemd service `eternal-terminal`
-
-Systemd service command:
-
-```bash
-${cfg.package}/bin/etserver --cfgfile=/etc/et.cfg --logtostdout
-```
-
-Why a custom NixOS service was needed:
-
-- the upstream Debian service file hardcodes `/usr/bin/etserver`
-- it also hardcodes `/etc/et.cfg`
-- Debian packaging also carries maintainer scripts and `/lib/systemd/system` / `/etc`
-  installation behavior that is not appropriate to reuse as-is in a NixOS module
-
-Current default INI settings from the module:
-
-```ini
-[Debug]
-logdirectory = /var/log/eternal-terminal
-logsize = 20971520
-silent = 0
-telemetry = false
-verbose = 0
-```
-
-The module also sets:
-
-- `Networking.port = cfg.port`
-
-Notes:
-
-- importing the module through the flake gives `services.eternalTerminal.package`
-  a sensible default
-- importing `./default.nix` directly requires setting `services.eternalTerminal.package`
-
-## Why the module does not reuse upstream service packaging directly
-
-Upstream packaging in CMake and Debian is install-oriented for classic systems:
-
-- installs binaries under `/usr/bin` or `/usr/local/bin`
-- installs shell completions into system directories
-- packages `systemctl/et.service` into `/lib/systemd/system`
-- packages `etc/et.cfg` into `/etc`
-
-That is fine for `.deb` packaging, but not for a NixOS module. The NixOS module
-instead:
-
-- uses the Nix store path for `etserver`
-- generates the config file from module options
-- lets NixOS own the systemd unit declaration
-
-## Install behavior discovered from upstream CMake
-
-On non-Windows systems, upstream CMake installs these binaries:
-
-- `et`
-- `etserver`
-- `etterminal`
-- `htm`
-- `htmd`
-
-Upstream also installs:
-
-- bash completion as `et`
-- zsh completion as `_et`
-
-Those completions only target the `et` client command.
-
-## Commands that worked during the run
-
-### Local dev shell build
-
-```bash
-nix develop path:. --command bash -lc 'cmake -S . -B build -GNinja -DDISABLE_VCPKG=ON -DDISABLE_TELEMETRY=ON && cmake --build build -j"$(nproc)"'
-```
-
-### Flake output inspection
+For a local checkout, use `path:.`:
 
 ```bash
 nix flake show path:.
-```
-
-### Package build
-
-```bash
+nix develop path:.
 nix build path:. --no-link
 ```
 
-### Portable musl package build
+`nix develop` gives you a shell with the package inputs and the extra developer tools needed for normal CMake work on NixOS.
 
-```bash
-nix build path:.#portable-musl -L
-```
+## Using it with NixOS: module + package
 
-This produces a musl/static-flavored package build through the flake package
-output instead of a local CMake tree.
+Common setup: import the NixOS module for the service, and add the package if you also want the client tools in `PATH`.
 
-### Manual musl development shell
+The module manages the server side:
 
-```bash
-nix develop path:.#portable-musl
-```
+- generates `/etc/et.cfg`
+- starts `etserver` from the selected package
+- opens the configured port when `openFirewall = true`
 
-This shell is meant for fast local iteration on the musl target without waiting
-for a full Nix package rebuild each time.
-
-### Manual musl configure and build
-
-```bash
-rm -rf build-musl
-cmake -S . -B build-musl -GNinja \
-  -DDISABLE_VCPKG=ON \
-  -DDISABLE_TELEMETRY=ON \
-  -DDISABLE_SENTRY=ON \
-  -DBUILD_TESTING=OFF \
-  -DBUILD_SHARED_LIBS=OFF \
-  -DCMAKE_DISABLE_FIND_PACKAGE_SELinux=TRUE \
-  -DCMAKE_DISABLE_FIND_PACKAGE_UTempter=TRUE \
-  -DOPENSSL_USE_STATIC_LIBS=TRUE \
-  -DProtobuf_USE_STATIC_LIBS=ON \
-  -Dsodium_USE_STATIC_LIBS=ON
-cmake --build build-musl -j"$(nproc)" --target et etserver
-```
-
-For repeated tries after a source change, use the incremental build command:
-
-```bash
-cmake --build build-musl -j"$(nproc)" --target et etserver
-```
-
-To print full linker commands during debugging:
-
-```bash
-ninja -C build-musl -v et etserver
-```
-
-### Rebuild and test in the dev shell
-
-```bash
-nix develop path:. --command bash -lc 'cmake -S . -B build -GNinja -DDISABLE_VCPKG=ON -DDISABLE_TELEMETRY=ON && cmake --build build -j"$(nproc)" && ctest --test-dir build --parallel "$(nproc)"'
-```
-
-## Verification completed in this run
-
-The following checks succeeded.
-
-### Flake evaluation
-
-- `nix flake show path:.` showed:
-  - `devShells.default`
-  - `packages.default`
-  - `packages.eternal-terminal`
-  - `nixosModules.default`
-  - `nixosModules.eternalTerminal`
-
-### Module shape
-
-- `default.nix` evaluates as a module function
-
-### Package build
-
-- `nix build path:. --no-link` produced a package successfully
-- `nix build path:.#portable-musl -L` produced the musl/static package successfully
-
-Installed binaries verified in the built output:
-
-- `et`
-- `etserver`
-- `etterminal`
-- `htm`
-- `htmd`
-
-Installed completions verified in the built output:
-
-- bash: `share/bash-completion/completions/et`
-- zsh: `share/zsh/site-functions/_et`
-
-### Manual musl build
-
-- `nix develop path:.#portable-musl` opened a working musl-oriented dev shell
-- local incremental build succeeded with `ninja et etserver` in `build-musl/`
-
-### Test run
-
-- `ctest` passed
-- result: `110/110` tests passed
-
-## Warnings seen but not blocking
-
-The codebase still emits warnings during builds.
-
-Notable ones:
-
-- `easylogging++` `wcstombs` warning with glibc fortify
-- ignored return value warnings in `DaemonCreator.cpp`
-- ignored return value warnings in `TerminalHandler.cpp`
-
-There was also repeated `pkg-config` chatter about `libsepol` while probing
-`libselinux`, but CMake still found SELinux and continued.
-
-## Current recommended NixOS usage
-
-Example flake-based NixOS integration:
+Example flake-based NixOS configuration:
 
 ```nix
 {
@@ -430,7 +50,11 @@ Example flake-based NixOS integration:
       system = "x86_64-linux";
       modules = [
         et.nixosModules.default
-        ({ ... }: {
+        ({ pkgs, ... }: {
+          environment.systemPackages = [
+            et.packages.${pkgs.stdenv.hostPlatform.system}.default
+          ];
+
           services.eternalTerminal = {
             enable = true;
             openFirewall = true;
@@ -444,38 +68,25 @@ Example flake-based NixOS integration:
 }
 ```
 
-After activation, manage it like any other NixOS service.
+Notes:
 
-Useful checks:
+- The module runs the server, but it does not add the client tools to `PATH` by itself. Add the package to `environment.systemPackages` if you also want `et`, `htm`, and the other binaries available interactively.
+- When imported through the flake, `services.eternalTerminal.package` defaults to the flake package.
+- When importing `./default.nix` directly, set `services.eternalTerminal.package` yourself.
+
+## Module options
+
+- `services.eternalTerminal.enable`
+- `services.eternalTerminal.package`
+- `services.eternalTerminal.port`
+- `services.eternalTerminal.openFirewall`
+- `services.eternalTerminal.settings`
+
+`services.eternalTerminal.settings` is written as INI sections into `/etc/et.cfg`. `Networking.port` is always taken from `services.eternalTerminal.port`.
+
+## Service checks
 
 ```bash
 systemctl status eternal-terminal
-which et
+journalctl -u eternal-terminal -b
 ```
-
-## Maintainer notes
-
-- Keep `inputs.self.submodules = true` in the flake.
-- Keep using `path:.` for local one-off flake commands while files are untracked.
-- Keep the package source filtered so local build outputs do not contaminate Nix builds.
-- Keep Catch2 gated behind `BUILD_TESTING` so package builds stay smaller and faster.
-- Keep `devShells.portable-musl` aligned with the `packages.portable-musl` inputs so
-  local musl debugging matches the flake build.
-- The musl/static path needs explicit protobuf, absl, utf8_range, and libunwind static
-  link handling in CMake.
-- If a future package build fails on missing vendored code, check submodule state first.
-- If a future CMake configure warns about missing completion directories, check that
-  `bash-completion` is present and the completion install dirs are still passed in
-  `cmakeFlags`.
-
-## Current working tree note
-
-At the end of this run, the Nix-related working tree changes were:
-
-- modified `CMakeLists.txt`
-- new `flake.nix`
-- new `default.nix`
-- generated `flake.lock`
-- updated `README.md`
-
-This file was added afterward to capture the run.

--- a/README.md
+++ b/README.md
@@ -130,6 +130,34 @@ make
 sudo make install
 ```
 
+### NixOS
+
+If you use flakes, you can import the bundled NixOS module and let it manage
+the package, `/etc/et.cfg`, and the `etserver` service:
+
+```nix
+{
+  inputs.et.url = "github:MisterTea/EternalTerminal";
+
+  outputs = { nixpkgs, et, ... }: {
+    nixosConfigurations.my-host = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      modules = [
+        et.nixosModules.default
+        ({ ... }: {
+          services.eternalTerminal = {
+            enable = true;
+            openFirewall = true;
+            port = 2022;
+            settings.Networking.bind_ip = "0.0.0.0";
+          };
+        })
+      ];
+    };
+  };
+}
+```
+
 ### Windows
 
 Eternal Terminal works under WSL (Windows Subsystem for Linux). Follow the ubuntu instructions.
@@ -148,7 +176,10 @@ You are ready to start using ET!
 
 ## Configuring
 
-If you'd like to modify the server settings (e.g. to change the listening port), edit /etc/et.cfg.
+If you'd like to modify the server settings (e.g. to change the listening
+port), edit `/etc/et.cfg`. On NixOS, set `services.eternalTerminal.settings`
+instead so the generated `/etc/et.cfg` stays in sync with your system
+configuration.
 
 ## Using
 

--- a/cmake/FindUnwind.cmake
+++ b/cmake/FindUnwind.cmake
@@ -12,6 +12,13 @@ if (PKG_CONFIG_FOUND)
   pkg_check_modules(PC_UNWIND QUIET libunwind)
 endif()
 
+if (PC_UNWIND_FOUND)
+  set(Unwind_EXTRA_LIBRARIES ${PC_UNWIND_LINK_LIBRARIES})
+  if (PC_UNWIND_STATIC_LINK_LIBRARIES)
+    set(Unwind_STATIC_EXTRA_LIBRARIES ${PC_UNWIND_STATIC_LINK_LIBRARIES})
+  endif()
+endif()
+
 find_path (Unwind_INCLUDE_DIR
   NAMES unwind.h libunwind.h
   HINTS ${PC_UNWIND_INCLUDE_DIRS}
@@ -89,13 +96,23 @@ find_package_handle_standard_args (Unwind REQUIRED_VARS Unwind_INCLUDE_DIR
 
 if (Unwind_FOUND)
   if (NOT TARGET unwind::unwind)
+    set(_Unwind_LINK_LIBRARIES ${Unwind_LIBRARY} ${Unwind_PLATFORM_LIBRARY})
+    if (Unwind_LIBRARY MATCHES "\\.a$")
+      list(APPEND _Unwind_LINK_LIBRARIES ${Unwind_STATIC_EXTRA_LIBRARIES})
+      if (UNIX)
+        list(APPEND _Unwind_LINK_LIBRARIES lzma)
+      endif()
+    else()
+      list(APPEND _Unwind_LINK_LIBRARIES ${Unwind_EXTRA_LIBRARIES})
+    endif()
+
     add_library (unwind::unwind INTERFACE IMPORTED)
 
     set_property (TARGET unwind::unwind PROPERTY
       INTERFACE_INCLUDE_DIRECTORIES ${Unwind_INCLUDE_DIR}
     )
     set_property (TARGET unwind::unwind PROPERTY
-      INTERFACE_LINK_LIBRARIES ${Unwind_LIBRARY} ${Unwind_PLATFORM_LIBRARY}
+      INTERFACE_LINK_LIBRARIES ${_Unwind_LINK_LIBRARIES}
     )
     set_property (TARGET unwind::unwind PROPERTY
       IMPORTED_CONFIGURATIONS RELEASE

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,96 @@
+{
+  config,
+  lib,
+  pkgs,
+  package ? null,
+  ...
+}:
+let
+  cfg = config.services.eternalTerminal;
+  settingsFormat = pkgs.formats.ini { };
+  defaultSettings = {
+    Debug = {
+      logdirectory = "/var/log/eternal-terminal";
+      logsize = 20971520;
+      silent = 0;
+      telemetry = false;
+      verbose = 0;
+    };
+  };
+  mergedSettings = lib.recursiveUpdate defaultSettings cfg.settings;
+  effectiveSettings = lib.recursiveUpdate mergedSettings {
+    Networking.port = cfg.port;
+  };
+  configFile = settingsFormat.generate "et.cfg" effectiveSettings;
+in
+{
+  options.services.eternalTerminal = {
+    enable = lib.mkEnableOption "Eternal Terminal server";
+
+    package = lib.mkOption {
+      type = lib.types.nullOr lib.types.package;
+      default = package;
+      description = ''
+        Package that provides `etserver`. When this module is imported through
+        the flake, it defaults to that flake's package output.
+      '';
+    };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 2022;
+      description = "TCP port for the Eternal Terminal server.";
+    };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Open the configured Eternal Terminal port in the firewall.";
+    };
+
+    settings = lib.mkOption {
+      type = settingsFormat.type;
+      default = { };
+      example = {
+        Debug.serverfifo = "/run/etserver.fifo";
+        Networking.bind_ip = "0.0.0.0";
+      };
+      description = ''
+        Extra `et.cfg` settings grouped by INI section. This is merged with the
+        module defaults, and `services.eternalTerminal.port` always wins for
+        `Networking.port`.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable (
+    lib.mkMerge [
+      {
+        assertions = [
+          {
+            assertion = cfg.package != null;
+            message = "services.eternalTerminal.package must be set when importing ./default.nix directly.";
+          }
+        ];
+
+        environment.etc."et.cfg".source = configFile;
+        networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [ cfg.port ];
+      }
+
+      (lib.mkIf (cfg.package != null) {
+        systemd.services."eternal-terminal" = {
+          description = "Eternal Terminal";
+          after = [ "network.target" ];
+          wantedBy = [ "multi-user.target" ];
+
+          serviceConfig = {
+            ExecStart = "${cfg.package}/bin/etserver --cfgfile=/etc/et.cfg --logtostdout";
+            LogsDirectory = "eternal-terminal";
+            Restart = "on-failure";
+            Type = "simple";
+          };
+        };
+      })
+    ]
+  );
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1774386573,
+        "narHash": "sha256-4hAV26quOxdC6iyG7kYaZcM3VOskcPUrdCQd/nx8obc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "46db2e09e1d3f113a13c0d7b81e2f221c63b8ce9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -54,7 +54,6 @@
           {
             packageSet,
             buildPackages ? packageSet.buildPackages,
-            static ? false,
           }:
           let
             baseBuildInputs = [
@@ -66,17 +65,16 @@
               packageSet.xz
               packageSet.zlib
             ];
-            linuxExtras = lib.optionals (!static && packageSet.stdenv.hostPlatform.isLinux) [
+            linuxExtras = lib.optionals packageSet.stdenv.hostPlatform.isLinux [
               packageSet.libselinux
               packageSet.libutempter
             ];
           in
           packageSet.stdenv.mkDerivation rec {
-            pname = if static then "eternal-terminal-musl-static" else "eternal-terminal";
+            pname = "eternal-terminal";
             version = "6.2.11";
             src = cleanedSource;
 
-            dontDisableStatic = static;
             strictDeps = true;
             nativeBuildInputs = [
               buildPackages.cmake
@@ -93,22 +91,10 @@
               "-DDISABLE_VCPKG=ON"
               "-DBASH_COMPLETION_COMPLETIONSDIR=${placeholder "out"}/share/bash-completion/completions"
               "-DZSH_COMPLETIONS_DIR=${placeholder "out"}/share/zsh/site-functions"
-            ]
-            ++ lib.optionals static [
-              "-DBUILD_SHARED_LIBS=OFF"
-              "-DCMAKE_DISABLE_FIND_PACKAGE_SELinux=TRUE"
-              "-DCMAKE_DISABLE_FIND_PACKAGE_UTempter=TRUE"
-              "-DOPENSSL_USE_STATIC_LIBS=TRUE"
-              "-DProtobuf_USE_STATIC_LIBS=ON"
-              "-Dsodium_USE_STATIC_LIBS=ON"
             ];
 
             meta = with lib; {
-              description =
-                if static then
-                  "Remote terminal with a musl static build"
-                else
-                  "Remote terminal that reconnects without interrupting the session";
+              description = "Remote terminal that reconnects without interrupting the session";
               homepage = "https://mistertea.github.io/EternalTerminal/";
               license = licenses.asl20;
               mainProgram = "et";
@@ -119,15 +105,6 @@
           packageSet = pkgs;
           buildPackages = pkgs.buildPackages;
         };
-        eternalTerminalStatic =
-          if pkgs.stdenv.hostPlatform.isLinux then
-            mkEternalTerminal {
-              packageSet = pkgs.pkgsStatic;
-              buildPackages = pkgs.pkgsStatic.buildPackages;
-              static = true;
-            }
-          else
-            null;
         packageBuildInputs = [
           pkgs."abseil-cpp"
           pkgs.libsodium
@@ -140,26 +117,12 @@
           pkgs.libselinux
           pkgs.libutempter
         ];
-        staticPackageBuildInputs = [
-          pkgs.pkgsStatic."abseil-cpp"
-          pkgs.pkgsStatic.libsodium
-          pkgs.pkgsStatic.libunwind
-          pkgs.pkgsStatic.openssl
-          pkgs.pkgsStatic.protobuf
-          pkgs.pkgsStatic.xz
-          pkgs.pkgsStatic.zlib
-        ];
         cmakePrefixPath = lib.makeSearchPathOutput "dev" "" packageBuildInputs;
-        cmakePrefixPathStatic = lib.makeSearchPathOutput "dev" "" staticPackageBuildInputs;
       in
       {
         packages = {
           default = eternalTerminal;
           "eternal-terminal" = eternalTerminal;
-        }
-        // lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
-          "portable-musl" = eternalTerminalStatic;
-          "static-musl" = eternalTerminalStatic;
         };
 
         devShells = {
@@ -183,23 +146,6 @@
             shellHook = ''
               export OPENSSL_ROOT_DIR="${pkgs.openssl.dev}"
               export CMAKE_PREFIX_PATH="${cmakePrefixPath}:$CMAKE_PREFIX_PATH"
-            '';
-          };
-        }
-        // lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
-          portable-musl = pkgs.mkShell {
-            inputsFrom = [ eternalTerminalStatic ];
-
-            packages = [
-              pkgs.curl
-              pkgs.git
-              pkgs.gnumake
-              pkgs.llvmPackages_18.clang-tools
-            ];
-
-            shellHook = ''
-              export OPENSSL_ROOT_DIR="${pkgs.pkgsStatic.openssl.dev}"
-              export CMAKE_PREFIX_PATH="${cmakePrefixPathStatic}:$CMAKE_PREFIX_PATH"
             '';
           };
         };

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,212 @@
+{
+  description = "EternalTerminal development shell, package, and NixOS module";
+
+  inputs = {
+    self.submodules = true;
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    let
+      nixosModule =
+        {
+          config,
+          lib,
+          pkgs,
+          ...
+        }:
+        import ./default.nix {
+          inherit config lib pkgs;
+          package = self.packages.${pkgs.system}.default;
+        };
+    in
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+        };
+        lib = pkgs.lib;
+        cleanedSource = lib.cleanSourceWith {
+          src = ./.;
+          filter =
+            path: type:
+            let
+              relPath = lib.removePrefix "${toString ./.}/" (toString path);
+            in
+            lib.cleanSourceFilter path type
+            && !(
+              relPath == "build"
+              || lib.hasPrefix "build/" relPath
+              || relPath == "cov_build"
+              || lib.hasPrefix "cov_build/" relPath
+              || relPath == "result"
+              || lib.hasPrefix "result/" relPath
+            );
+        };
+        mkEternalTerminal =
+          {
+            packageSet,
+            buildPackages ? packageSet.buildPackages,
+            static ? false,
+          }:
+          let
+            baseBuildInputs = [
+              packageSet."abseil-cpp"
+              packageSet.libsodium
+              packageSet.libunwind
+              packageSet.openssl
+              packageSet.protobuf
+              packageSet.xz
+              packageSet.zlib
+            ];
+            linuxExtras = lib.optionals (!static && packageSet.stdenv.hostPlatform.isLinux) [
+              packageSet.libselinux
+              packageSet.libutempter
+            ];
+          in
+          packageSet.stdenv.mkDerivation rec {
+            pname = if static then "eternal-terminal-musl-static" else "eternal-terminal";
+            version = "6.2.11";
+            src = cleanedSource;
+
+            dontDisableStatic = static;
+            strictDeps = true;
+            nativeBuildInputs = [
+              buildPackages.cmake
+              buildPackages.ninja
+              buildPackages."pkg-config"
+              buildPackages.protobuf
+            ];
+            buildInputs = baseBuildInputs ++ linuxExtras;
+
+            cmakeFlags = [
+              "-DBUILD_TESTING=OFF"
+              "-DDISABLE_SENTRY=ON"
+              "-DDISABLE_TELEMETRY=ON"
+              "-DDISABLE_VCPKG=ON"
+              "-DBASH_COMPLETION_COMPLETIONSDIR=${placeholder "out"}/share/bash-completion/completions"
+              "-DZSH_COMPLETIONS_DIR=${placeholder "out"}/share/zsh/site-functions"
+            ]
+            ++ lib.optionals static [
+              "-DBUILD_SHARED_LIBS=OFF"
+              "-DCMAKE_DISABLE_FIND_PACKAGE_SELinux=TRUE"
+              "-DCMAKE_DISABLE_FIND_PACKAGE_UTempter=TRUE"
+              "-DOPENSSL_USE_STATIC_LIBS=TRUE"
+              "-DProtobuf_USE_STATIC_LIBS=ON"
+              "-Dsodium_USE_STATIC_LIBS=ON"
+            ];
+
+            meta = with lib; {
+              description =
+                if static then
+                  "Remote terminal with a musl static build"
+                else
+                  "Remote terminal that reconnects without interrupting the session";
+              homepage = "https://mistertea.github.io/EternalTerminal/";
+              license = licenses.asl20;
+              mainProgram = "et";
+              platforms = platforms.unix;
+            };
+          };
+        eternalTerminal = mkEternalTerminal {
+          packageSet = pkgs;
+          buildPackages = pkgs.buildPackages;
+        };
+        eternalTerminalStatic =
+          if pkgs.stdenv.hostPlatform.isLinux then
+            mkEternalTerminal {
+              packageSet = pkgs.pkgsStatic;
+              buildPackages = pkgs.pkgsStatic.buildPackages;
+              static = true;
+            }
+          else
+            null;
+        packageBuildInputs = [
+          pkgs."abseil-cpp"
+          pkgs.libsodium
+          pkgs.libunwind
+          pkgs.openssl
+          pkgs.protobuf
+          pkgs.zlib
+        ]
+        ++ lib.optionals pkgs.stdenv.hostPlatform.isLinux [
+          pkgs.libselinux
+          pkgs.libutempter
+        ];
+        staticPackageBuildInputs = [
+          pkgs.pkgsStatic."abseil-cpp"
+          pkgs.pkgsStatic.libsodium
+          pkgs.pkgsStatic.libunwind
+          pkgs.pkgsStatic.openssl
+          pkgs.pkgsStatic.protobuf
+          pkgs.pkgsStatic.xz
+          pkgs.pkgsStatic.zlib
+        ];
+        cmakePrefixPath = lib.makeSearchPathOutput "dev" "" packageBuildInputs;
+        cmakePrefixPathStatic = lib.makeSearchPathOutput "dev" "" staticPackageBuildInputs;
+      in
+      {
+        packages = {
+          default = eternalTerminal;
+          "eternal-terminal" = eternalTerminal;
+        }
+        // lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+          "portable-musl" = eternalTerminalStatic;
+          "static-musl" = eternalTerminalStatic;
+        };
+
+        devShells = {
+          default = pkgs.mkShell {
+            inputsFrom = [ eternalTerminal ];
+
+            packages = [
+              pkgs.autoconf
+              pkgs.automake
+              pkgs."bash-completion"
+              pkgs.curl
+              pkgs.git
+              pkgs.gnumake
+              pkgs.libtool
+              pkgs.llvmPackages_18.clang-tools
+              pkgs.unzip
+              pkgs.zip
+            ]
+            ++ lib.optionals pkgs.stdenv.hostPlatform.isLinux [ pkgs.gdb ];
+
+            shellHook = ''
+              export OPENSSL_ROOT_DIR="${pkgs.openssl.dev}"
+              export CMAKE_PREFIX_PATH="${cmakePrefixPath}:$CMAKE_PREFIX_PATH"
+            '';
+          };
+        }
+        // lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+          portable-musl = pkgs.mkShell {
+            inputsFrom = [ eternalTerminalStatic ];
+
+            packages = [
+              pkgs.curl
+              pkgs.git
+              pkgs.gnumake
+              pkgs.llvmPackages_18.clang-tools
+            ];
+
+            shellHook = ''
+              export OPENSSL_ROOT_DIR="${pkgs.pkgsStatic.openssl.dev}"
+              export CMAKE_PREFIX_PATH="${cmakePrefixPathStatic}:$CMAKE_PREFIX_PATH"
+            '';
+          };
+        };
+      }
+    )
+    // {
+      nixosModules.default = nixosModule;
+      nixosModules.eternalTerminal = nixosModule;
+    };
+}

--- a/format.sh
+++ b/format.sh
@@ -1,2 +1,11 @@
 #!/bin/bash
-find ./src ./test -type f | grep "\.[hc]pp" | xargs clang-format-18 --style=Google -i
+
+if command -v clang-format-18 >/dev/null 2>&1; then
+	formatter=(clang-format-18)
+elif command -v clang-format >/dev/null 2>&1; then
+	formatter=(clang-format)
+else
+	formatter=(nix run 'github:NixOS/nixpkgs/nixos-unstable#llvmPackages_18.clang-tools' -- clang-format)
+fi
+
+find ./src ./test -type f | grep "\.[hc]pp" | xargs "${formatter[@]}" --style=Google -i


### PR DESCRIPTION
## Summary

- add a flake with a package, dev shell, and exported NixOS module
- add a NixOS module that generates `/etc/et.cfg` and runs `etserver`
- adjust the build for Nix-managed dependencies and document Nix/NixOS usage

## Verification

- `nix build path:. --no-link`
