### PR TITLE
Fix std::bad_cast crash when -u/--username is passed to et client

### DIFF
--- a/src/terminal/TerminalClientMain.cpp
+++ b/src/terminal/TerminalClientMain.cpp
@@ -128,7 +128,8 @@ int main(int argc, char** argv) {
     options.add_options()             //
         ("h,help", "Print help")      //
         ("version", "Print version")  //
-        ("u,username", "Username")    //
+        ("u,username", "Username",
+         cxxopts::value<std::string>())  //
         ("host", "Remote host name",
          cxxopts::value<std::string>())  //
         ("p,port", "Remote machine etserver port",


### PR DESCRIPTION
The client `username` option was declared with no value type:

    ("u,username", "Username")

so cxxopts backed it with a bool (its default for valueless options). Reading it later via `result["username"].as<string>()` performs a dynamic_cast to `standard_value<string>&`, which throws std::bad_cast and aborts the client the moment `-u`/`--username` is used, e.g.

    et -u cit cit.sb   ->   Uncaught c++ exception: std::bad_cast (SIGABRT)

As a side effect `-u` consumed no argument, so the username would have been swallowed as the positional host.

Declare the option with cxxopts::value<std::string>() (matching the other string options) so `-u <user>` is parsed as a string and the positional host is parsed correctly.