### PR TITLE
Fix broken image in howitworks.md

### DIFF
--- a/howitworks.md
+++ b/howitworks.md
@@ -35,7 +35,7 @@ Eternal TCP is an implementation of resumable TCP that can be used by any applic
 
 # The Eternal Terminal (ET).
 
-![E.T. Communicator](https://upload.wikimedia.org/wikipedia/commons/thumb/4/4c/ET_Communicator_Cropped.jpg/550px-ET_Communicator_Cropped.jpg "E.T. Communicator")
+![E.T. Communicator](https://upload.wikimedia.org/wikipedia/commons/thumb/4/4c/ET_Communicator_Cropped.jpg/500px-ET_Communicator_Cropped.jpg "E.T. Communicator")
 
 E.T. the Extra-Terrestrial was a movie about an alien and a boy that
 together build a device to "phone home" and send the alien back to his


### PR DESCRIPTION
The image for the ET Communicator was sourced from Wikimedia, but they removed the 550px thumbnail size:

	Error
	-----
	Use thumbnail sizes listed on https://w.wiki/GHai

The thumbnail sizes that bracket are 500px and 960px. This patch picks 500px because it’s closer to the old image, so it doesn’t unbalance the page.

Fixes #750