### PR TITLE
Forward Ctrl-C input on Windows client

### DIFF
--- a/src/terminal/PseudoTerminalConsole.hpp
+++ b/src/terminal/PseudoTerminalConsole.hpp
@@ -34,7 +34,13 @@ class PseudoTerminalConsole : public Console {
   virtual void setup() {
 #ifdef WIN32
     auto hstdin = GetStdHandle(STD_INPUT_HANDLE);
-    SetConsoleMode(hstdin, inputMode | ENABLE_VIRTUAL_TERMINAL_INPUT);
+    // Disable processed input so Ctrl-C is delivered as terminal input instead
+    // of terminating the local client. This matches the Unix raw-mode path.
+    DWORD rawInputMode =
+        (inputMode & ~(ENABLE_PROCESSED_INPUT | ENABLE_LINE_INPUT |
+                       ENABLE_ECHO_INPUT)) |
+        ENABLE_VIRTUAL_TERMINAL_INPUT;
+    SetConsoleMode(hstdin, rawInputMode);
     auto hstdout = GetStdHandle(STD_OUTPUT_HANDLE);
     SetConsoleMode(hstdout, outputMode | ENABLE_PROCESSED_OUTPUT |
                                 ENABLE_WRAP_AT_EOL_OUTPUT |

--- a/src/terminal/PseudoTerminalConsole.hpp
+++ b/src/terminal/PseudoTerminalConsole.hpp
@@ -37,8 +37,8 @@ class PseudoTerminalConsole : public Console {
     // Disable processed input so Ctrl-C is delivered as terminal input instead
     // of terminating the local client. This matches the Unix raw-mode path.
     DWORD rawInputMode =
-        (inputMode & ~(ENABLE_PROCESSED_INPUT | ENABLE_LINE_INPUT |
-                       ENABLE_ECHO_INPUT)) |
+        (inputMode &
+         ~(ENABLE_PROCESSED_INPUT | ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT)) |
         ENABLE_VIRTUAL_TERMINAL_INPUT;
     SetConsoleMode(hstdin, rawInputMode);
     auto hstdout = GetStdHandle(STD_OUTPUT_HANDLE);


### PR DESCRIPTION
When using Eternal Terminal on Windows, Ctrl+C gets trapped by the client instead of being forwarded to the host, causing the session to disconnect. This patch puts stdin closer to raw mode during the session on PseudoTerminalConsole on Windows. Resolves https://github.com/MisterTea/EternalTerminal/issues/754