### PR TITLE
Add Unix socket path forwarding for -t and -r tunnel options

### DIFF
--- a/src/base/TunnelUtils.cpp
+++ b/src/base/TunnelUtils.cpp
@@ -1,6 +1,9 @@
 #include "TunnelUtils.hpp"
 
 namespace et {
+
+bool isSocketPath(const string& s) { return !s.empty() && s[0] == '/'; }
+
 void processEtStyleTunnelArg(vector<PortForwardSourceRequest>& pfsrs,
                              const vector<string> sourceDestination,
                              const string& input) {
@@ -9,8 +12,29 @@ void processEtStyleTunnelArg(vector<PortForwardSourceRequest>& pfsrs,
         "Tunnel argument must have source and destination between a ':'");
   }
   try {
-    if (sourceDestination[0].find_first_not_of("0123456789-") != string::npos &&
-        sourceDestination[1].find_first_not_of("0123456789-") != string::npos) {
+    bool srcIsSocket = isSocketPath(sourceDestination[0]);
+    bool srcIsNumeric =
+        sourceDestination[0].find_first_not_of("0123456789-") == string::npos;
+    bool dstIsSocket = isSocketPath(sourceDestination[1]);
+
+    if (srcIsSocket || (dstIsSocket && srcIsNumeric)) {
+      PortForwardSourceRequest pfsr;
+      if (srcIsSocket) {
+        pfsr.mutable_source()->set_name(sourceDestination[0]);
+      } else {
+        pfsr.mutable_source()->set_name("localhost");
+        pfsr.mutable_source()->set_port(stoi(sourceDestination[0]));
+      }
+      if (dstIsSocket) {
+        pfsr.mutable_destination()->set_name(sourceDestination[1]);
+      } else {
+        pfsr.mutable_destination()->set_port(stoi(sourceDestination[1]));
+      }
+      pfsrs.push_back(pfsr);
+    } else if (sourceDestination[0].find_first_not_of("0123456789-") !=
+                   string::npos &&
+               sourceDestination[1].find_first_not_of("0123456789-") !=
+                   string::npos) {
       // forwarding named pipes with environment variables (don't set source)
       PortForwardSourceRequest pfsr;
       pfsr.set_environmentvariable(sourceDestination[0]);

--- a/src/terminal/TerminalClient.cpp
+++ b/src/terminal/TerminalClient.cpp
@@ -32,9 +32,8 @@ TerminalClient::TerminalClient(
         auto pfsresponse =
             portForwardHandler->createSource(pfsr, nullptr, -1, -1);
         if (pfsresponse.has_error()) {
-          LOG(WARNING) << "Failed to establish port forward "
-                       << pfsr.source().port() << ":"
-                       << pfsr.destination().port() << " - "
+          LOG(WARNING) << "Failed to establish port forward " << pfsr.source()
+                       << " -> " << pfsr.destination() << " - "
                        << pfsresponse.error();
           continue;
         }

--- a/src/terminal/TerminalClientMain.cpp
+++ b/src/terminal/TerminalClientMain.cpp
@@ -145,11 +145,14 @@ int main(int argc, char** argv) {
         ("t,tunnel",
          "Tunnel: Array of source:destination ports or "
          "srcStart-srcEnd:dstStart-dstEnd (inclusive) port ranges (e.g. "
-         "10080:80,10443:443, 10090-10092:8000-8002) or ssh-style -L/-R "
-         "argument. Defaults to localhost for bind address unless ssh-style "
-         "tunnel argument is used.",
+         "10080:80,10443:443, 10090-10092:8000-8002), ssh-style -L/-R "
+         "argument, or Unix socket paths (e.g. "
+         "/tmp/local.sock:/tmp/remote.sock, 8080:/tmp/remote.sock, "
+         "/tmp/local.sock:8080). Defaults to localhost for bind address "
+         "unless ssh-style tunnel argument is used.",
          cxxopts::value<std::string>())  //
-        ("r,reversetunnel", "Reverse Tunnel: See doc for -t/--tunnel.",
+        ("r,reversetunnel",
+         "Reverse Tunnel: Same syntax as -t/--tunnel but reversed.",
          cxxopts::value<std::string>())  //
         ("jumphost", "jumphost between localhost and destination",
          cxxopts::value<std::string>())  //

--- a/src/terminal/forwarding/PortForwardHandler.cpp
+++ b/src/terminal/forwarding/PortForwardHandler.cpp
@@ -75,15 +75,13 @@ PortForwardSourceResponse PortForwardHandler::createSource(
       sourceHandlers.push_back(handler);
       return PortForwardSourceResponse();
     } else {
-      if (userid < 0 || groupid < 0) {
-        STFATAL
-            << "Tried to create a unix socket forward with no userid/groupid";
-      }
       auto handler = shared_ptr<ForwardSourceHandler>(new ForwardSourceHandler(
           pipeSocketHandler, source, pfsr.destination()));
 #ifndef WIN32
-      FATAL_FAIL(::chmod(source.name().c_str(), S_IRUSR | S_IWUSR | S_IXUSR));
-      FATAL_FAIL(::chown(source.name().c_str(), userid, groupid));
+      if (userid >= 0 && groupid >= 0) {
+        FATAL_FAIL(::chmod(source.name().c_str(), S_IRUSR | S_IWUSR | S_IXUSR));
+        FATAL_FAIL(::chown(source.name().c_str(), userid, groupid));
+      }
 #endif
       sourceHandlers.push_back(handler);
       return PortForwardSourceResponse();

--- a/test/unit_tests/TunnelUtilsTest.cpp
+++ b/test/unit_tests/TunnelUtilsTest.cpp
@@ -88,6 +88,57 @@ TEST_CASE("Parses environment variable forward", "[TunnelUtils]") {
   REQUIRE_FALSE(requests[0].has_source());
 }
 
+TEST_CASE("Parses Unix socket to Unix socket forward", "[TunnelUtils]") {
+  auto requests = parseRangesToRequests("/tmp/local.sock:/tmp/remote.sock");
+
+  REQUIRE(requests.size() == 1);
+  REQUIRE(requests[0].has_source());
+  REQUIRE(requests[0].source().name() == "/tmp/local.sock");
+  REQUIRE_FALSE(requests[0].source().has_port());
+  REQUIRE(requests[0].has_destination());
+  REQUIRE(requests[0].destination().name() == "/tmp/remote.sock");
+  REQUIRE_FALSE(requests[0].destination().has_port());
+}
+
+TEST_CASE("Parses Unix socket source to TCP destination", "[TunnelUtils]") {
+  auto requests = parseRangesToRequests("/tmp/local.sock:8080");
+
+  REQUIRE(requests.size() == 1);
+  REQUIRE(requests[0].has_source());
+  REQUIRE(requests[0].source().name() == "/tmp/local.sock");
+  REQUIRE_FALSE(requests[0].source().has_port());
+  REQUIRE(requests[0].has_destination());
+  REQUIRE(requests[0].destination().port() == 8080);
+}
+
+TEST_CASE("Parses TCP source to Unix socket destination", "[TunnelUtils]") {
+  auto requests = parseRangesToRequests("8080:/tmp/remote.sock");
+
+  REQUIRE(requests.size() == 1);
+  REQUIRE(requests[0].has_source());
+  REQUIRE(requests[0].source().name() == "localhost");
+  REQUIRE(requests[0].source().port() == 8080);
+  REQUIRE(requests[0].has_destination());
+  REQUIRE(requests[0].destination().name() == "/tmp/remote.sock");
+  REQUIRE_FALSE(requests[0].destination().has_port());
+}
+
+TEST_CASE("Parses mixed socket and port comma-separated", "[TunnelUtils]") {
+  auto requests =
+      parseRangesToRequests("/tmp/local.sock:8080,9090:/tmp/remote.sock");
+
+  REQUIRE(requests.size() == 2);
+
+  REQUIRE(requests[0].source().name() == "/tmp/local.sock");
+  REQUIRE_FALSE(requests[0].source().has_port());
+  REQUIRE(requests[0].destination().port() == 8080);
+
+  REQUIRE(requests[1].source().name() == "localhost");
+  REQUIRE(requests[1].source().port() == 9090);
+  REQUIRE(requests[1].destination().name() == "/tmp/remote.sock");
+  REQUIRE_FALSE(requests[1].destination().has_port());
+}
+
 TEST_CASE("Rejects malformed port forward input", "[TunnelUtils]") {
   SECTION("Mismatched range lengths") {
     REQUIRE_THROWS_WITH(


### PR DESCRIPTION
Support forwarding Unix domain sockets in addition to TCP ports. Paths starting with '/' are recognized as socket endpoints, enabling combinations like socket-to-socket, socket-to-port, and port-to-socket.