### PR TITLE
fix: pass long instead of int for SSH_OPTIONS_TIMEOUT (#737)

### DIFF
--- a/src/terminal/ParseConfigFile.hpp
+++ b/src/terminal/ParseConfigFile.hpp
@@ -1433,12 +1433,18 @@ static int ssh_config_parse_line(const char *targethost,
         SAFE_FREE(b);
       }
       break;
-    case SOC_TIMEOUT:
-      i = ssh_config_get_int(&s, -1);
-      if (i >= 0 && *parsing) {
-        ssh_options_set(options, SSH_OPTIONS_TIMEOUT, &i);
+    case SOC_TIMEOUT: {
+      // SSH_OPTIONS_TIMEOUT is documented as `long` and the handler casts
+      // value to `long *`. Passing `int *` made the handler read 8 bytes
+      // from a 4-byte slot on LP64 (arm64 macOS, x86_64 Linux), so
+      // uninitialized upper bits could flip the sign and trigger a bogus
+      // "invalid error" message. See issue #737.
+      long timeout = ssh_config_get_int(&s, -1);
+      if (timeout >= 0 && *parsing) {
+        ssh_options_set(options, SSH_OPTIONS_TIMEOUT, &timeout);
       }
       break;
+    }
     case SOC_STRICTHOSTKEYCHECK:
       i = ssh_config_get_yesno(&s, -1);
       if (i >= 0 && *parsing) {


### PR DESCRIPTION
## Summary

Fixes #737 — the spurious `invalid error` message printed to stdout on connect when `~/.ssh/config` contains `ConnectTimeout`.

## Root cause

`ssh_config_parse_line()` (`src/terminal/ParseConfigFile.hpp`) shares a single `int i` across cases. For the `SOC_TIMEOUT` case it does:

```cpp
i = ssh_config_get_int(&s, -1);
ssh_options_set(options, SSH_OPTIONS_TIMEOUT, &i);  // passes int*
```

But `SSH_OPTIONS_TIMEOUT` is documented as `long` (line ~656) and the handler in `ssh_options_set()` casts the pointer accordingly:

```cpp
case SSH_OPTIONS_TIMEOUT:
  ...
  long *x = (long *)value;   // reads 8 bytes
  if (*x < 0) {
    CLOG(INFO, "stdout") << "invalid error" << endl;
    return -1;
  }
```

On LP64 platforms (arm64 macOS, x86_64 Linux), the handler reads 8 bytes from a 4-byte stack slot, picking up uninitialized upper bits. Whenever those bits happen to have the sign bit set, the handler treats the value as negative and prints `invalid error` before returning. The connection still succeeds because the return value of `ssh_options_set` is not checked here, so the symptom is purely cosmetic — but confusing.

This only triggers when `ConnectTimeout` actually appears in the user's ssh config (it's the only keyword mapped to `SOC_TIMEOUT`).

## Fix

Use a local `long timeout` for this case so the type matches the consumer. Scoped with braces to keep the new local out of other cases. No change to the handler API or to any other case.

## Test plan

- [x] Builds cleanly (single-line type change in one case)
- [x] Reproduce: add `ConnectTimeout 10` under `Host *` in `~/.ssh/config`, run `et user@host` on arm64 macOS — `invalid error` no longer appears
- [x] Connection still works as before; remove the line and behavior is identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)