### PR TITLE
terminal: Fix etserver crash on session end due to ECHILD

### DIFF
--- a/src/terminal/PseudoUserTerminal.hpp
+++ b/src/terminal/PseudoUserTerminal.hpp
@@ -104,7 +104,11 @@ class PseudoUserTerminal : public UserTerminal {
     FATAL_FAIL(waitpid(getPid(), &throwaway, WUNTRACED));
 #else
     siginfo_t childInfo;
-    FATAL_FAIL(waitid(P_PID, getPid(), &childInfo, WEXITED));
+    if (getPid() > 0) {
+      if (waitid(P_PID, getPid(), &childInfo, WEXITED) == -1) {
+        LOG(ERROR) << "waitid failed, child already reaped.";
+      }
+    }
 #endif
   }
 


### PR DESCRIPTION
When etserver runs with SIGCHLD set to SIG_IGN, POSIX-compliant systems like FreeBSD automatically reap child shell processes the moment they terminate.

When the network connection closes and handleSessionEnd() executes, it calls waitid(). Because the child has already been auto-reaped by the OS, waitid() legitimately returns -1 with errno set to ECHILD. The FATAL_FAIL macro wrapping this call incorrectly interprets this as a catastrophic failure and aborts the entire server.

This removes the FATAL_FAIL wrapper around waitid(), allowing the server to gracefully handle the already-reaped child process without crashing.

0  thr_kill () at thr_kill.S:4
    reason="Fatal log at [/wrkdirs/usr/ports/net/eternalterminal/work/EternalTerminal-et-v6.2.11/src/terminal/PsuedoUserTerminal.hpp:99] If you wish to disable 'abort on fatal log' please use el::Loggers::addFlag"...)
    at /wrkdirs/usr/ports/net/eternalterminal/work/EternalTerminal-et-v6.2.11/external_imported/easyloggingpp/src/easylogging++.cc:125
    at /wrkdirs/usr/ports/net/eternalterminal/work/EternalTerminal-et-v6.2.11/external_imported/easyloggingpp/src/easylogging++.cc:2653
    at /wrkdirs/usr/ports/net/eternalterminal/work/EternalTerminal-et-v6.2.11/external_imported/easyloggingpp/src/easylogging++.cc:2616
    at /wrkdirs/usr/ports/net/eternalterminal/work/EternalTerminal-et-v6.2.11/external_imported/easyloggingpp/src/easylogging++.h:3209
    at /wrkdirs/usr/ports/net/eternalterminal/work/EternalTerminal-et-v6.2.11/src/terminal/PsuedoUserTerminal.hpp:99
    at /wrkdirs/usr/ports/net/eternalterminal/work/EternalTerminal-et-v6.2.11/src/terminal/UserTerminalHandler.cpp:116
    at /wrkdirs/usr/ports/net/eternalterminal/work/EternalTerminal-et-v6.2.11/src/terminal/UserTerminalHandler.cpp:60
    at /wrkdirs/usr/ports/net/eternalterminal/work/EternalTerminal-et-v6.2.11/src/terminal/TerminalMain.cpp:189