### PR TITLE
base: Fix etserver crash on transient accept() errors

### DIFF
--- a/src/base/UnixSocketHandler.cpp
+++ b/src/base/UnixSocketHandler.cpp
@@ -142,12 +142,28 @@ int UnixSocketHandler::accept(int sockFd) {
     initSocket(client_sock);
     VLOG(3) << "Client_socket inserted to activeSockets";
     return client_sock;
-  } else if (acceptErrno != EAGAIN && acceptErrno != EWOULDBLOCK) {
+  } else if (isTransientAcceptError(acceptErrno)) {
+    // Transient, per-connection failure: fall through and return -1; the
+    // server loop simply retries on the next iteration.
+  } else {
     FATAL_FAIL(-1);  // STFATAL with the error
   }
 
   SetErrno(acceptErrno);
   return -1;
+}
+
+bool UnixSocketHandler::isTransientAcceptError(int err) {
+  // accept(2) routinely fails for benign, per-connection reasons that must
+  // not abort the whole server:
+  //  - EAGAIN/EWOULDBLOCK: non-blocking socket with no pending connection.
+  //  - ECONNABORTED: the peer reset the connection between landing in the
+  //    listen queue and our accept() call.  Surfaced readily on FreeBSD by
+  //    clients that connect and immediately disconnect (keepalive/reconnect
+  //    churn) and previously aborted etserver.
+  //  - EINTR: the call was interrupted by a signal.
+  return err == EAGAIN || err == EWOULDBLOCK || err == ECONNABORTED ||
+         err == EINTR;
 }
 
 void UnixSocketHandler::close(int fd) {

--- a/src/base/UnixSocketHandler.hpp
+++ b/src/base/UnixSocketHandler.hpp
@@ -27,6 +27,12 @@ class UnixSocketHandler : public SocketHandler {
    * @brief Accepts a pending connection on the provided listening socket.
    */
   virtual int accept(int fd);
+  /**
+   * @brief Returns true if an accept() errno is a transient, per-connection
+   * failure that must be reported to the caller rather than aborting the
+   * server (EAGAIN/EWOULDBLOCK, ECONNABORTED, EINTR).
+   */
+  static bool isTransientAcceptError(int err);
   /** @brief Closes the descriptor and removes it from the tracked set. */
   virtual void close(int fd);
   /** @brief Returns all actively tracked sockets. */

--- a/test/unit_tests/UnixSocketHandlerTest.cpp
+++ b/test/unit_tests/UnixSocketHandlerTest.cpp
@@ -3,12 +3,25 @@
 
 using namespace et;
 
+TEST_CASE("AcceptTransientErrorClassification", "[UnixSocketHandler]") {
+  // The errnos that must be tolerated rather than aborting the server.
+  // ECONNABORTED is the case that crashed etserver on FreeBSD.
+  REQUIRE(UnixSocketHandler::isTransientAcceptError(EAGAIN));
+  REQUIRE(UnixSocketHandler::isTransientAcceptError(EWOULDBLOCK));
+  REQUIRE(UnixSocketHandler::isTransientAcceptError(ECONNABORTED));
+  REQUIRE(UnixSocketHandler::isTransientAcceptError(EINTR));
+
+  // Genuine logic errors must still be treated as fatal.
+  REQUIRE_FALSE(UnixSocketHandler::isTransientAcceptError(EBADF));
+  REQUIRE_FALSE(UnixSocketHandler::isTransientAcceptError(EINVAL));
+  REQUIRE_FALSE(UnixSocketHandler::isTransientAcceptError(ENOTSOCK));
+  REQUIRE_FALSE(UnixSocketHandler::isTransientAcceptError(EFAULT));
+}
+
 TEST_CASE("AcceptDoesNotAbortWhenNoPendingConnection", "[UnixSocketHandler]") {
-  // Regression test for the etserver crash on FreeBSD: accept() on a
-  // non-blocking listening socket with no pending connection fails with
-  // EAGAIN/EWOULDBLOCK.  Previously every errno other than those two hit
-  // FATAL_FAIL and aborted the whole server (the same path ECONNABORTED took
-  // on FreeBSD).  accept() must instead return -1 to its caller.
+  // End-to-end check: accept() on a non-blocking listening socket with no
+  // pending connection fails with EAGAIN/EWOULDBLOCK and must return -1 to the
+  // caller instead of hitting FATAL_FAIL.
   shared_ptr<PipeSocketHandler> socketHandler(new PipeSocketHandler());
 
   string tmpPath = GetTempDirectory() + string("et_test_XXXXXXXX");
@@ -22,12 +35,13 @@ TEST_CASE("AcceptDoesNotAbortWhenNoPendingConnection", "[UnixSocketHandler]") {
   REQUIRE(!serverFds.empty());
   int serverFd = *serverFds.begin();
 
-  // No client has connected and the listening socket is non-blocking, so
-  // accept() returns -1 rather than aborting the process.
   int clientFd = socketHandler->accept(serverFd);
   REQUIRE(clientFd == -1);
   REQUIRE((GetErrno() == EAGAIN || GetErrno() == EWOULDBLOCK));
 
   socketHandler->stopListening(endpoint);
+  // stopListening() only closes the fd; the bound socket file remains, so
+  // remove it before the (now empty) directory.
+  FATAL_FAIL(::remove(pipePath.c_str()));
   FATAL_FAIL(::remove(pipeDirectory.c_str()));
 }

--- a/test/unit_tests/UnixSocketHandlerTest.cpp
+++ b/test/unit_tests/UnixSocketHandlerTest.cpp
@@ -1,0 +1,33 @@
+#include "PipeSocketHandler.hpp"
+#include "TestHeaders.hpp"
+
+using namespace et;
+
+TEST_CASE("AcceptDoesNotAbortWhenNoPendingConnection", "[UnixSocketHandler]") {
+  // Regression test for the etserver crash on FreeBSD: accept() on a
+  // non-blocking listening socket with no pending connection fails with
+  // EAGAIN/EWOULDBLOCK.  Previously every errno other than those two hit
+  // FATAL_FAIL and aborted the whole server (the same path ECONNABORTED took
+  // on FreeBSD).  accept() must instead return -1 to its caller.
+  shared_ptr<PipeSocketHandler> socketHandler(new PipeSocketHandler());
+
+  string tmpPath = GetTempDirectory() + string("et_test_XXXXXXXX");
+  string pipeDirectory = string(mkdtemp(&tmpPath[0]));
+  string pipePath = pipeDirectory + "/pipe";
+
+  SocketEndpoint endpoint;
+  endpoint.set_name(pipePath);
+
+  set<int> serverFds = socketHandler->listen(endpoint);
+  REQUIRE(!serverFds.empty());
+  int serverFd = *serverFds.begin();
+
+  // No client has connected and the listening socket is non-blocking, so
+  // accept() returns -1 rather than aborting the process.
+  int clientFd = socketHandler->accept(serverFd);
+  REQUIRE(clientFd == -1);
+  REQUIRE((GetErrno() == EAGAIN || GetErrno() == EWOULDBLOCK));
+
+  socketHandler->stopListening(endpoint);
+  FATAL_FAIL(::remove(pipeDirectory.c_str()));
+}


### PR DESCRIPTION
UnixSocketHandler::accept() called FATAL_FAIL on any accept() errno other than EAGAIN/EWOULDBLOCK, aborting the entire server. accept(2) routinely returns benign per-connection errors -- notably ECONNABORTED (the peer reset the connection before we accepted it) and EINTR. These are surfaced readily on FreeBSD by clients that connect and immediately disconnect (keepalive/reconnect churn), crashing etserver.

Treat EAGAIN, EWOULDBLOCK, ECONNABORTED, and EINTR as non-fatal and return -1; the accept loop already handles this by retrying. Genuinely unexpected errnos still fail fatally.

Backtrace on FreeBSD:

  #0  thr_kill () at thr_kill.S:4
  #1  __raise (s=s@entry=6) at /usr/src/lib/libc/gen/raise.c:50
  #2  abort () at /usr/src/lib/libc/stdlib/abort.c:64
  #3  el::base::utils::abort (status=1, reason="Fatal log at [.../src/base/UnixSocketHandler.cpp:146] ...")
      at external_imported/easyloggingpp/src/easylogging++.cc:125
  #4  el::base::Writer::triggerDispatch () at external_imported/easyloggingpp/src/easylogging++.cc:2653
  #5  el::base::Writer::processDispatch () at external_imported/easyloggingpp/src/easylogging++.cc:2616
  #6  el::base::Writer::~Writer () at external_imported/easyloggingpp/src/easylogging++.h:3209
  #7  et::UnixSocketHandler::accept (this=..., sockFd=10) at src/base/UnixSocketHandler.cpp:146
  #8  et::ServerConnection::acceptNewConnection (this=..., fd=10) at src/base/ServerConnection.cpp:17
  #9  et::TerminalServer::run (this=...) at src/terminal/TerminalServer.cpp:79
  #10 main (argc=6, argv=...) at src/terminal/TerminalServerMain.cpp:203