### PR TITLE
[Windows] Reassert autowrap after console setup

### DIFF
--- a/src/terminal/PseudoTerminalConsole.hpp
+++ b/src/terminal/PseudoTerminalConsole.hpp
@@ -5,6 +5,10 @@
 #include "ETerminal.pb.h"
 #include "RawSocketUtils.hpp"
 
+#ifdef WIN32
+#include <iostream>
+#endif
+
 namespace et {
 /**
  * @brief Configures the local console into raw mode and exposes terminal info.
@@ -30,11 +34,17 @@ class PseudoTerminalConsole : public Console {
   virtual void setup() {
 #ifdef WIN32
     auto hstdin = GetStdHandle(STD_INPUT_HANDLE);
-    SetConsoleMode(hstdin, ENABLE_VIRTUAL_TERMINAL_INPUT);
+    SetConsoleMode(hstdin, inputMode | ENABLE_VIRTUAL_TERMINAL_INPUT);
     auto hstdout = GetStdHandle(STD_OUTPUT_HANDLE);
-    SetConsoleMode(hstdout, ENABLE_PROCESSED_OUTPUT |
+    SetConsoleMode(hstdout, outputMode | ENABLE_PROCESSED_OUTPUT |
+                                ENABLE_WRAP_AT_EOL_OUTPUT |
                                 ENABLE_VIRTUAL_TERMINAL_PROCESSING |
                                 DISABLE_NEWLINE_AUTO_RETURN);
+    // DISABLE_NEWLINE_AUTO_RETURN is needed to keep full-screen terminal apps
+    // like tmux from scrolling incorrectly, but some Windows terminal hosts can
+    // leave long interactive input repainting over one visual row after this
+    // mode change. Reassert DECAWM so readline-style input wraps normally.
+    std::cout << "\033[?7h" << std::flush;
 #else
     termios terminal_local;
     tcgetattr(0, &terminal_local);


### PR DESCRIPTION
Description:
Windows ET setup changes console output modes to enable VT processing and DISABLE_NEWLINE_AUTO_RETURN. On affected Windows terminal hosts, long readline input can then repaint over the same visual row instead of wrapping, even though a DECRQM query still reports DECAWM enabled. Preserve the existing console mode bits and explicitly include ENABLE_WRAP_AT_EOL_OUTPUT so setup does not unnecessarily clear normal wrapping-related console state. That alone was tested and was not sufficient to fix the regression; the empirically required step is re-emitting DEC autowrap enable after the output mode change. DISABLE_NEWLINE_AUTO_RETURN remains intentional because removing it would regress full-screen terminal apps such as tmux, where it suppresses incorrect scrolling when content reaches the right edge of the terminal window.

Test plan:
Built the Windows et target locally; verified a raw ET session from Windows wraps long command input correctly after reconnecting; verified tmux full-screen scrolling still works without duplicated status elements from improper terminal-edge scrolling