### PR TITLE
Fix input-write deadlock in UserTerminalHandler on large input bursts

### DIFF
--- a/src/terminal/PseudoUserTerminal.hpp
+++ b/src/terminal/PseudoUserTerminal.hpp
@@ -1,6 +1,7 @@
 #ifndef __PSUEDO_USER_TERMINAL_HPP__
 #define __PSUEDO_USER_TERMINAL_HPP__
 
+#include <fcntl.h>
 #include <stdlib.h>
 #include <sys/types.h>
 #include <sys/wait.h>
@@ -53,6 +54,16 @@ class PseudoUserTerminal : public UserTerminal {
       utempter_add_record(masterFd, buf);
     }
 #endif
+
+    // The handler polls this fd with select() and does non-blocking reads and
+    // writes, so make the master non-blocking here, where it is created.  If it
+    // stayed blocking, a large input burst would block the handler's single
+    // write() call and deadlock against the shell's echo (see
+    // UserTerminal::setup and UserTerminalHandler::runUserTerminal).
+    int flags = fcntl(masterFd, F_GETFL, 0);
+    if (flags != -1) {
+      fcntl(masterFd, F_SETFL, flags | O_NONBLOCK);
+    }
     return masterFd;
   }
 

--- a/src/terminal/UserTerminal.hpp
+++ b/src/terminal/UserTerminal.hpp
@@ -18,7 +18,9 @@ class UserTerminal {
    * @param routerFd File descriptor that should be linked to the terminal
    * session.
    * @returns File descriptor used for reading incoming data (typically a master
-   * pty).
+   * pty).  It must be non-blocking: the handler polls it with select() and does
+   * non-blocking reads and writes, so a large input burst can never block the
+   * single-threaded pump (which would deadlock against the shell's echo).
    */
   virtual int setup(int routerFd) = 0;
   /** @brief Drives the interactive shell loop until the session exits. */

--- a/src/terminal/UserTerminalHandler.cpp
+++ b/src/terminal/UserTerminalHandler.cpp
@@ -68,6 +68,20 @@ void UserTerminalHandler::runUserTerminal(int masterFd) {
   time_t lastSecond = time(NULL);
   int64_t outputPerSecond = 0;
 
+  // The pty master is non-blocking (set by UserTerminal::setup, where the fd is
+  // created).  This loop is single-threaded, so we must never block inside the
+  // input write: the old blocking `RawSocketUtils::writeAll(masterFd, ...)`
+  // did, and a large burst of input (e.g. a pasted heredoc) echoes back, fills
+  // the pty output buffer, stalls the shell, and the shell then stops reading
+  // input
+  // -- so the write never completes and we also stop draining output: a
+  // deadlock that wedges the session past ~one pty buffer of input.  Instead we
+  // buffer pending input, drain it to the pty whenever it is writable, and keep
+  // reading output every iteration.  When the buffer fills we stop reading more
+  // input from the router, so backpressure reaches the client.
+  string pendingInput;
+  const size_t maxPendingInput = 256 * 1024;
+
   while (true) {
     {
       lock_guard<recursive_mutex> guard(shutdownMutex);
@@ -78,6 +92,7 @@ void UserTerminalHandler::runUserTerminal(int masterFd) {
     // Data structures needed for select() and
     // non-blocking I/O.
     fd_set rfd;
+    fd_set wfd;
     timeval tv;
 
     // Only read terminal output when the router can accept it, so
@@ -85,14 +100,24 @@ void UserTerminalHandler::runUserTerminal(int masterFd) {
     const bool routerWritable = isSocketWritable(routerFd);
 
     FD_ZERO(&rfd);
+    FD_ZERO(&wfd);
     if (routerWritable) {
       FD_SET(masterFd, &rfd);
     }
-    FD_SET(routerFd, &rfd);
+    // Stop pulling more input from the router once the pty-input buffer is
+    // full, so backpressure reaches the client instead of buffering without
+    // bound.
+    if (pendingInput.length() < maxPendingInput) {
+      FD_SET(routerFd, &rfd);
+    }
+    // Wake as soon as the pty can accept more of the buffered input.
+    if (!pendingInput.empty()) {
+      FD_SET(masterFd, &wfd);
+    }
     int maxfd = max(masterFd, routerFd);
     tv.tv_sec = 0;
     tv.tv_usec = 10000;
-    select(maxfd + 1, &rfd, NULL, NULL, &tv);
+    select(maxfd + 1, &rfd, &wfd, NULL, &tv);
     VLOG(4) << "select is done";
 
     time_t currentSecond = time(NULL);
@@ -158,9 +183,9 @@ void UserTerminalHandler::runUserTerminal(int masterFd) {
             TerminalBuffer tb =
                 socketHandler->readProto<TerminalBuffer>(routerFd, false);
             VLOG(4) << "Read from router";
-            const string &buffer = tb.buffer();
-            RawSocketUtils::writeAll(masterFd, &buffer[0], buffer.length());
-            VLOG(4) << "Write to terminal";
+            // Buffer the input; it is drained to the pty (non-blocking) below
+            // so a large burst can never block this loop.
+            pendingInput.append(tb.buffer());
             break;
           }
           case TERMINAL_INFO: {
@@ -174,6 +199,26 @@ void UserTerminalHandler::runUserTerminal(int masterFd) {
             term->setInfo(tmpwin);
             break;
           }
+        }
+      }
+
+      // Drain buffered input to the pty without blocking.  A short write (the
+      // pty input buffer is full) just leaves the rest pending for the next
+      // iteration, so output keeps draining in the meantime.
+      if (!pendingInput.empty()) {
+        int rc = write(masterFd, pendingInput.data(), pendingInput.length());
+        int writeErrno = errno;  // Save errno before any logging
+        if (rc > 0) {
+          pendingInput.erase(0, rc);
+        } else if (rc < 0 && writeErrno != EAGAIN &&
+                   writeErrno != EWOULDBLOCK) {
+          // Fatal write error - log with correct errno and exit gracefully
+          LOG(ERROR) << "Terminal write error: " << writeErrno << " "
+                     << strerror(writeErrno);
+          term->handleSessionEnd();
+          lock_guard<recursive_mutex> guard(shutdownMutex);
+          shuttingDown = true;
+          break;
         }
       }
     } catch (const std::exception &ex) {

--- a/test/FakeConsole.hpp
+++ b/test/FakeConsole.hpp
@@ -1,6 +1,8 @@
 #ifndef __FAKE_CONSOLE_HPP__
 #define __FAKE_CONSOLE_HPP__
 
+#include <fcntl.h>
+
 #include "Console.hpp"
 #include "ETerminal.pb.h"
 #include "PipeSocketHandler.hpp"
@@ -157,6 +159,11 @@ class FakeUserTerminal : public UserTerminal {
     FATAL_FAIL(clientServerFd);
     serverListenThread.join();
     FATAL_FAIL(serverClientFd);
+    // Honor the UserTerminal contract: the handler polls this fd non-blocking.
+    int flags = fcntl(clientServerFd, F_GETFL, 0);
+    if (flags != -1) {
+      fcntl(clientServerFd, F_SETFL, flags | O_NONBLOCK);
+    }
     return getFd();
   };
 

--- a/test/integration_tests/TerminalTest.cpp
+++ b/test/integration_tests/TerminalTest.cpp
@@ -1,4 +1,15 @@
 #include <atomic>
+#include <chrono>
+#include <future>
+
+#if __APPLE__
+#include <util.h>
+#else
+#include <pty.h>
+#endif
+#include <fcntl.h>
+#include <sys/wait.h>
+#include <termios.h>
 
 #include "FakeConsole.hpp"
 #include "FakeSshSetupHandler.hpp"
@@ -83,6 +94,173 @@ void readWriteTest(shared_ptr<PipeSocketHandler> routerSocketHandler,
 
   unsetenv("ET_TEST_VAR1");
   unsetenv("ET_TEST_VAR2_EMPTY");
+}
+
+// A UserTerminal backed by a *real* pty running `cat`, so the test exercises
+// real pty buffer + backpressure semantics.  FakeUserTerminal is a socket pair
+// and cannot reproduce the input-write deadlock -- which is exactly why that
+// bug went unnoticed.  `cat` echoes input back byte-for-byte; the pty is raw +
+// no-echo so the round-trip is exactly 1:1.
+class RealPtyEchoTerminal : public UserTerminal {
+ public:
+  RealPtyEchoTerminal() : masterFd(-1), childPid(-1) {}
+  virtual ~RealPtyEchoTerminal() {}
+
+  virtual int setup(int routerFd) {
+    struct termios tios;
+    memset(&tios, 0, sizeof(tios));
+    cfmakeraw(&tios);
+    tios.c_cc[VMIN] = 1;
+    tios.c_cc[VTIME] = 0;
+    childPid = forkpty(&masterFd, NULL, &tios, NULL);
+    if (childPid == -1) {
+      FATAL_FAIL(childPid);
+    }
+    if (childPid == 0) {
+      execl("/bin/cat", "cat", (char*)NULL);
+      _exit(127);
+    }
+    // Honor the UserTerminal contract: the handler polls this fd non-blocking.
+    int flags = fcntl(masterFd, F_GETFL, 0);
+    if (flags != -1) {
+      fcntl(masterFd, F_SETFL, flags | O_NONBLOCK);
+    }
+    return masterFd;
+  }
+  virtual void runTerminal() {}
+  virtual void handleSessionEnd() {}
+  virtual void cleanup() {
+    if (masterFd >= 0) {
+      close(masterFd);
+      masterFd = -1;
+    }
+    if (childPid > 0) {
+      int status = 0;
+      waitpid(childPid, &status, 0);
+      childPid = -1;
+    }
+  }
+  virtual int getFd() { return masterFd; }
+  virtual void setInfo(const winsize& tmpwin) {}
+
+ private:
+  int masterFd;
+  pid_t childPid;
+};
+
+// Pushes a payload much larger than one pty buffer through the real handler and
+// a real pty, and requires that every byte echoes back within a deadline.  The
+// pre-fix handler wrote input with a *blocking* writeAll(masterFd, ...); while
+// blocked there it stopped draining output, so the echo filled the pty output
+// buffer, the shell stalled, and the input write never completed -- a deadlock
+// that hung past ~one pty buffer of input.  This test times out on that code
+// and passes with the buffered non-blocking input drain.
+void largeInputNoDeadlockTest(shared_ptr<PipeSocketHandler> routerSocketHandler,
+                              SocketEndpoint serverEndpoint,
+                              shared_ptr<SocketHandler> clientSocketHandler,
+                              shared_ptr<SocketHandler> clientPipeSocketHandler,
+                              shared_ptr<FakeConsole> fakeConsole,
+                              const SocketEndpoint& routerEndpoint) {
+  auto fakeSubprocessUtils = make_shared<FakeSubprocessUtils>();
+  auto sshSetupHandler = make_shared<FakeSshSetupHandler>(fakeSubprocessUtils);
+  auto [id, passkey] = sshSetupHandler->SetupSsh(
+      "", "localhost", "localhost", 2022, "", "", false, 0, "", "", {});
+
+  auto realPty = make_shared<RealPtyEchoTerminal>();
+  auto uth = shared_ptr<UserTerminalHandler>(new UserTerminalHandler(
+      routerSocketHandler, realPty, true, routerEndpoint, id + "/" + passkey));
+  thread uthThread([uth]() { uth->run(); });
+  sleep(1);
+
+  shared_ptr<TerminalClient> terminalClient(
+      new TerminalClient(clientSocketHandler, clientPipeSocketHandler,
+                         serverEndpoint, id, passkey, fakeConsole, false, "",
+                         "", false, "", MAX_CLIENT_KEEP_ALIVE_DURATION, {}));
+  thread terminalClientThread(
+      [terminalClient]() { terminalClient->run("", false); });
+  sleep(3);
+
+  // Before the bulk test, confirm the full client -> pty(`cat`) -> client echo
+  // pipe is actually live, and drain anything the connection produced during
+  // setup.  The fixed sleeps above are not a reliable readiness signal on a
+  // slow build -- under a sanitizer run with `ctest --parallel`, typing could
+  // start before the pipeline was fully wired, which made this test flaky in
+  // CI.  The sentinel is far smaller than one pty buffer, so it round-trips
+  // even on the pre-fix handler; only the large payload below can trigger the
+  // deadlock, so the warmup cannot mask a regression.
+  const string sentinel = "ET_WARMUP_SENTINEL";
+  fakeConsole->simulateKeystrokes(sentinel);
+  {
+    std::promise<bool> warmPromise;
+    auto warmFuture = warmPromise.get_future();
+    thread warmThread([&warmPromise, fakeConsole, sentinel]() {
+      // Read one byte at a time until the rolling tail matches the sentinel,
+      // discarding any bytes that preceded the echo.
+      string seen;
+      while (seen.size() < sentinel.size() ||
+             seen.compare(seen.size() - sentinel.size(), sentinel.size(),
+                          sentinel) != 0) {
+        seen += fakeConsole->getTerminalData(1);
+      }
+      warmPromise.set_value(true);
+    });
+    bool warm = warmFuture.wait_for(std::chrono::seconds(30)) ==
+                std::future_status::ready;
+    REQUIRE(warm);  // the echo pipe must be live before the bulk test
+    if (warm) {
+      warmThread.join();
+    } else {
+      warmThread.detach();
+    }
+  }
+
+  // A payload well past one pty buffer (~1KB macOS, ~8KB Linux) -- enough to
+  // deadlock the pre-fix handler -- but small enough not to stress the
+  // pipe-based test transport.
+  const int kSize = 8 * 1024;
+  string payload(kSize, '\0');
+  for (int a = 0; a < kSize; a++) {
+    payload[a] = 'a' + (rand() % 26);
+  }
+
+  thread typeThread([payload, fakeConsole]() {
+    for (size_t off = 0; off < payload.size(); off += 1024) {
+      fakeConsole->simulateKeystrokes(payload.substr(off, 1024));
+    }
+  });
+
+  // Read the echo back under a watchdog; the deadlocking code never delivers
+  // it.  The deadline is generous so a slow (sanitizer) build still cleanly
+  // distinguishes a wedge (never delivers) from success, without flaking.
+  std::promise<string> donePromise;
+  auto doneFuture = donePromise.get_future();
+  thread readThread([&donePromise, fakeConsole, kSize]() {
+    donePromise.set_value(fakeConsole->getTerminalData(kSize));
+  });
+
+  bool completed = doneFuture.wait_for(std::chrono::seconds(60)) ==
+                   std::future_status::ready;
+  REQUIRE(completed);  // would time out (FAIL) on the pre-fix deadlock
+
+  if (completed) {
+    string got = doneFuture.get();
+    REQUIRE(got.size() == (size_t)kSize);
+    REQUIRE(got == payload);
+    typeThread.join();
+    readThread.join();
+  } else {
+    // Don't hang the suite on a regression; teardown unblocks the threads.
+    typeThread.detach();
+    readThread.detach();
+  }
+
+  terminalClient->shutdown();
+  terminalClientThread.join();
+  terminalClient.reset();
+
+  uth->shutdown();
+  uthThread.join();
+  uth.reset();
 }
 
 class LogInterceptHandler : public el::LogDispatchCallback {
@@ -243,6 +421,13 @@ TEST_CASE_METHOD(EndToEndTestFixture, "EndToEndTest",
   readWriteTest(routerSocketHandler, fakeUserTerminal, serverEndpoint,
                 clientSocketHandler, clientPipeSocketHandler, fakeConsole,
                 routerEndpoint);
+}
+
+TEST_CASE_METHOD(EndToEndTestFixture, "LargeInputNoDeadlock",
+                 "[EndToEndTest][integration]") {
+  largeInputNoDeadlockTest(routerSocketHandler, serverEndpoint,
+                           clientSocketHandler, clientPipeSocketHandler,
+                           fakeConsole, routerEndpoint);
 }
 
 void simultaneousTerminalConnectionTest(


### PR DESCRIPTION
## The bug

The per-session terminal pump, `UserTerminalHandler::runUserTerminal`, is a single-threaded `select` loop that wrote client input to the pty master with a **blocking** `RawSocketUtils::writeAll()`. A burst of input larger than ~one pty buffer deadlocks the session:

1. The input echoes back and fills the pty's output buffer.
2. With its output buffer full, the shell stalls and stops reading input.
3. The blocking write to the master never drains, so it never returns.
4. Stuck in that write, the loop also stops draining output -- the very thing that would unstick the shell.

The whole session wedges. It's reproducible by pasting a multi-KB heredoc: ~1KB on macOS, ~8-10KB on Linux (where one pty buffer is larger).

Related is [issue 682](https://github.com/MisterTea/EternalTerminal/issues/682).

## The fix

The read path already tolerated `EAGAIN` -- it was written expecting a non-blocking master -- but nothing ever made the master non-blocking. So:

- **Set `O_NONBLOCK` where the fd is created**, in `UserTerminal::setup` (`PseudoUserTerminal` and the test terminals). This is now part of that interface's contract.
- **Rework the pump to never block:** buffer pending input, drain it to the master through the `select` write set, and keep reading output every iteration.
- **Add backpressure:** when the input buffer fills, stop reading more from the router so backpressure reaches the client -- symmetric to the existing output gating on `routerWritable`.

## Testing

A new regression test, `TerminalTest "LargeInputNoDeadlock"`, drives a real pty (`cat` in raw mode) through the real handler. It first does a small warmup round-trip to confirm the full client -> pty -> client echo path is live, then pushes an 8KB payload (well past one pty buffer) and requires every byte to echo back within a generous deadline. The old code deadlocks and the read never completes, so the test **times out and fails; with the fix it round-trips and passes.** The warmup keeps the test reliable on a slow build (a sanitizer run under `ctest --parallel`), where it would otherwise start typing before the pipeline was wired; it is far smaller than one pty buffer, so it round-trips even on the buggy code and cannot mask the regression. The existing tests never caught this because they all use `FakeUserTerminal` (a socket pair), which has no pty buffer semantics.

The full `et-test` suite is green, and the fix has been validated live: a 56KB one-shot input that previously wedged the session now round-trips byte-exact against a real `etserver`.

## Why it's low-risk

**Server-side only -- no protocol, client, or proto changes.** The change is confined to the terminal pump and the `UserTerminal::setup` contract; the wire format and everything around it are untouched. A non-blocking master is what the read path already assumed, so this makes the code match its own expectations.

## Asking for guidance

Setting `O_NONBLOCK` in `setup` (rather than inside the pump) made the contract explicit and kept the fake terminals honest, but I'm happy to move it if you'd rather. Is the approach right?

---

*This PR was prepared with AI assistance; I've reviewed and stand behind it.*
