### PR TITLE
Keep sessions alive while the client is disconnected

### DIFF
--- a/src/base/BackedWriter.cpp
+++ b/src/base/BackedWriter.cpp
@@ -8,15 +8,17 @@ BackedWriter::BackedWriter(std::shared_ptr<SocketHandler> socketHandler_,
       cryptoHandler(cryptoHandler_),
       socketFd(socketFd_),
       backupSize(0),
+      disconnectedBytes(0),
       sequenceNumber(0) {}
 
 BackedWriterWriteState BackedWriter::write(Packet packet) {
   // If recover started, Wait until finished
   lock_guard<std::mutex> guard(recoverMutex);
 
-  // If no socket and buffer exceeds disconnect limit, signal caller to wait
-  // This prevents blocking during normal disconnects while preserving data
-  if (socketFd < 0 && backupSize + packet.length() > DISCONNECT_BUFFER_BYTES) {
+  // If no socket and the data buffered since the disconnect exceeds the
+  // limit, signal caller to wait
+  if (socketFd < 0 &&
+      disconnectedBytes + packet.length() > DISCONNECT_BUFFER_BYTES) {
     return BackedWriterWriteState::SKIPPED;
   }
 
@@ -37,6 +39,7 @@ BackedWriterWriteState BackedWriter::write(Packet packet) {
 
   // If no socket, data is buffered for later recovery
   if (socketFd < 0) {
+    disconnectedBytes += packet.length();
     return BackedWriterWriteState::BUFFERED_ONLY;
   }
 
@@ -106,5 +109,8 @@ vector<std::string> BackedWriter::recover(int64_t lastValidSequenceNumber) {
   throw std::runtime_error("Client is too far behind server.");
 }
 
-void BackedWriter::revive(int newSocketFd) { socketFd = newSocketFd; }
+void BackedWriter::revive(int newSocketFd) {
+  socketFd = newSocketFd;
+  disconnectedBytes = 0;
+}
 }  // namespace et

--- a/src/base/BackedWriter.hpp
+++ b/src/base/BackedWriter.hpp
@@ -30,8 +30,8 @@ class BackedWriter {
  public:
   /** @brief Maximum bytes to buffer for recovery (64MB). */
   static const int64_t MAX_BACKUP_BYTES = 64 * 1024 * 1024;
-  /** @brief Max buffer before blocking when disconnected (4MB). */
-  static const int64_t DISCONNECT_BUFFER_BYTES = 4 * 1024 * 1024;
+  /** @brief Max bytes buffered while disconnected before blocking (64MB). */
+  static const int64_t DISCONNECT_BUFFER_BYTES = 64 * 1024 * 1024;
 
   /**
    * @brief Creates a writer bound to a socket and crypto pair.
@@ -59,6 +59,16 @@ class BackedWriter {
    * @brief Points the writer at a new socket fd so writes can resume.
    */
   void revive(int newSocketFd);
+
+  /**
+   * @brief Returns true when writing `bytes` more will not block the caller:
+   * either a socket is attached or the disconnect buffer still has room.
+   */
+  bool hasBufferCapacity(int64_t bytes) {
+    lock_guard<std::mutex> guard(recoverMutex);
+    return socketFd >= 0 ||
+           disconnectedBytes + bytes <= DISCONNECT_BUFFER_BYTES;
+  }
 
   /**
    * @brief Mutex guarding recovery operations so callers can hold it when
@@ -98,6 +108,8 @@ class BackedWriter {
   std::deque<Packet> backupBuffer;
   /** @brief Running size of the backup buffer. */
   int64_t backupSize;
+  /** @brief Bytes buffered since the socket was lost; reset on revive. */
+  int64_t disconnectedBytes;
   /** @brief Sequence number that increments each time a packet is backed up. */
   int64_t sequenceNumber;
 };

--- a/src/base/Connection.cpp
+++ b/src/base/Connection.cpp
@@ -23,6 +23,15 @@ inline bool isSkippableError(int err_no) {
   return (err_no == EAGAIN || err_no == ECONNRESET || err_no == ETIMEDOUT ||
           err_no == EWOULDBLOCK || err_no == EHOSTUNREACH || err_no == EPIPE ||
           err_no == ENOTCONN || err_no == ECONNABORTED ||
+          err_no == ENETDOWN ||     // Laptop woke up with the network down
+          err_no == ENETUNREACH ||  // Network still coming up after a wake
+          err_no == ENETRESET ||
+#ifdef EHOSTDOWN
+          err_no == EHOSTDOWN ||
+#endif
+#ifdef EPROTOTYPE
+          err_no == EPROTOTYPE ||  // macOS: send() racing a socket teardown
+#endif
           err_no == EBADF  // Bad file descriptor can happen when
                            // there's a race condition between a thread
                            // closing a connection and one
@@ -167,10 +176,12 @@ bool Connection::read(Packet* packet) {
       closeSocketAndMaybeReconnect();
       return 0;
     } else {
-      // Throw the error
+      // Sever the connection instead of throwing; reconnect/recover will
+      // take over and the session survives
       STERROR << "Got a serious error trying to read: " << localErrno << " / "
               << strerror(localErrno);
-      throw std::runtime_error("Failed a call to read");
+      closeSocketAndMaybeReconnect();
+      return 0;
     }
   } else {
     return messagesRead > 0;
@@ -212,8 +223,11 @@ bool Connection::write(const Packet& packet) {
       // The connection has been severed, handle and hide from the caller
       closeSocketAndMaybeReconnect();
     } else {
-      STFATAL << "Unexpected socket error: " << writeErrno << " "
+      // Sever the connection instead of crashing the process, which on a
+      // server would kill every session
+      STERROR << "Unexpected socket error: " << writeErrno << " "
               << strerror(writeErrno);
+      closeSocketAndMaybeReconnect();
     }
   }
 

--- a/src/base/Connection.hpp
+++ b/src/base/Connection.hpp
@@ -53,6 +53,18 @@ class Connection {
 
   inline bool isDisconnected() { return socketFd == -1; }
 
+  /**
+   * @brief Returns true when writePacket() of `bytes` more will not block:
+   * either the socket is connected or the disconnect buffer has room.
+   */
+  inline bool canBufferWrite(int64_t bytes) {
+    lock_guard<std::recursive_mutex> guard(connectionMutex);
+    if (shuttingDown) {
+      return true;
+    }
+    return writer && writer->hasBufferCapacity(bytes);
+  }
+
   inline string getId() { return id; }
 
   inline bool hasData() { return reader->hasData(); }

--- a/src/base/Headers.hpp
+++ b/src/base/Headers.hpp
@@ -374,6 +374,31 @@ inline bool waitOnSocketData(int fd) {
   return FD_ISSET(fd, &fdset);
 }
 
+/**
+ * Check whether a fd would accept a write right now without blocking.
+ *
+ * @return true if the fd is writable, or false if its buffer is full or the
+ *   check is interrupted by a syscall.
+ */
+inline bool isSocketWritable(int fd) {
+  fd_set fdset;
+  FD_ZERO(&fdset);
+  FD_SET(fd, &fdset);
+  timeval tv;
+  tv.tv_sec = 0;
+  tv.tv_usec = 0;
+  const int selectResult = select(fd + 1, NULL, &fdset, NULL, &tv);
+  if (selectResult < 0) {
+    if (errno == EINTR) {
+      // Interrupted by the signal, the caller will retry.
+      return false;
+    } else {
+      FATAL_FAIL(selectResult);
+    }
+  }
+  return FD_ISSET(fd, &fdset);
+}
+
 inline string genRandomAlphaNum(int len) {
   static const char alphanum[] =
       "0123456789"

--- a/src/base/SocketHandler.cpp
+++ b/src/base/SocketHandler.cpp
@@ -87,6 +87,11 @@ void SocketHandler::writeAllOrThrow(int fd, const void* buf, size_t count,
         LOG(INFO) << "Got EAGAIN, waiting...";
         // This is fine, just keep retrying at 10hz
         std::this_thread::sleep_for(std::chrono::microseconds(100 * 1000));
+      } else if (!timeout && localErrno == ETIMEDOUT) {
+        // macOS returns ETIMEDOUT on unix sockets whose peer has stopped
+        // draining even though the connection is intact; keep retrying
+        LOG_EVERY_N(100, WARNING) << "Got ETIMEDOUT, retrying...";
+        std::this_thread::sleep_for(std::chrono::microseconds(100 * 1000));
       } else {
         LOG(WARNING) << "Failed a call to writeAll: " << strerror(localErrno);
         throw std::runtime_error("Failed a call to writeAll");

--- a/src/terminal/TerminalServer.cpp
+++ b/src/terminal/TerminalServer.cpp
@@ -136,8 +136,14 @@ void TerminalServer::runJumpHost(
     timeval tv;
 
     FD_ZERO(&rfd);
-    FD_SET(terminalFd, &rfd);
-    int maxfd = terminalFd;
+    int maxfd = -1;
+    // Only drain the terminal while the client connection can absorb the
+    // data, so backpressure reaches the terminal instead of this loop
+    // blocking inside writePacket()
+    if (serverClientState->canBufferWrite(2 * BUF_SIZE)) {
+      FD_SET(terminalFd, &rfd);
+      maxfd = terminalFd;
+    }
     int serverClientFd = serverClientState->getSocketFd();
     if (serverClientFd > 0) {
       FD_SET(serverClientFd, &rfd);
@@ -280,8 +286,14 @@ void TerminalServer::runTerminal(
     timeval tv;
 
     FD_ZERO(&rfd);
-    FD_SET(terminalFd, &rfd);
-    int maxfd = terminalFd;
+    int maxfd = -1;
+    // Only drain the terminal while the client connection can absorb the
+    // data, so backpressure reaches the shell instead of this loop blocking
+    // inside writePacket()
+    if (serverClientState->canBufferWrite(2 * BUF_SIZE)) {
+      FD_SET(terminalFd, &rfd);
+      maxfd = terminalFd;
+    }
     int serverClientFd = serverClientState->getSocketFd();
     if (serverClientFd > 0) {
       FD_SET(serverClientFd, &rfd);

--- a/src/terminal/UserTerminalHandler.cpp
+++ b/src/terminal/UserTerminalHandler.cpp
@@ -80,8 +80,14 @@ void UserTerminalHandler::runUserTerminal(int masterFd) {
     fd_set rfd;
     timeval tv;
 
+    // Only read terminal output when the router can accept it, so
+    // backpressure reaches the shell instead of killing the session
+    const bool routerWritable = isSocketWritable(routerFd);
+
     FD_ZERO(&rfd);
-    FD_SET(masterFd, &rfd);
+    if (routerWritable) {
+      FD_SET(masterFd, &rfd);
+    }
     FD_SET(routerFd, &rfd);
     int maxfd = max(masterFd, routerFd);
     tv.tv_sec = 0;

--- a/test/unit_tests/BackedIOTest.cpp
+++ b/test/unit_tests/BackedIOTest.cpp
@@ -278,39 +278,110 @@ TEST_CASE("BackedWriter buffers when disconnected until limit", "[BackedIO]") {
 
   auto writer = make_shared<BackedWriter>(handler, crypto, fd);
 
+  string chunk(1024 * 1024, 'x');  // 1MB chunks
+
+  // Deliver some data while connected; this backup of already-delivered data
+  // must not eat into the disconnect headroom.
+  for (int i = 0; i < 8; i++) {
+    REQUIRE(writer->write(Packet(i, chunk)) == BackedWriterWriteState::SUCCESS);
+  }
+
   // Disconnect
   writer->invalidateSocket();
+  REQUIRE(writer->hasBufferCapacity(1024));
 
-  // Small writes should succeed (BUFFERED_ONLY)
-  Packet small1(1, "small");
-  REQUIRE(writer->write(small1) == BackedWriterWriteState::BUFFERED_ONLY);
-
-  // Fill most of the 4MB disconnect buffer (leave room for overhead)
-  string chunk(64 * 1024, 'x');   // 64KB chunks
-  for (int i = 0; i < 60; i++) {  // 60 * 64KB = 3.75MB, under 4MB limit
-    Packet p(i, chunk);
-    REQUIRE(writer->write(p) == BackedWriterWriteState::BUFFERED_ONLY);
-  }
-
-  // Fill remaining buffer to just under limit
-  string smallChunk(1024, 'y');
-  for (int i = 0; i < 250; i++) {  // ~250KB more
-    Packet p(i + 100, smallChunk);
-    auto result = writer->write(p);
+  // The full disconnect buffer should be available for post-disconnect data.
+  int buffered = 0;
+  while (true) {
+    auto result = writer->write(Packet(buffered % 256, chunk));
     if (result == BackedWriterWriteState::SKIPPED) {
-      // Hit the limit - this is expected
-      REQUIRE(true);
-      handler->close(fd);
-      return;
+      break;
     }
     REQUIRE(result == BackedWriterWriteState::BUFFERED_ONLY);
+    buffered++;
+    // Must hit the cap by DISCONNECT_BUFFER_BYTES worth of payload.
+    REQUIRE(buffered <= BackedWriter::DISCONNECT_BUFFER_BYTES / (1024 * 1024));
   }
+  // Nearly all of the headroom was usable despite the pre-disconnect backup.
+  REQUIRE(buffered >=
+          BackedWriter::DISCONNECT_BUFFER_BYTES / (1024 * 1024) - 1);
+  REQUIRE(!writer->hasBufferCapacity(2 * 1024 * 1024));
 
-  // If we get here, force overflow with one more write
-  Packet overflow(255, chunk);
-  REQUIRE(writer->write(overflow) == BackedWriterWriteState::SKIPPED);
+  // Reviving on a new socket resets the disconnect accounting.
+  const int newFd = handler->createChannel();
+  writer->revive(newFd);
+  REQUIRE(writer->hasBufferCapacity(1024));
+  writer->invalidateSocket();
+  REQUIRE(writer->write(Packet(1, chunk)) ==
+          BackedWriterWriteState::BUFFERED_ONLY);
 
   handler->close(fd);
+}
+
+TEST_CASE("writeAllOrThrow retries ETIMEDOUT when patient", "[SocketHandler]") {
+  // On macOS, a unix socket whose peer stops draining for a long time
+  // surfaces ETIMEDOUT from send() even though the connection is intact.
+  class TimeoutThenOkHandler : public InMemorySocketHandler {
+   public:
+    int failures = 0;
+    ssize_t write(int fd, const void* buf, size_t count) override {
+      if (failures > 0) {
+        failures--;
+        SetErrno(ETIMEDOUT);
+        return -1;
+      }
+      return InMemorySocketHandler::write(fd, buf, count);
+    }
+  };
+  auto handler = make_shared<TimeoutThenOkHandler>();
+  const int fd = handler->createChannel();
+  const string data = "hello";
+
+  // With timeout disabled (infinite patience), ETIMEDOUT is retried.
+  handler->failures = 3;
+  REQUIRE_NOTHROW(
+      handler->writeAllOrThrow(fd, data.data(), data.length(), false));
+  string echoed(data.length(), '\0');
+  REQUIRE(handler->read(fd, &echoed[0], echoed.length()) ==
+          (ssize_t)data.length());
+  REQUIRE(echoed == data);
+
+  // With a timeout requested, ETIMEDOUT still fails fast.
+  handler->failures = 3;
+  REQUIRE_THROWS(
+      handler->writeAllOrThrow(fd, data.data(), data.length(), true));
+}
+
+TEST_CASE("Connection severs instead of dying on unexpected read errno",
+          "[Connection]") {
+  // A client waking from sleep can see errnos like ENETDOWN; the connection
+  // must sever (and later reconnect) rather than tear down the session.
+  class ErrnoReadHandler : public InMemorySocketHandler {
+   public:
+    int err = ENETDOWN;
+    bool hasData(int) override { return true; }
+    ssize_t read(int, void*, size_t) override {
+      SetErrno(err);
+      return -1;
+    }
+  };
+  const string key = "12345678901234567890123456789012";
+
+  for (int err : {ENETDOWN, ENETUNREACH, EINVAL}) {
+    auto handler = make_shared<ErrnoReadHandler>();
+    handler->err = err;
+    const int fd = handler->createChannel();
+    auto reader = make_shared<BackedReader>(
+        handler, make_shared<CryptoHandler>(key, 0), fd);
+    auto writer = make_shared<BackedWriter>(
+        handler, make_shared<CryptoHandler>(key, 0), fd);
+    TestConnection connection(handler, reader, writer, fd, key);
+
+    Packet packet;
+    REQUIRE_NOTHROW(connection.readPacket(&packet));
+    REQUIRE(connection.isDisconnected());
+    connection.shutdown();
+  }
 }
 
 TEST_CASE("BackedWriter trims old data when connected and buffer exceeds 64MB",


### PR DESCRIPTION
Sessions die when a client goes away (e.g. laptop lid closed) while the shell keeps producing output. The failure chain, observed in production logs:

1. The disconnect buffer (4MB) fills with pending terminal output.
2. The server's session thread blocks forever in `writePacket` (`Waiting to write...`).
3. The etterminal's router socket stops draining, and macOS eventually fails the etterminal's blocked write with ETIMEDOUT (`Failed a call to writeAll: Operation timed out`).
4. The etterminal exits, and the reconnecting client gets `INVALID_KEY` — the session is gone.

This fixes each link in the chain by propagating backpressure to the shell's pty instead of blocking or dying:

- **TerminalServer** only reads from the terminal router when the client connection can absorb the data.
- **UserTerminalHandler** only reads the pty when the router socket is writable, and **SocketHandler** retries ETIMEDOUT on writes when the caller didn't request a timeout (macOS raises it on unix sockets whose peer stops draining, even though the connection is intact).
- **BackedWriter** counts the disconnect limit against bytes buffered since the disconnect (not total backup size, which can already be at its cap with delivered data), and raises it from 4MB to 64MB.
- **Connection** treats wake-from-sleep errnos (ENETDOWN, ENETUNREACH, ENETRESET, EHOSTDOWN, EPROTOTYPE) as skippable, and severs and reconnects on unexpected errnos instead of throwing (which kills the session) or aborting (which on a server kills every session).

Tested with a sleep/wake harness: a client SIGSTOP'd behind a killed TCP proxy with ~1MB/s of terminal output during a 45 second outage now recovers and replays all output. Unit tests added for the disconnect-buffer accounting, the ETIMEDOUT retry, and severing on unexpected read errnos.