### PR TITLE
Add manual deployment workflows

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -2,4 +2,4 @@
 skip = .git,*.pdf,*.svg,.codespellrc
 check-hidden = true
 ignore-regex = \bhenrik@gassmann.onl\b
-ignore-words-list = te
+ignore-words-list = te,fpr,buildd

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -20,3 +20,5 @@ jobs:
         uses: actions/checkout@v4
       - name: Codespell
         uses: codespell-project/actions-codespell@v2
+        with:
+          skip: ./external

--- a/.github/workflows/deploy_archlinux_aur.yml
+++ b/.github/workflows/deploy_archlinux_aur.yml
@@ -1,0 +1,128 @@
+name: Deploy Arch Linux AUR
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Release tag to deploy. Leave blank to use the latest GitHub release."
+        required: false
+        default: ""
+      aur_repo:
+        description: "AUR package Git repository."
+        required: true
+        default: "ssh://aur@aur.archlinux.org/eternalterminal.git"
+      push_changes:
+        description: "Push the generated commit to AUR."
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  deploy_archlinux_aur:
+    name: deploy-archlinux-aur
+    runs-on: ubuntu-latest
+    container:
+      image: archlinux:latest
+    env:
+      AUR_REPO: ${{ inputs.aur_repo }}
+      RELEASE_TAG: ${{ inputs.release_tag }}
+    steps:
+      - name: Install packaging dependencies
+        run: |
+          pacman -Syu --disable-sandbox --noconfirm --needed \
+            base-devel \
+            curl \
+            git \
+            jq \
+            openssh \
+            sudo \
+            wget
+
+      - name: Create packaging user
+        run: |
+          useradd -m -G wheel -s /bin/bash packager
+          echo "%wheel ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+      - name: Configure SSH and Git
+        env:
+          AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+        run: |
+          if [[ -z "${AUR_SSH_PRIVATE_KEY}" ]]; then
+            echo "Missing required secret AUR_SSH_PRIVATE_KEY" >&2
+            exit 1
+          fi
+
+          install -d -m 700 /home/packager/.ssh
+          printf '%s\n' "${AUR_SSH_PRIVATE_KEY}" > /home/packager/.ssh/id_ed25519
+          chmod 600 /home/packager/.ssh/id_ed25519
+          ssh-keyscan aur.archlinux.org >> /home/packager/.ssh/known_hosts
+          chown -R packager:packager /home/packager/.ssh
+
+          sudo -u packager git config --global user.name "Jason Gauci"
+          sudo -u packager git config --global user.email "jgmath2000@gmail.com"
+
+      - name: Resolve release
+        run: |
+          if [[ -z "${RELEASE_TAG}" ]]; then
+            release_json="$(curl --fail --silent --show-error --location "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/latest")"
+            RELEASE_TAG="$(jq --raw-output ".tag_name" <<<"${release_json}")"
+          fi
+
+          if [[ -z "${RELEASE_TAG}" || "${RELEASE_TAG}" == "null" ]]; then
+            echo "Could not resolve a release tag" >&2
+            exit 1
+          fi
+
+          VERSION_NUMBER="${RELEASE_TAG#et-v}"
+          if [[ "${VERSION_NUMBER}" == "${RELEASE_TAG}" ]]; then
+            echo "Expected release tag to start with et-v, got ${RELEASE_TAG}" >&2
+            exit 1
+          fi
+
+          {
+            echo "RELEASE_TAG=${RELEASE_TAG}"
+            echo "VERSION_NUMBER=${VERSION_NUMBER}"
+          } >> "${GITHUB_ENV}"
+
+      - name: Update AUR package
+        run: |
+          sudo -u packager git clone "${AUR_REPO}" /home/packager/arch_et
+          pushd /home/packager/arch_et
+
+          sudo -u packager wget "https://github.com/MisterTea/EternalTerminal/archive/et-v${VERSION_NUMBER}.tar.gz"
+          NEW_SHA="$(sha256sum "et-v${VERSION_NUMBER}.tar.gz" | awk '{print $1}')"
+          rm "et-v${VERSION_NUMBER}.tar.gz"
+
+          sed -i -E "s/sha256sums=\('(.*)'\)/sha256sums=\('${NEW_SHA}'\)/" PKGBUILD
+          sed -i -E "s/pkgver='(.*)'/pkgver='${VERSION_NUMBER}'/" PKGBUILD
+
+          chown -R packager:packager /home/packager/arch_et
+          sudo -u packager bash -lc 'cd /home/packager/arch_et && makepkg --printsrcinfo > .SRCINFO'
+
+          sudo -u packager git diff -- PKGBUILD .SRCINFO
+          popd
+
+      - name: Commit and push AUR package
+        env:
+          PUSH_CHANGES: ${{ inputs.push_changes }}
+        run: |
+          pushd /home/packager/arch_et
+
+          if sudo -u packager git diff --quiet -- PKGBUILD .SRCINFO; then
+            echo "PKGBUILD and .SRCINFO are already up to date for ${RELEASE_TAG}"
+            exit 0
+          fi
+
+          sudo -u packager git add PKGBUILD .SRCINFO
+          sudo -u packager git commit -m "Update eternalterminal to ${VERSION_NUMBER}"
+
+          if [[ "${PUSH_CHANGES}" == "true" ]]; then
+            sudo -u packager git push origin HEAD:master
+          else
+            echo "push_changes is false; leaving generated commit unpushed"
+          fi
+
+          popd

--- a/.github/workflows/deploy_debian_repo.yml
+++ b/.github/workflows/deploy_debian_repo.yml
@@ -1,0 +1,304 @@
+name: Deploy Debian Repo
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Release tag to deploy. Leave blank to use the latest GitHub release."
+        required: false
+        default: ""
+      deployment_ref:
+        description: "Ref containing the deployment packaging templates."
+        required: true
+        default: "deployment"
+      debian_repo:
+        description: "Git repository containing the published Debian repo."
+        required: true
+        default: "git@github.com:MisterTea/debian-et.git"
+      push_changes:
+        description: "Commit and push generated repository contents."
+        required: true
+        type: boolean
+        default: true
+      debian_suites:
+        description: "Space-separated Debian suites to build. Leave blank for oldstable, stable, and testing."
+        required: false
+        default: ""
+      debian_arches:
+        description: "Space-separated Debian architectures to build. Leave blank for amd64 and arm64."
+        required: false
+        default: ""
+      verbose_build:
+        description: "Run debhelper in verbose mode."
+        required: true
+        type: boolean
+        default: true
+      quiet_cowbuilder:
+        description: "Redirect cowbuilder logs to files unless a cowbuilder command fails."
+        required: true
+        type: boolean
+        default: false
+      deb_build_jobs:
+        description: "Parallel jobs passed to Debian package builds."
+        required: true
+        default: "2"
+
+permissions:
+  contents: read
+
+jobs:
+  deploy_debian_repo:
+    name: deploy-debian-repo
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    env:
+      DEBFULLNAME: Jason Gauci
+      DEBEMAIL: jgmath2000@gmail.com
+      DEPLOYMENT_REF: ${{ inputs.deployment_ref }}
+      DEBIAN_REPO: ${{ inputs.debian_repo }}
+      DEBIAN_ARCHES: ${{ inputs.debian_arches }}
+      DEBIAN_SUITES: ${{ inputs.debian_suites }}
+      DEB_BUILD_JOBS: ${{ inputs.deb_build_jobs }}
+      INPUT_RELEASE_TAG: ${{ inputs.release_tag }}
+      QUIET_COWBUILDER: ${{ inputs.quiet_cowbuilder }}
+      PUSH_CHANGES: ${{ inputs.push_changes }}
+      VERBOSE_BUILD: ${{ inputs.verbose_build }}
+    steps:
+      - name: Install build and publishing dependencies
+        run: |
+          sudo apt-get update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+            aptly \
+            arch-test \
+            binfmt-support \
+            build-essential \
+            ca-certificates \
+            cmake \
+            cowbuilder \
+            curl \
+            debhelper \
+            debian-archive-keyring \
+            debootstrap \
+            devscripts \
+            distro-info \
+            git \
+            jq \
+            libcurl4-openssl-dev \
+            libprotobuf-dev \
+            libsodium-dev \
+            libssl-dev \
+            libtool \
+            libunwind-dev \
+            libutempter-dev \
+            ninja-build \
+            openssh-client \
+            protobuf-compiler \
+            python3 \
+            qemu-user-static \
+            rsync \
+            ubuntu-dev-tools \
+            wget
+
+          sudo update-binfmts --enable || true
+          echo "PBUILDERSATISFYDEPENDSCMD=/usr/lib/pbuilder/pbuilder-satisfydepends-apt" > "${HOME}/.pbuilderrc"
+
+      - name: Resolve release
+        run: |
+          if [[ -n "${INPUT_RELEASE_TAG}" ]]; then
+            release_tag="${INPUT_RELEASE_TAG}"
+            tarball_url="https://api.github.com/repos/${GITHUB_REPOSITORY}/tarball/${release_tag}"
+          else
+            latest_release="$(curl --fail --silent --show-error --location "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/latest")"
+            release_tag="$(jq --raw-output ".tag_name" <<<"${latest_release}")"
+            tarball_url="$(jq --raw-output ".tarball_url" <<<"${latest_release}")"
+          fi
+
+          if [[ -z "${release_tag}" || "${release_tag}" == "null" ]]; then
+            echo "Could not resolve a release tag" >&2
+            exit 1
+          fi
+
+          version="${release_tag#et-v}"
+          if [[ "${version}" == "${release_tag}" ]]; then
+            echo "Expected release tag to start with et-v, got ${release_tag}" >&2
+            exit 1
+          fi
+
+          {
+            echo "RELEASE_TAG=${release_tag}"
+            echo "RELEASE_VERSION=${version}"
+            echo "TARBALL_URL=${tarball_url}"
+            echo "ORIG_TARBALL=et_${version}.orig.tar.gz"
+          } >> "${GITHUB_ENV}"
+
+      - name: Check out deployment packaging
+        run: |
+          git clone --depth 1 --branch "${DEPLOYMENT_REF}" "https://github.com/${GITHUB_REPOSITORY}.git" deployment-branch
+
+      - name: Download original release tarball
+        run: |
+          wget "${TARBALL_URL}" -O "${ORIG_TARBALL}"
+
+      - name: Build Debian packages and publish local repositories
+        run: |
+          debbuildopts="-j${DEB_BUILD_JOBS}"
+
+          run_cowbuilder() {
+            local log_file="$1"
+            shift
+
+            if [[ "${QUIET_COWBUILDER}" == "true" ]]; then
+              echo "Running cowbuilder command; full log: ${log_file}"
+              if ! "$@" >"${log_file}" 2>&1; then
+                echo "cowbuilder command failed; matching error lines:" >&2
+                awk 'tolower($0) ~ /(error:|fatal:|failed|killed|undefined reference|cannot|no such file|returned exit status)/ { print }' "${log_file}" >&2 || true
+                echo "cowbuilder command failed; last 200 log lines:" >&2
+                tail -n 400 "${log_file}" >&2 || true
+                return 1
+              fi
+            else
+              "$@"
+            fi
+          }
+
+          if [[ -n "${DEBIAN_SUITES}" ]]; then
+            read -r -a debian_suites <<<"${DEBIAN_SUITES}"
+          else
+            mapfile -t debian_suites < <(
+              {
+                debian-distro-info --oldstable
+                debian-distro-info --stable
+                debian-distro-info --testing
+              } | awk 'NF' | sort -u
+            )
+          fi
+
+          if [[ "${#debian_suites[@]}" -eq 0 ]]; then
+            echo "No Debian suites discovered" >&2
+            exit 1
+          fi
+
+          if [[ -n "${DEBIAN_ARCHES}" ]]; then
+            read -r -a debian_arches <<<"${DEBIAN_ARCHES}"
+          else
+            debian_arches=(amd64 arm64)
+          fi
+
+          if [[ "${#debian_arches[@]}" -eq 0 ]]; then
+            echo "No Debian architectures configured" >&2
+            exit 1
+          fi
+
+          for distro in "${debian_suites[@]}"; do
+            rm -rf EternalTerminal
+            mkdir EternalTerminal
+            tar -xzf "${ORIG_TARBALL}" --strip-components=1 -C EternalTerminal
+
+            rm -rf EternalTerminal/debian
+            cp -a deployment-branch/deployment/debian/debian_SOURCE EternalTerminal/debian
+            python3 -c 'import pathlib; path = pathlib.Path("EternalTerminal/debian/rules"); path.write_text(path.read_text().replace("-DDISABLE_VCPKG:BOOL=ON", "-DDISABLE_VCPKG:BOOL=ON -DDISABLE_TELEMETRY:BOOL=ON"))'
+            if [[ "${VERBOSE_BUILD}" != "true" ]]; then
+              python3 -c 'import pathlib; path = pathlib.Path("EternalTerminal/debian/rules"); path.write_text(path.read_text().replace("export DH_VERBOSE = 1", "export DH_VERBOSE = 0"))'
+            fi
+            python3 -c 'import pathlib, sys; path = pathlib.Path("EternalTerminal/debian/changelog"); path.write_text(path.read_text().replace("##DISTRO##", sys.argv[1]))' "${distro}"
+            sed -i -E 's/^\* /  * /; s/^-- / -- /' EternalTerminal/debian/changelog
+            printf '\nexport DEB_BUILD_OPTIONS += noautodbgsym\n\noverride_dh_strip:\n\tdh_strip --no-automatic-dbgsym\n' >> EternalTerminal/debian/rules
+
+            rm -f ./*.dsc ./*.changes ./*.buildinfo ./*.debian.tar.* ./*.upload
+            pushd EternalTerminal
+            debuild -S -us -uc
+            popd
+
+            for arch in "${debian_arches[@]}"; do
+              cow_dir="${HOME}/pbuilder/${distro}-${arch}.cow"
+              result_dir="${HOME}/pbuilder/${distro}-${arch}_result"
+
+              if [[ ! -d "${cow_dir}" ]]; then
+                run_cowbuilder "cowbuilder-${distro}-${arch}-create.log" \
+                  cowbuilder-dist "${distro}" "${arch}" create --debootstrapopts --variant=buildd
+              fi
+
+              run_cowbuilder "cowbuilder-${distro}-${arch}-update.log" \
+                cowbuilder-dist "${distro}" "${arch}" update
+              run_cowbuilder "cowbuilder-${distro}-${arch}-build.log" \
+                cowbuilder-dist "${distro}" "${arch}" build \
+                --debbuildopts "${debbuildopts}" \
+                ./*.dsc
+
+              mkdir -p "debian-packages/${distro}-${arch}"
+              result_dirs=("${result_dir}" "${HOME}/pbuilder/${distro}_result")
+              package_files=()
+              for candidate_result_dir in "${result_dirs[@]}"; do
+                if [[ -d "${candidate_result_dir}" ]]; then
+                  shopt -s nullglob
+                  package_files+=("${candidate_result_dir}"/*.deb)
+                  cp -a "${candidate_result_dir}"/*.buildinfo "debian-packages/${distro}-${arch}/" || true
+                  cp -a "${candidate_result_dir}"/*.changes "debian-packages/${distro}-${arch}/" || true
+                  shopt -u nullglob
+                fi
+              done
+
+              if [[ "${#package_files[@]}" -eq 0 ]]; then
+                echo "No Debian packages found in expected result directories:" >&2
+                printf '  %s\n' "${result_dirs[@]}" >&2
+                exit 1
+              fi
+
+              cp -a "${package_files[@]}" "debian-packages/${distro}-${arch}/"
+            done
+
+            aptly repo create -distribution="${distro}" -component=main "et-${distro}" || true
+            aptly repo add -force-replace=true "et-${distro}" debian-packages/"${distro}"-*/*.deb
+            aptly publish drop "${distro}" || true
+            aptly publish repo -skip-signing "et-${distro}"
+          done
+
+      - name: Upload built Debian packages
+        if: ${{ !env.ACT }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: debian-packages-${{ env.RELEASE_TAG }}
+          path: debian-packages/
+
+      - name: Upload published Debian repository
+        if: ${{ !env.ACT }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: debian-repository-${{ env.RELEASE_TAG }}
+          path: ~/.aptly/public/
+
+      - name: Configure SSH for Debian repository push
+        if: ${{ inputs.push_changes }}
+        env:
+          DEBIAN_REPO_SSH_PRIVATE_KEY: ${{ secrets.DEBIAN_REPO_SSH_PRIVATE_KEY }}
+        run: |
+          if [[ -z "${DEBIAN_REPO_SSH_PRIVATE_KEY}" ]]; then
+            echo "Missing required secret DEBIAN_REPO_SSH_PRIVATE_KEY" >&2
+            exit 1
+          fi
+
+          install -d -m 700 "${HOME}/.ssh"
+          printf '%s\n' "${DEBIAN_REPO_SSH_PRIVATE_KEY}" > "${HOME}/.ssh/id_ed25519"
+          chmod 600 "${HOME}/.ssh/id_ed25519"
+          ssh-keyscan github.com >> "${HOME}/.ssh/known_hosts"
+
+          git config --global user.name "Jason Gauci"
+          git config --global user.email "jgmath2000@gmail.com"
+
+      - name: Commit and push Debian repository
+        if: ${{ inputs.push_changes }}
+        run: |
+          git clone "${DEBIAN_REPO}" debian-et
+          mkdir -p debian-et/debian-source
+          rsync -raz --delete ~/.aptly/public/ debian-et/debian-source/
+
+          pushd debian-et
+          if git diff --quiet -- debian-source; then
+            echo "Debian repository is already up to date"
+            exit 0
+          fi
+
+          git add debian-source
+          git commit -m "Update Debian packages for ${RELEASE_TAG}"
+          git push origin HEAD
+          popd

--- a/.github/workflows/deploy_ubuntu_ppa.yml
+++ b/.github/workflows/deploy_ubuntu_ppa.yml
@@ -1,0 +1,199 @@
+name: Deploy Ubuntu PPA
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Release tag to deploy. Leave blank to use the latest GitHub release."
+        required: false
+        default: ""
+      deployment_ref:
+        description: "Ref containing the deployment packaging templates."
+        required: true
+        default: "deployment"
+      ppa:
+        description: "Launchpad PPA target."
+        required: true
+        default: "ppa:jgmath2000/et"
+
+permissions:
+  contents: read
+
+jobs:
+  deploy_ubuntu_ppa:
+    name: deploy-ubuntu-ppa
+    runs-on: ubuntu-latest
+    env:
+      DEBFULLNAME: Jason Gauci
+      DEBEMAIL: jgmath2000@gmail.com
+    steps:
+      - name: Install packaging dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential \
+            ca-certificates \
+            cmake \
+            curl \
+            debhelper \
+            devscripts \
+            distro-info \
+            dput \
+            git \
+            gnupg \
+            jq \
+            libcurl4-openssl-dev \
+            libprotobuf-dev \
+            libsodium-dev \
+            libssl-dev \
+            libtool \
+            libunwind-dev \
+            libutempter-dev \
+            protobuf-compiler \
+            python3 \
+            wget
+
+      - name: Import GPG signing key
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          if [[ -z "${GPG_PRIVATE_KEY}" ]]; then
+            echo "Missing required secret GPG_PRIVATE_KEY" >&2
+            exit 1
+          fi
+          if [[ -z "${GPG_PASSPHRASE}" ]]; then
+            echo "Missing required secret GPG_PASSPHRASE" >&2
+            exit 1
+          fi
+
+          install -d -m 700 "${HOME}/.gnupg"
+          {
+            echo "use-agent"
+            echo "pinentry-mode loopback"
+          } > "${HOME}/.gnupg/gpg.conf"
+          echo "allow-loopback-pinentry" > "${HOME}/.gnupg/gpg-agent.conf"
+          gpgconf --kill gpg-agent || true
+
+          printf '%s\n' "${GPG_PRIVATE_KEY}" | gpg --batch --import
+          key_fingerprint="$(gpg --batch --list-secret-keys --with-colons | awk -F: '$1 == "fpr" { print $10; exit }')"
+          if [[ -z "${key_fingerprint}" ]]; then
+            echo "No GPG secret key was imported" >&2
+            exit 1
+          fi
+
+          passphrase_file="${RUNNER_TEMP}/gpg-passphrase"
+          printf '%s' "${GPG_PASSPHRASE}" > "${passphrase_file}"
+          chmod 600 "${passphrase_file}"
+
+          printf 'gpg signing smoke test\n' > "${RUNNER_TEMP}/gpg-smoke-test"
+          gpg --batch --yes --pinentry-mode loopback \
+            --passphrase-file "${passphrase_file}" \
+            --local-user "${key_fingerprint}" \
+            --detach-sign --armor \
+            --output "${RUNNER_TEMP}/gpg-smoke-test.asc" \
+            "${RUNNER_TEMP}/gpg-smoke-test"
+
+          {
+            echo "GPG_KEY_ID=${key_fingerprint}"
+            echo "GPG_PASSPHRASE_FILE=${passphrase_file}"
+          } >> "${GITHUB_ENV}"
+
+      - name: Resolve release
+        env:
+          INPUT_RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          if [[ -n "${INPUT_RELEASE_TAG}" ]]; then
+            release_tag="${INPUT_RELEASE_TAG}"
+            tarball_url="https://api.github.com/repos/${GITHUB_REPOSITORY}/tarball/${release_tag}"
+          else
+            latest_release="$(curl --fail --silent --show-error --location "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/latest")"
+            release_tag="$(jq --raw-output ".tag_name" <<<"${latest_release}")"
+            tarball_url="$(jq --raw-output ".tarball_url" <<<"${latest_release}")"
+          fi
+
+          if [[ -z "${release_tag}" || "${release_tag}" == "null" ]]; then
+            echo "Could not resolve a release tag" >&2
+            exit 1
+          fi
+
+          version="${release_tag#et-v}"
+          if [[ "${version}" == "${release_tag}" ]]; then
+            echo "Expected release tag to start with et-v, got ${release_tag}" >&2
+            exit 1
+          fi
+
+          {
+            echo "RELEASE_TAG=${release_tag}"
+            echo "RELEASE_VERSION=${version}"
+            echo "TARBALL_URL=${tarball_url}"
+            echo "ORIG_TARBALL=et_${version}.orig.tar.gz"
+          } >> "${GITHUB_ENV}"
+
+      - name: Check out deployment packaging
+        env:
+          DEPLOYMENT_REF: ${{ inputs.deployment_ref }}
+        run: |
+          git clone --depth 1 --branch "${DEPLOYMENT_REF}" "https://github.com/${GITHUB_REPOSITORY}.git" deployment-branch
+
+      - name: Download original release tarball
+        run: |
+          wget "${TARBALL_URL}" -O "${ORIG_TARBALL}"
+
+      - name: Extract release source
+        run: |
+          mkdir EternalTerminal
+          tar -xzf "${ORIG_TARBALL}" --strip-components=1 -C EternalTerminal
+
+      - name: Build source packages and dry-run upload
+        env:
+          PPA: ${{ inputs.ppa }}
+        run: |
+          rm -f ./*.changes
+
+          readarray -t ubuntu_series < <(distro-info --supported)
+          if [[ "${#ubuntu_series[@]}" -eq 0 ]]; then
+            echo "distro-info --supported did not return any Ubuntu series" >&2
+            exit 1
+          fi
+
+          pushd EternalTerminal
+          for distro in "${ubuntu_series[@]}"; do
+            rm -rf debian
+            cp -a ../deployment-branch/deployment/debian/debian_SOURCE debian
+            python3 -c 'import pathlib, sys; path = pathlib.Path("debian/changelog"); path.write_text(path.read_text().replace("##DISTRO##", sys.argv[1]))' "${distro}"
+            sed -i -E 's/^\* /  * /; s/^-- / -- /' debian/changelog
+            debuild -S -us -uc
+
+            changes_files=(../*"${distro}"*.changes)
+            if [[ ! -e "${changes_files[0]}" ]]; then
+              echo "No .changes file generated for ${distro}" >&2
+              exit 1
+            fi
+            dsc_files=(../*"${distro}"*.dsc)
+            if [[ ! -e "${dsc_files[0]}" ]]; then
+              echo "No .dsc file generated for ${distro}" >&2
+              exit 1
+            fi
+
+            debsign \
+              -k"${GPG_KEY_ID}" \
+              -p"gpg --batch --yes --pinentry-mode loopback --passphrase-file ${GPG_PASSPHRASE_FILE}" \
+              "${changes_files[0]}"
+
+            gpg --batch --verify "${changes_files[0]}"
+            gpg --batch --verify "${dsc_files[0]}"
+            dput --simulate --unchecked -f "${PPA}" "${changes_files[0]}"
+          done
+          popd
+
+      - name: Upload generated source packages
+        if: ${{ !env.ACT }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ubuntu-ppa-source-packages-${{ env.RELEASE_TAG }}
+          path: |
+            *.changes
+            *.dsc
+            *.debian.tar.*
+            *.orig.tar.gz

--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -102,6 +102,13 @@ jobs:
           popd
         if: matrix.sanitize == 'tsan'
 
+      - name: Stop sshd for act
+        if: ${{ always() }}
+        run: |
+          if [[ -n "${ACT:-}" ]]; then
+            sudo pkill -x sshd || true
+          fi
+
   linux_jumphost_system_test:
     runs-on: ubuntu-22.04
     env:
@@ -155,6 +162,13 @@ jobs:
       - name: Connect with jumphost
         run: ./test/system_tests/connect_with_jumphost.sh
 
+      - name: Stop sshd for act
+        if: ${{ always() }}
+        run: |
+          if [[ -n "${ACT:-}" ]]; then
+            sudo pkill -x sshd || true
+          fi
+
   linux_backwards_compatibility:
     runs-on: ubuntu-22.04
     env:
@@ -207,3 +221,10 @@ jobs:
 
       - name: Backwards compatibility with et-v6.2.10
         run: ./test/system_tests/backwards_compatibility.sh
+
+      - name: Stop sshd for act
+        if: ${{ always() }}
+        run: |
+          if [[ -n "${ACT:-}" ]]; then
+            sudo pkill -x sshd || true
+          fi

--- a/.github/workflows/portability_ci.yml
+++ b/.github/workflows/portability_ci.yml
@@ -1,0 +1,182 @@
+name: Portability CI
+
+on:
+  push:
+    branches:
+      - master
+      - release
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  linux_distros:
+    name: build-${{ matrix.distro }}
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.container }}
+    strategy:
+      fail-fast: true
+      max-parallel: 1
+      matrix:
+        include:
+          - distro: debian
+            container: debian:stable
+            install: |
+              apt-get update
+              DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+                autoconf \
+                automake \
+                build-essential \
+                ca-certificates \
+                cmake \
+                curl \
+                debhelper \
+                git \
+                libcurl4-openssl-dev \
+                libprotobuf-dev \
+                libsodium-dev \
+                libssl-dev \
+                libtool \
+                libunwind-dev \
+                libutempter-dev \
+                ninja-build \
+                pkg-config \
+                protobuf-compiler \
+                tar \
+                unzip \
+                zip
+          - distro: fedora
+            container: fedora:latest
+            install: |
+              dnf install -y \
+                @development-tools \
+                ca-certificates \
+                cmake \
+                curl \
+                gcc \
+                gcc-c++ \
+                git \
+                libatomic \
+                libcurl-devel \
+                libsodium-devel \
+                libunwind-devel \
+                ninja-build \
+                openssl-devel \
+                pkgconf-pkg-config \
+                protobuf-compiler \
+                protobuf-devel \
+                tar \
+                unzip \
+                zip
+          - distro: archlinux
+            container: archlinux:latest
+            install: |
+              pacman -Syu --disable-sandbox --noconfirm --needed \
+                autoconf \
+                automake \
+                base-devel \
+                ca-certificates \
+                cmake \
+                curl \
+                git \
+                jq \
+                libtool \
+                libunwind \
+                libutempter \
+                libsodium \
+                namcap \
+                ninja \
+                openssh \
+                openssl \
+                pkgconf \
+                protobuf \
+                tar \
+                unzip \
+                zip
+    env:
+      CMAKE_BUILD_DIR: ${{ github.workspace }}/build
+    steps:
+      - name: Install dependencies
+        shell: bash
+        run: ${{ matrix.install }}
+
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Generate project files
+        shell: bash
+        run: |
+          cmake -DDISABLE_TELEMETRY=ON -DDISABLE_VCPKG=ON -S "${{ github.workspace }}" -B "${{ env.CMAKE_BUILD_DIR }}" -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo
+
+      - name: Build and test
+        shell: bash
+        run: |
+          parallel_level="${CI_PARALLEL_LEVEL:-4}"
+          cmake --build "${{ env.CMAKE_BUILD_DIR }}" --parallel "${parallel_level}"
+          ctest --test-dir "${{ env.CMAKE_BUILD_DIR }}" --parallel "${parallel_level}" --output-on-failure
+
+  freebsd:
+    name: build-freebsd
+    runs-on: ubuntu-latest
+    env:
+      CMAKE_BUILD_DIR: ${{ github.workspace }}/build
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install act QEMU dependencies
+        if: ${{ env.ACT }}
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            qemu-efi-aarch64 \
+            qemu-system-arm \
+            rsync
+          sudo rm -rf /root/work
+          sudo ln -s "${GITHUB_WORKSPACE}" /root/work
+
+      - name: Start FreeBSD VM
+        uses: vmactions/freebsd-vm@v1
+        with:
+          usesh: true
+
+      - name: Expose FreeBSD shell for act
+        if: ${{ env.ACT }}
+        shell: bash
+        run: |
+          sudo ln -sf "${HOME}/.local/bin/freebsd" /usr/local/bin/freebsd
+
+      - name: Build and test on FreeBSD
+        shell: freebsd {0}
+        run: |
+          if [ -f /root/work/CMakeLists.txt ]; then
+            cd /root/work
+          else
+            cd "${GITHUB_WORKSPACE}"
+          fi
+
+          pkg install -y \
+            autoconf \
+            automake \
+            ca_root_nss \
+            cmake \
+            curl \
+            git \
+            libtool \
+            libunwind \
+            libsodium \
+            ninja \
+            openssl \
+            protobuf \
+            unzip \
+            zip
+
+          cmake -DDISABLE_TELEMETRY=ON -DDISABLE_VCPKG=ON -DOPENSSL_ROOT_DIR=/usr/local -DCMAKE_PREFIX_PATH=/usr/local -S "$(pwd)" -B "$(pwd)/build" -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo
+          parallel_level="${CI_PARALLEL_LEVEL:-4}"
+          cmake --build "$(pwd)/build" --parallel "${parallel_level}"
+          ctest --test-dir "$(pwd)/build" --parallel "${parallel_level}" --output-on-failure

--- a/.github/workflows/portability_ci.yml
+++ b/.github/workflows/portability_ci.yml
@@ -95,8 +95,6 @@ jobs:
                 tar \
                 unzip \
                 zip
-    env:
-      CMAKE_BUILD_DIR: ${{ github.workspace }}/build
     steps:
       - name: Install dependencies
         shell: bash
@@ -109,14 +107,16 @@ jobs:
       - name: Generate project files
         shell: bash
         run: |
-          cmake -DDISABLE_TELEMETRY=ON -DDISABLE_VCPKG=ON -S "${{ github.workspace }}" -B "${{ env.CMAKE_BUILD_DIR }}" -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo
+          cmake_build_dir="${GITHUB_WORKSPACE}/build"
+          cmake -DDISABLE_TELEMETRY=ON -DDISABLE_VCPKG=ON -S "${GITHUB_WORKSPACE}" -B "${cmake_build_dir}" -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo
 
       - name: Build and test
         shell: bash
         run: |
+          cmake_build_dir="${GITHUB_WORKSPACE}/build"
           parallel_level="${CI_PARALLEL_LEVEL:-4}"
-          cmake --build "${{ env.CMAKE_BUILD_DIR }}" --parallel "${parallel_level}"
-          ctest --test-dir "${{ env.CMAKE_BUILD_DIR }}" --parallel "${parallel_level}" --output-on-failure
+          cmake --build "${cmake_build_dir}" --parallel "${parallel_level}"
+          ctest --test-dir "${cmake_build_dir}" --parallel "${parallel_level}" --output-on-failure
 
   freebsd:
     name: build-freebsd

--- a/deployment/deploy_archlinux_aur_act.sh
+++ b/deployment/deploy_archlinux_aur_act.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "${script_dir}/.." && pwd)"
+
+workflow="${repo_root}/.github/workflows/deploy_archlinux_aur.yml"
+release_tag="${RELEASE_TAG:-}"
+aur_repo="${AUR_REPO:-ssh://aur@aur.archlinux.org/eternalterminal.git}"
+push_changes="${PUSH_CHANGES:-false}"
+ssh_key_path="${AUR_SSH_KEY_PATH:-${HOME}/.ssh/id_rsa}"
+
+if ! command -v act >/dev/null 2>&1; then
+  echo "act is required to run this script" >&2
+  exit 1
+fi
+
+if [[ ! -r "${ssh_key_path}" ]]; then
+  echo "AUR SSH key not found or not readable: ${ssh_key_path}" >&2
+  echo "Set AUR_SSH_KEY_PATH to use a different key." >&2
+  exit 1
+fi
+
+export AUR_SSH_PRIVATE_KEY
+AUR_SSH_PRIVATE_KEY="$(< "${ssh_key_path}")"
+
+cmd=(
+  act workflow_dispatch
+  -W "${workflow}"
+  --container-architecture linux/amd64
+  --secret AUR_SSH_PRIVATE_KEY
+  --input "aur_repo=${aur_repo}"
+  --input "push_changes=${push_changes}"
+)
+
+if [[ -n "${release_tag}" ]]; then
+  cmd+=(--input "release_tag=${release_tag}")
+fi
+
+cd "${repo_root}"
+exec "${cmd[@]}" "$@"

--- a/deployment/deploy_debian_repo_act.sh
+++ b/deployment/deploy_debian_repo_act.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "${script_dir}/.." && pwd)"
+
+workflow="${repo_root}/.github/workflows/deploy_debian_repo.yml"
+release_tag="${RELEASE_TAG:-}"
+deployment_ref="${DEPLOYMENT_REF:-deployment}"
+debian_repo="${DEBIAN_REPO:-git@github.com:MisterTea/debian-et.git}"
+push_changes="${PUSH_CHANGES:-false}"
+ssh_key_path="${DEBIAN_REPO_SSH_KEY_PATH:-${HOME}/.ssh/id_rsa}"
+debian_suites="${DEBIAN_SUITES:-bookworm}"
+debian_arches="${DEBIAN_ARCHES:-amd64 arm64}"
+verbose_build="${VERBOSE_BUILD:-false}"
+quiet_cowbuilder="${QUIET_COWBUILDER:-true}"
+deb_build_jobs="${DEB_BUILD_JOBS:-1}"
+
+if ! command -v act >/dev/null 2>&1; then
+  echo "act is required to run this script" >&2
+  exit 1
+fi
+
+cmd=(
+  act workflow_dispatch
+  -W "${workflow}"
+  --container-architecture linux/amd64
+  --container-options "--privileged"
+  --input "deployment_ref=${deployment_ref}"
+  --input "debian_repo=${debian_repo}"
+  --input "push_changes=${push_changes}"
+  --input "debian_suites=${debian_suites}"
+  --input "debian_arches=${debian_arches}"
+  --input "verbose_build=${verbose_build}"
+  --input "quiet_cowbuilder=${quiet_cowbuilder}"
+  --input "deb_build_jobs=${deb_build_jobs}"
+)
+
+if [[ "${push_changes}" == "true" ]]; then
+  if [[ ! -r "${ssh_key_path}" ]]; then
+    echo "Debian repo SSH key not found or not readable: ${ssh_key_path}" >&2
+    echo "Set DEBIAN_REPO_SSH_KEY_PATH to use a different key." >&2
+    exit 1
+  fi
+
+  export DEBIAN_REPO_SSH_PRIVATE_KEY
+  DEBIAN_REPO_SSH_PRIVATE_KEY="$(< "${ssh_key_path}")"
+  cmd+=(--secret DEBIAN_REPO_SSH_PRIVATE_KEY)
+elif [[ -r "${ssh_key_path}" ]]; then
+  export DEBIAN_REPO_SSH_PRIVATE_KEY
+  DEBIAN_REPO_SSH_PRIVATE_KEY="$(< "${ssh_key_path}")"
+  cmd+=(--secret DEBIAN_REPO_SSH_PRIVATE_KEY)
+fi
+
+if [[ -n "${release_tag}" ]]; then
+  cmd+=(--input "release_tag=${release_tag}")
+fi
+
+cd "${repo_root}"
+exec "${cmd[@]}" "$@"

--- a/deployment/deploy_ubuntu_ppa_act.sh
+++ b/deployment/deploy_ubuntu_ppa_act.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "${script_dir}/.." && pwd)"
+
+workflow="${repo_root}/.github/workflows/deploy_ubuntu_ppa.yml"
+release_tag="${RELEASE_TAG:-}"
+deployment_ref="${DEPLOYMENT_REF:-deployment}"
+ppa="${PPA:-ppa:jgmath2000/et}"
+gpg_key_id="${GPG_KEY_ID:-}"
+gpg_passphrase_file="${GPG_PASSPHRASE_FILE:-${HOME}/.gnupg/pphrase}"
+
+if ! command -v act >/dev/null 2>&1; then
+  echo "act is required to run this script" >&2
+  exit 1
+fi
+
+if ! command -v gpg >/dev/null 2>&1; then
+  echo "gpg is required to export the local signing key" >&2
+  exit 1
+fi
+
+if [[ -z "${gpg_key_id}" ]]; then
+  gpg_key_id="$(
+    gpg --batch --list-secret-keys --with-colons |
+      awk -F: '$1 == "fpr" { print $10; exit }'
+  )"
+fi
+
+if [[ -z "${gpg_key_id}" ]]; then
+  echo "No local GPG secret key found. Set GPG_KEY_ID to the key fingerprint or long key ID." >&2
+  exit 1
+fi
+
+if [[ -z "${GPG_PASSPHRASE:-}" ]]; then
+  if [[ -r "${gpg_passphrase_file}" ]]; then
+    GPG_PASSPHRASE="$(< "${gpg_passphrase_file}")"
+  elif [[ -t 0 && -r /dev/tty ]]; then
+    read -r -s -p "GPG passphrase: " GPG_PASSPHRASE </dev/tty
+    echo >/dev/tty
+  else
+    echo "GPG_PASSPHRASE must be set, or ${gpg_passphrase_file} must be readable." >&2
+    exit 1
+  fi
+fi
+
+export GPG_PRIVATE_KEY
+if [[ -r "${gpg_passphrase_file}" ]]; then
+  GPG_PRIVATE_KEY="$(
+    gpg --batch --yes --pinentry-mode loopback \
+      --passphrase-file "${gpg_passphrase_file}" \
+      --armor --export-secret-keys "${gpg_key_id}"
+  )"
+else
+  GPG_PRIVATE_KEY="$(
+    printf '%s' "${GPG_PASSPHRASE}" |
+      gpg --batch --yes --pinentry-mode loopback \
+        --passphrase-fd 0 \
+        --armor --export-secret-keys "${gpg_key_id}"
+  )"
+fi
+export GPG_PASSPHRASE
+
+cmd=(
+  act workflow_dispatch
+  -W "${workflow}"
+  --container-architecture linux/amd64
+  --secret GPG_PRIVATE_KEY
+  --secret GPG_PASSPHRASE
+  --input "deployment_ref=${deployment_ref}"
+  --input "ppa=${ppa}"
+)
+
+if [[ -n "${release_tag}" ]]; then
+  cmd+=(--input "release_tag=${release_tag}")
+fi
+
+cd "${repo_root}"
+exec "${cmd[@]}" "$@"

--- a/src/base/DaemonCreator.cpp
+++ b/src/base/DaemonCreator.cpp
@@ -47,13 +47,18 @@ int DaemonCreator::create(bool parentExit, string childPidFile) {
     std::stringstream pid_ss;
     pid_ss << getpid() << "\n";
     std::string pid_str = pid_ss.str();
-    write(pidFilehandle, pid_str.c_str(), pid_str.length());
-    close(pidFilehandle);
+    ssize_t bytesWritten =
+        write(pidFilehandle, pid_str.c_str(), pid_str.length());
+    FATAL_FAIL(bytesWritten);
+    if (static_cast<size_t>(bytesWritten) != pid_str.length()) {
+      STFATAL << "Error writing pidfile: " << childPidFile;
+    }
+    FATAL_FAIL(close(pidFilehandle));
   }
 
   /* Change the working directory to the root directory */
   /* or another appropriated directory */
-  chdir("/");
+  FATAL_FAIL(chdir("/"));
 
   auto fd = open("/dev/null", O_WRONLY | O_CREAT, 0666);
   dup2(fd, STDOUT_FILENO);

--- a/src/base/LogHandler.cpp
+++ b/src/base/LogHandler.cpp
@@ -3,7 +3,7 @@
 INITIALIZE_EASYLOGGINGPP
 
 namespace et {
-el::Configurations LogHandler::setupLogHandler(int *argc, char ***argv) {
+el::Configurations LogHandler::setupLogHandler(int* argc, char*** argv) {
   // easylogging parses verbose arguments, see [Application Arguments]
   // in https://github.com/muflihun/easyloggingpp/blob/master/README.md
   // but it is non-intuitive so we explicitly set verbosity based on cxxopts
@@ -24,13 +24,13 @@ el::Configurations LogHandler::setupLogHandler(int *argc, char ***argv) {
   return defaultConf;
 }
 
-void LogHandler::setupLogFiles(el::Configurations *defaultConf,
-                               const string &path, const string &filenamePrefix,
+void LogHandler::setupLogFiles(el::Configurations* defaultConf,
+                               const string& path, const string& filenamePrefix,
                                bool logToStdout, bool redirectStderrToFile,
                                bool appendPid, string maxlogsize) {
   auto now = std::chrono::system_clock::now();
   time_t rawtime = std::chrono::system_clock::to_time_t(now);
-  struct tm *timeinfo = std::localtime(&rawtime);
+  struct tm* timeinfo = std::localtime(&rawtime);
 
   char buffer[80];
   strftime(buffer, sizeof(buffer), "%Y-%m-%d_%H-%M-%S", timeinfo);
@@ -72,14 +72,14 @@ void LogHandler::setupLogFiles(el::Configurations *defaultConf,
   }
 }
 
-void LogHandler::rolloutHandler(const char *filename, std::size_t size) {
+void LogHandler::rolloutHandler(const char* filename, std::size_t size) {
   // SHOULD NOT LOG ANYTHING HERE BECAUSE LOG FILE IS CLOSED!
   // REMOVE OLD LOG
   remove(filename);
 }
 
 void LogHandler::setupStdoutLogger() {
-  el::Logger *stdoutLogger = el::Loggers::getLogger("stdout");
+  el::Logger* stdoutLogger = el::Loggers::getLogger("stdout");
   // Easylogging configurations
   el::Configurations stdoutConf;
   stdoutConf.setToDefault();
@@ -90,11 +90,11 @@ void LogHandler::setupStdoutLogger() {
   el::Loggers::reconfigureLogger(stdoutLogger, stdoutConf);
 }
 
-string LogHandler::createLogFile(const string &path, const string &filename) {
+string LogHandler::createLogFile(const string& path, const string& filename) {
   string fullFname = path + "/" + filename;
   try {
     fs::create_directories(path);
-  } catch (const fs::filesystem_error &fse) {
+  } catch (const fs::filesystem_error& fse) {
     CLOG(ERROR, "stdout") << "Cannot create logfile directory: " << fse.what()
                           << endl;
     throw std::runtime_error("Cannot create logfile directory: " +
@@ -109,10 +109,10 @@ string LogHandler::createLogFile(const string &path, const string &filename) {
   return fullFname;
 }
 
-void LogHandler::stderrToFile(const string &path,
-                              const string &stderrFilename) {
+void LogHandler::stderrToFile(const string& path,
+                              const string& stderrFilename) {
   string fullFname = createLogFile(path, stderrFilename);
-  FILE *stderr_stream = freopen(fullFname.c_str(), "w", stderr);
+  FILE* stderr_stream = freopen(fullFname.c_str(), "w", stderr);
   if (!stderr_stream) {
     STFATAL << "Invalid filename " << stderrFilename;
   }

--- a/src/base/LogHandler.hpp
+++ b/src/base/LogHandler.hpp
@@ -13,14 +13,14 @@ class LogHandler {
    * @brief Initializes logging using the supplied `argc/argv` parameters.
    * @return A default configuration that callers can further customize.
    */
-  static el::Configurations setupLogHandler(int *argc, char ***argv);
+  static el::Configurations setupLogHandler(int* argc, char*** argv);
 
   /**
    * @brief Sets up file-based logging, optionally writing stderr to disk.
    * @param defaultConf Base easylogging configuration that will be mutated.
    */
-  static void setupLogFiles(el::Configurations *defaultConf, const string &path,
-                            const string &filenamePrefix,
+  static void setupLogFiles(el::Configurations* defaultConf, const string& path,
+                            const string& filenamePrefix,
                             bool logToStdout = false,
                             bool redirectStderrToFile = false,
                             bool appendPid = false,
@@ -29,7 +29,7 @@ class LogHandler {
   /**
    * @brief Performs log rotation by removing the supplied filename.
    */
-  static void rolloutHandler(const char *filename, std::size_t size);
+  static void rolloutHandler(const char* filename, std::size_t size);
 
   /**
    * @brief Reconfigures the easylogging stdout logger so it just writes
@@ -41,12 +41,12 @@ class LogHandler {
   /**
    * @brief Redirects stderr to a file created in the specified directory.
    */
-  static void stderrToFile(const string &path, const string &stderrFilename);
+  static void stderrToFile(const string& path, const string& stderrFilename);
 
   /**
    * @brief Ensures the directory exists and creates a new log file.
    */
-  static string createLogFile(const string &path, const string &filename);
+  static string createLogFile(const string& path, const string& filename);
 };
 }  // namespace et
 #endif  // __ET_LOG_HANDLER__

--- a/src/base/TcpSocketHandler.cpp
+++ b/src/base/TcpSocketHandler.cpp
@@ -3,11 +3,11 @@
 namespace et {
 TcpSocketHandler::TcpSocketHandler() {}
 
-int TcpSocketHandler::connect(const SocketEndpoint &endpoint) {
+int TcpSocketHandler::connect(const SocketEndpoint& endpoint) {
   lock_guard<std::recursive_mutex> guard(globalMutex);
   int sockFd = -1;
-  addrinfo *results = NULL;
-  addrinfo *p = NULL;
+  addrinfo* results = NULL;
+  addrinfo* p = NULL;
   addrinfo hints;
   memset(&hints, 0, sizeof(addrinfo));
   hints.ai_family = AF_UNSPEC;
@@ -89,7 +89,7 @@ int TcpSocketHandler::connect(const SocketEndpoint &endpoint) {
       socklen_t len = sizeof so_error;
 
       FATAL_FAIL(
-          ::getsockopt(sockFd, SOL_SOCKET, SO_ERROR, (char *)&so_error, &len));
+          ::getsockopt(sockFd, SOL_SOCKET, SO_ERROR, (char*)&so_error, &len));
 
       if (so_error == 0) {
         if (p->ai_canonname) {
@@ -148,7 +148,7 @@ int TcpSocketHandler::connect(const SocketEndpoint &endpoint) {
   return sockFd;
 }
 
-set<int> TcpSocketHandler::listen(const SocketEndpoint &endpoint) {
+set<int> TcpSocketHandler::listen(const SocketEndpoint& endpoint) {
   lock_guard<std::recursive_mutex> guard(globalMutex);
 
   int port = endpoint.port();
@@ -163,7 +163,7 @@ set<int> TcpSocketHandler::listen(const SocketEndpoint &endpoint) {
   hints.ai_family = AF_UNSPEC;
   hints.ai_socktype = SOCK_STREAM;
   hints.ai_flags = AI_PASSIVE;  // use any IP address
-  const char *bindIp = NULL;
+  const char* bindIp = NULL;
   if (endpoint.has_name()) {
     bindIp = endpoint.name().c_str();
   }
@@ -182,7 +182,7 @@ set<int> TcpSocketHandler::listen(const SocketEndpoint &endpoint) {
   for (p = servinfo; p != NULL; p = p->ai_next) {
     // Deduplicate addresses from getaddrinfo — "localhost" can resolve to
     // the same address more than once.
-    string addrKey(reinterpret_cast<const char *>(p->ai_addr), p->ai_addrlen);
+    string addrKey(reinterpret_cast<const char*>(p->ai_addr), p->ai_addrlen);
     if (!seenAddresses.insert(addrKey).second) {
       LOG(INFO) << "Skipping duplicate address for family " << p->ai_family;
       continue;
@@ -203,7 +203,7 @@ set<int> TcpSocketHandler::listen(const SocketEndpoint &endpoint) {
       // interfaces.  We will create another socket object for IPV4
       // if it doesn't already exist.
       int flag = 1;
-      FATAL_FAIL(setsockopt(sockFd, IPPROTO_IPV6, IPV6_V6ONLY, (char *)&flag,
+      FATAL_FAIL(setsockopt(sockFd, IPPROTO_IPV6, IPV6_V6ONLY, (char*)&flag,
                             sizeof(int)));
     }
 
@@ -231,7 +231,7 @@ set<int> TcpSocketHandler::listen(const SocketEndpoint &endpoint) {
     // Listen
     FATAL_FAIL(::listen(sockFd, 32));
     LOG(INFO) << "Listening on "
-              << inet_ntoa(((sockaddr_in *)p->ai_addr)->sin_addr) << ":" << port
+              << inet_ntoa(((sockaddr_in*)p->ai_addr)->sin_addr) << ":" << port
               << "/" << p->ai_family << "/" << p->ai_socktype << "/"
               << p->ai_protocol;
 
@@ -247,7 +247,7 @@ set<int> TcpSocketHandler::listen(const SocketEndpoint &endpoint) {
   return serverSockets;
 }
 
-set<int> TcpSocketHandler::getEndpointFds(const SocketEndpoint &endpoint) {
+set<int> TcpSocketHandler::getEndpointFds(const SocketEndpoint& endpoint) {
   lock_guard<std::recursive_mutex> guard(globalMutex);
 
   int port = endpoint.port();
@@ -258,7 +258,7 @@ set<int> TcpSocketHandler::getEndpointFds(const SocketEndpoint &endpoint) {
   return portServerSockets[port];
 }
 
-void TcpSocketHandler::stopListening(const SocketEndpoint &endpoint) {
+void TcpSocketHandler::stopListening(const SocketEndpoint& endpoint) {
   lock_guard<std::recursive_mutex> guard(globalMutex);
 
   int port = endpoint.port();
@@ -266,7 +266,7 @@ void TcpSocketHandler::stopListening(const SocketEndpoint &endpoint) {
   if (it == portServerSockets.end()) {
     STFATAL << "Tried to stop listening to a port that we weren't listening on";
   }
-  auto &serverSockets = it->second;
+  auto& serverSockets = it->second;
   for (int sockFd : serverSockets) {
 #ifdef _MSC_VER
     FATAL_FAIL(::closesocket(sockFd));
@@ -282,7 +282,7 @@ void TcpSocketHandler::initSocket(int fd) {
   {
     int flag = 1;
     FATAL_FAIL_UNLESS_EINVAL(
-        setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, (char *)&flag, sizeof(int)));
+        setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, (char*)&flag, sizeof(int)));
   }
   {
     // Set linger if possible
@@ -290,7 +290,7 @@ void TcpSocketHandler::initSocket(int fd) {
     so_linger.l_onoff = 1;
     so_linger.l_linger = 5;
     FATAL_FAIL_UNLESS_EINVAL(setsockopt(
-        fd, SOL_SOCKET, SO_LINGER, (const char *)&so_linger, sizeof so_linger));
+        fd, SOL_SOCKET, SO_LINGER, (const char*)&so_linger, sizeof so_linger));
   }
 }
 }  // namespace et

--- a/src/base/UnixSocketHandler.cpp
+++ b/src/base/UnixSocketHandler.cpp
@@ -26,7 +26,7 @@ bool UnixSocketHandler::waitForData(int fd, int64_t sec, int64_t usec) {
 
 bool UnixSocketHandler::hasData(int fd) { return waitForData(fd, 0, 0); }
 
-ssize_t UnixSocketHandler::read(int fd, void *buf, size_t count) {
+ssize_t UnixSocketHandler::read(int fd, void* buf, size_t count) {
   if (fd <= 0) {
     STFATAL << "Tried to read from an invalid socket: " << fd;
   }
@@ -44,7 +44,7 @@ ssize_t UnixSocketHandler::read(int fd, void *buf, size_t count) {
   lock_guard<recursive_mutex> guard(*(it->second));
   VLOG(4) << "Unixsocket handler read from fd: " << fd;
 #ifdef WIN32
-  ssize_t readBytes = ::recv(fd, (char *)buf, count, 0);
+  ssize_t readBytes = ::recv(fd, (char*)buf, count, 0);
 #else
   ssize_t readBytes = ::read(fd, buf, count);
 #endif
@@ -57,7 +57,7 @@ ssize_t UnixSocketHandler::read(int fd, void *buf, size_t count) {
   return readBytes;
 }
 
-ssize_t UnixSocketHandler::write(int fd, const void *buf, size_t count) {
+ssize_t UnixSocketHandler::write(int fd, const void* buf, size_t count) {
   VLOG(4) << "Unixsocket handler write to fd: " << fd;
   if (fd <= 0) {
     STFATAL << "Tried to write to an invalid socket: " << fd;
@@ -79,13 +79,13 @@ ssize_t UnixSocketHandler::write(int fd, const void *buf, size_t count) {
     lock_guard<recursive_mutex> guard(*(it->second));
     int w;
 #ifdef WIN32
-    w = ::send(fd, ((const char *)buf) + bytesWritten, count - bytesWritten, 0);
+    w = ::send(fd, ((const char*)buf) + bytesWritten, count - bytesWritten, 0);
 #else
 #ifdef MSG_NOSIGNAL
-    w = ::send(fd, ((const char *)buf) + bytesWritten, count - bytesWritten,
+    w = ::send(fd, ((const char*)buf) + bytesWritten, count - bytesWritten,
                MSG_NOSIGNAL);
 #else
-    w = ::write(fd, ((const char *)buf) + bytesWritten, count - bytesWritten);
+    w = ::write(fd, ((const char*)buf) + bytesWritten, count - bytesWritten);
 #endif
 #endif
     auto localErrno = GetErrno();
@@ -118,7 +118,7 @@ void UnixSocketHandler::addToActiveSockets(int fd) {
 int UnixSocketHandler::accept(int sockFd) {
   sockaddr_storage client;
   socklen_t c = sizeof(client);
-  int client_sock = ::accept(sockFd, (sockaddr *)&client, &c);
+  int client_sock = ::accept(sockFd, (sockaddr*)&client, &c);
   auto acceptErrno = GetErrno();
   while (true) {
     {
@@ -216,7 +216,7 @@ void UnixSocketHandler::initServerSocket(int fd) {
   {
     int flag = 1;
     FATAL_FAIL(
-        setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, (char *)&flag, sizeof(int)));
+        setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, (char*)&flag, sizeof(int)));
   }
 }
 

--- a/src/htm/HtmServer.cpp
+++ b/src/htm/HtmServer.cpp
@@ -7,7 +7,7 @@
 
 namespace et {
 HtmServer::HtmServer(shared_ptr<SocketHandler> _socketHandler,
-                     const SocketEndpoint &endpoint)
+                     const SocketEndpoint& endpoint)
     : IpcPairServer(_socketHandler, endpoint),
       state(_socketHandler),
       running(true) {}
@@ -38,10 +38,10 @@ void HtmServer::run() {
       // on the same master descriptor (line 90).
       if (FD_ISSET(endpointFd, &rfd)) {
         LOG(INFO) << "READING FROM STDIN";
-        socketHandler->readAll(endpointFd, (char *)&header, 1, false);
+        socketHandler->readAll(endpointFd, (char*)&header, 1, false);
         LOG(INFO) << "Got message header: " << int(header);
         int32_t length;
-        socketHandler->readB64(endpointFd, (char *)&length, 4);
+        socketHandler->readB64(endpointFd, (char*)&length, 4);
         LOG(INFO) << "READ LENGTH: " << length;
         switch (header) {
           case INSERT_KEYS: {
@@ -98,9 +98,9 @@ void HtmServer::run() {
           }
           case RESIZE_PANE: {
             int32_t cols;
-            socketHandler->readB64(endpointFd, (char *)&cols, 4);
+            socketHandler->readB64(endpointFd, (char*)&cols, 4);
             int32_t rows;
-            socketHandler->readB64(endpointFd, (char *)&rows, 4);
+            socketHandler->readB64(endpointFd, (char*)&rows, 4);
             string paneId = string(UUID_LENGTH, '0');
             socketHandler->readAll(endpointFd, &paneId[0], paneId.length(),
                                    false);
@@ -128,7 +128,7 @@ void HtmServer::run() {
       if (endpointFd > 0) {
         state.update(endpointFd);
       }
-    } catch (std::runtime_error &re) {
+    } catch (std::runtime_error& re) {
       STERROR << re.what();
       closeEndpoint();
     }
@@ -136,12 +136,12 @@ void HtmServer::run() {
   closeEndpoint();
 }
 
-void HtmServer::sendDebug(const string &msg) {
+void HtmServer::sendDebug(const string& msg) {
   LOG(INFO) << "SENDING DEBUG LOG: " << msg;
   unsigned char header = DEBUG_LOG;
   int32_t length = Base64::EncodedLength(msg);
-  socketHandler->writeAllOrThrow(endpointFd, (const char *)&header, 1, false);
-  socketHandler->writeB64(endpointFd, (const char *)&length, 4);
+  socketHandler->writeAllOrThrow(endpointFd, (const char*)&header, 1, false);
+  socketHandler->writeB64(endpointFd, (const char*)&length, 4);
   socketHandler->writeB64(endpointFd, &msg[0], msg.length());
 }
 
@@ -166,8 +166,8 @@ void HtmServer::recover() {
     int32_t length = jsonString.length();
     VLOG(1) << "SENDING INIT: " << jsonString;
     VLOG(1) << "SENDING INIT: " << length;
-    socketHandler->writeAllOrThrow(endpointFd, (const char *)&header, 1, false);
-    socketHandler->writeB64(endpointFd, (const char *)&length, 4);
+    socketHandler->writeAllOrThrow(endpointFd, (const char*)&header, 1, false);
+    socketHandler->writeB64(endpointFd, (const char*)&length, 4);
     socketHandler->writeAllOrThrow(endpointFd, &jsonString[0],
                                    jsonString.length(), false);
   }

--- a/src/htm/HtmServerMain.cpp
+++ b/src/htm/HtmServerMain.cpp
@@ -5,7 +5,7 @@
 
 using namespace et;
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   // Version string need to be set before GFLAGS parse arguments
   GOOGLE_PROTOBUF_VERIFY_VERSION;
   srand(1);

--- a/src/htm/IpcPairEndpoint.hpp
+++ b/src/htm/IpcPairEndpoint.hpp
@@ -26,7 +26,7 @@ class IpcPairEndpoint {
   virtual void closeEndpoint() {
     LOG(INFO) << "SENDING SESSION END";
     unsigned char header = SESSION_END;
-    socketHandler->writeAllOrThrow(endpointFd, (const char *)&header, 1, false);
+    socketHandler->writeAllOrThrow(endpointFd, (const char*)&header, 1, false);
     socketHandler->close(endpointFd);
     endpointFd = -1;
   }

--- a/src/htm/IpcPairServer.cpp
+++ b/src/htm/IpcPairServer.cpp
@@ -2,7 +2,7 @@
 
 namespace et {
 IpcPairServer::IpcPairServer(shared_ptr<SocketHandler> _socketHandler,
-                             const SocketEndpoint &_endpoint)
+                             const SocketEndpoint& _endpoint)
     : IpcPairEndpoint(_socketHandler, -1), endpoint(_endpoint) {
   serverFd = *(socketHandler->listen(endpoint).begin());
 }

--- a/src/htm/IpcPairServer.hpp
+++ b/src/htm/IpcPairServer.hpp
@@ -15,7 +15,7 @@ class IpcPairServer : public IpcPairEndpoint {
    * @brief Binds a listening socket for HTM clients that this server accepts.
    */
   IpcPairServer(shared_ptr<SocketHandler> _socketHandler,
-                const SocketEndpoint &_endpoint);
+                const SocketEndpoint& _endpoint);
   /** @brief Tears down listeners and closes the server fd. */
   virtual ~IpcPairServer();
   /** @brief Accepts a new HTM client and stores its descriptor in `endpointFd`.

--- a/src/htm/MultiplexerState.cpp
+++ b/src/htm/MultiplexerState.cpp
@@ -69,29 +69,29 @@ string MultiplexerState::toJsonString() {
   json state;
   state["shell"] = string(::getenv("SHELL"));
 
-  for (auto &it : tabs) {
+  for (auto& it : tabs) {
     state["tabs"][it.first] = it.second->toJson();
   }
 
-  for (auto &it : panes) {
+  for (auto& it : panes) {
     state["panes"][it.first] = it.second->toJson();
   }
 
-  for (auto &it : splits) {
+  for (auto& it : splits) {
     state["splits"][it.first] = it.second->toJson();
   }
 
   return state.dump();
 }
 
-void MultiplexerState::appendData(const string &uid, const string &data) {
+void MultiplexerState::appendData(const string& uid, const string& data) {
   if (panes.find(uid) == panes.end()) {
     STFATAL << "Tried to write to non-existent terminal";
   }
   panes[uid]->terminal->appendData(data);
 }
 
-void MultiplexerState::newTab(const string &tabId, const string &paneId) {
+void MultiplexerState::newTab(const string& tabId, const string& paneId) {
   fatalIfFound(tabId);
   fatalIfFound(paneId);
   auto tab = shared_ptr<Tab>(new Tab());
@@ -109,7 +109,7 @@ void MultiplexerState::newTab(const string &tabId, const string &paneId) {
   panes.insert(make_pair(paneId, pane));
 }
 
-void MultiplexerState::newSplit(const string &sourceId, const string &paneId,
+void MultiplexerState::newSplit(const string& sourceId, const string& paneId,
                                 bool vertical) {
   fatalIfFound(paneId);
 
@@ -127,7 +127,7 @@ void MultiplexerState::newSplit(const string &sourceId, const string &paneId,
     // The source is already part of a split with the same orientation.  Append
     // and resize
     auto split = splitIt->second;
-    for (auto &it : split->sizes) {
+    for (auto& it : split->sizes) {
       it /= 2.0;
     }
     split->sizes.push_back(0.5);
@@ -190,7 +190,7 @@ void MultiplexerState::newSplit(const string &sourceId, const string &paneId,
   tab->pane_or_split_id = newSplit->id;
 }
 
-void MultiplexerState::closePane(const string &paneId) {
+void MultiplexerState::closePane(const string& paneId) {
   if (closed.find(paneId) != closed.end()) {
     return;  // Already closed
   }
@@ -271,17 +271,17 @@ void MultiplexerState::closePane(const string &paneId) {
 
 void MultiplexerState::update(int endpointFd) {
   char header;
-  for (auto &it : panes) {
-    shared_ptr<TerminalHandler> &terminal = it.second->terminal;
+  for (auto& it : panes) {
+    shared_ptr<TerminalHandler>& terminal = it.second->terminal;
     string terminalData = terminal->pollUserTerminal();
     if (terminalData.length()) {
-      const string &paneId = it.first;
+      const string& paneId = it.first;
       header = APPEND_TO_PANE;
       int32_t length = Base64::EncodedLength(terminalData) + paneId.length();
       VLOG(1) << "WRITING TO " << paneId << ":" << length;
-      socketHandler->writeAllOrThrow(endpointFd, (const char *)&header, 1,
+      socketHandler->writeAllOrThrow(endpointFd, (const char*)&header, 1,
                                      false);
-      socketHandler->writeB64(endpointFd, (const char *)&length, 4);
+      socketHandler->writeB64(endpointFd, (const char*)&length, 4);
       socketHandler->writeAllOrThrow(endpointFd, &(paneId[0]), paneId.length(),
                                      false);
       socketHandler->writeB64(endpointFd, &terminalData[0],
@@ -295,9 +295,9 @@ void MultiplexerState::update(int endpointFd) {
       header = SERVER_CLOSE_PANE;
       int32_t length = paneId.length();
       VLOG(1) << "CLOSING " << paneId << ":" << length;
-      socketHandler->writeAllOrThrow(endpointFd, (const char *)&header, 1,
+      socketHandler->writeAllOrThrow(endpointFd, (const char*)&header, 1,
                                      false);
-      socketHandler->writeB64(endpointFd, (const char *)&length, 4);
+      socketHandler->writeB64(endpointFd, (const char*)&length, 4);
       socketHandler->writeAllOrThrow(endpointFd, &(paneId[0]), paneId.length(),
                                      false);
       // Break to avoid erase + iterate of panes
@@ -308,18 +308,18 @@ void MultiplexerState::update(int endpointFd) {
 
 void MultiplexerState::sendTerminalBuffers(int endpointFd) {
   char header;
-  for (auto &it : panes) {
-    const string &paneId = it.first;
-    shared_ptr<TerminalHandler> &terminal = it.second->terminal;
-    const deque<string> &terminalBuffer = terminal->getBuffer();
+  for (auto& it : panes) {
+    const string& paneId = it.first;
+    shared_ptr<TerminalHandler>& terminal = it.second->terminal;
+    const deque<string>& terminalBuffer = terminal->getBuffer();
     if (terminalBuffer.size()) {
       int byteCount = 0;
-      for (const string &it : terminalBuffer) {
+      for (const string& it : terminalBuffer) {
         byteCount += it.length() + 1;
       }
       string terminalData;
       terminalData.reserve(byteCount);
-      for (const string &it : terminalBuffer) {
+      for (const string& it : terminalBuffer) {
         if (terminalData.length()) {
           terminalData.append(1, '\n');
         }
@@ -328,9 +328,9 @@ void MultiplexerState::sendTerminalBuffers(int endpointFd) {
       header = APPEND_TO_PANE;
       int32_t length = Base64::EncodedLength(terminalData) + paneId.length();
       VLOG(1) << "WRITING TO " << paneId << ":" << length;
-      socketHandler->writeAllOrThrow(endpointFd, (const char *)&header, 1,
+      socketHandler->writeAllOrThrow(endpointFd, (const char*)&header, 1,
                                      false);
-      socketHandler->writeB64(endpointFd, (const char *)&length, 4);
+      socketHandler->writeB64(endpointFd, (const char*)&length, 4);
       socketHandler->writeAllOrThrow(endpointFd, &(paneId[0]), paneId.length(),
                                      false);
       socketHandler->writeB64(endpointFd, &terminalData[0],
@@ -340,11 +340,11 @@ void MultiplexerState::sendTerminalBuffers(int endpointFd) {
   }
 }
 
-void MultiplexerState::resizePane(const string &paneId, int cols, int rows) {
+void MultiplexerState::resizePane(const string& paneId, int cols, int rows) {
   getPane(paneId)->terminal->updateTerminalSize(cols, rows);
 }
 
-void MultiplexerState::fatalIfFound(const string &id) {
+void MultiplexerState::fatalIfFound(const string& id) {
   if (panes.find(id) != panes.end()) {
     STFATAL << "Found unexpected id in panes: " << id;
   }

--- a/src/htm/TerminalHandler.hpp
+++ b/src/htm/TerminalHandler.hpp
@@ -26,13 +26,13 @@ class TerminalHandler {
   void updateTerminalSize(int col, int row);
   /** @brief Writes raw bytes into the running terminal (e.g., from the client).
    */
-  void appendData(const string &data);
+  void appendData(const string& data);
   /** @brief Indicates whether the PTY child is still alive. */
   inline bool isRunning() { return run; }
   /** @brief Sends SIGTERM/Cleanup to stop the handler's child process. */
   void stop();
   /** @brief Returns the buffered output that should be sent to the client. */
-  const deque<string> &getBuffer() { return buffer; }
+  const deque<string>& getBuffer() { return buffer; }
 
  protected:
   /** @brief Master fd used to read/write the PTY. */

--- a/src/terminal/ParseConfigFile.hpp
+++ b/src/terminal/ParseConfigFile.hpp
@@ -138,28 +138,28 @@ enum ssh_options_e {
  * @brief Minimal structure mirroring libssh's `Options`.
  */
 struct Options {
-  char *username;
-  char *host;
-  char *sshdir;
-  char *knownhosts;
-  char *ProxyCommand;
-  char *ProxyJump;
+  char* username;
+  char* host;
+  char* sshdir;
+  char* knownhosts;
+  char* ProxyCommand;
+  char* ProxyJump;
   unsigned long timeout; /* seconds */
   unsigned int port;
   int StrictHostKeyChecking;
   int ssh2;
   int ssh1;
-  char *gss_server_identity;
-  char *gss_client_identity;
+  char* gss_server_identity;
+  char* gss_client_identity;
   int gss_delegate_creds;
   int forward_agent;
-  char *identity_agent;
+  char* identity_agent;
   vector<pair<int, int>> local_forwards;
   vector<pair<string, string>> env_vars;
 };
 
 // Free all allocated fields in an Options struct
-inline void freeOptionsFields(Options *opts) {
+inline void freeOptionsFields(Options* opts) {
   SAFE_FREE(opts->username);
   SAFE_FREE(opts->host);
   SAFE_FREE(opts->sshdir);
@@ -175,7 +175,7 @@ inline void freeOptionsFields(Options *opts) {
  * @brief Maps keyword strings to their opcodes for parser lookup.
  */
 struct ssh_config_keyword_table_s {
-  const char *name;
+  const char* name;
   enum ssh_config_opcode_e opcode;
 };
 
@@ -202,7 +202,7 @@ static struct ssh_config_keyword_table_s ssh_config_keyword_table[] = {
     {NULL, SOC_UNSUPPORTED}};
 
 /** @brief Returns the opcode associated with the given keyword string. */
-static enum ssh_config_opcode_e ssh_config_get_opcode(char *keyword) {
+static enum ssh_config_opcode_e ssh_config_get_opcode(char* keyword) {
   int i;
 
   for (i = 0; ssh_config_keyword_table[i].name != NULL; i++) {
@@ -215,17 +215,17 @@ static enum ssh_config_opcode_e ssh_config_get_opcode(char *keyword) {
 }
 
 /** @brief Parses a single line of ssh config, updating the provided Options. */
-static int ssh_config_parse_line(const char *targethost,
-                                 struct Options *options, const char *line,
-                                 unsigned int count, int *parsing, int seen[]);
+static int ssh_config_parse_line(const char* targethost,
+                                 struct Options* options, const char* line,
+                                 unsigned int count, int* parsing, int seen[]);
 
-char *ssh_get_user_home_dir(void) {
+char* ssh_get_user_home_dir(void) {
 #ifdef WIN32
   return strdup(getenv("USERPROFILE"));
 #else
-  char *szPath = NULL;
+  char* szPath = NULL;
   struct passwd pwd;
-  struct passwd *pwdbuf;
+  struct passwd* pwdbuf;
   char buf[NSS_BUFLEN_PASSWD];
   int rc;
 
@@ -247,7 +247,7 @@ char *ssh_get_user_home_dir(void) {
 #endif
 }
 
-char *ssh_get_local_username(void) {
+char* ssh_get_local_username(void) {
 #ifdef WIN32
   char username[UNLEN + 1];
   DWORD username_len = UNLEN + 1;
@@ -255,9 +255,9 @@ char *ssh_get_local_username(void) {
   return strdup(username);
 #else
   struct passwd pwd;
-  struct passwd *pwdbuf;
+  struct passwd* pwdbuf;
   char buf[NSS_BUFLEN_PASSWD];
-  char *name;
+  char* name;
   int rc;
 
   rc = getpwuid_r(getuid(), &pwd, buf, NSS_BUFLEN_PASSWD, &pwdbuf);
@@ -275,7 +275,7 @@ char *ssh_get_local_username(void) {
 #endif
 }
 
-char *ssh_lowercase(const char *str) {
+char* ssh_lowercase(const char* str) {
   char *n, *p;
 
   if (str == NULL) {
@@ -298,7 +298,7 @@ char *ssh_lowercase(const char *str) {
  * Returns true if the given string matches the pattern (which may contain ?
  * and * as wildcards), and zero if it does not match.
  */
-static int match_pattern(const char *s, const char *pattern) {
+static int match_pattern(const char* s, const char* pattern) {
   if (s == NULL || pattern == NULL) {
     return 0;
   }
@@ -370,7 +370,7 @@ static int match_pattern(const char *s, const char *pattern) {
  * Returns -1 if negation matches, 1 if there is a positive match, 0 if there is
  * no match at all.
  */
-static int match_pattern_list(const char *string, const char *pattern,
+static int match_pattern_list(const char* string, const char* pattern,
                               unsigned int len, int dolower) {
   char sub[1024];
   int negated;
@@ -434,7 +434,7 @@ static int match_pattern_list(const char *string, const char *pattern,
  * Returns -1 if negation matches, 1 if there is a positive match, 0 if there
  * is no match at all.
  */
-int match_hostname(const char *host, const char *pattern, unsigned int len) {
+int match_hostname(const char* host, const char* pattern, unsigned int len) {
   return match_pattern_list(host, pattern, len, 1);
 }
 
@@ -445,9 +445,9 @@ int match_hostname(const char *host, const char *pattern, unsigned int len) {
  *
  * @return              The expanded directory, NULL on error.
  */
-char *ssh_path_expand_tilde(const char *d) {
+char* ssh_path_expand_tilde(const char* d) {
   char *h = NULL, *r;
-  const char *p;
+  const char* p;
   int ld;
   int lh = 0;
 
@@ -463,7 +463,7 @@ char *ssh_path_expand_tilde(const char *d) {
 #ifdef WIN32
     STFATAL << "~user/path format not supported on windows";
 #else
-    struct passwd *pw;
+    struct passwd* pw;
     int s = p - d;
     char u[128];
 
@@ -481,7 +481,7 @@ char *ssh_path_expand_tilde(const char *d) {
 #endif
   } else {
     ld = strlen(d);
-    p = (char *)d;
+    p = (char*)d;
     h = ssh_get_user_home_dir();
   }
   if (h == NULL) {
@@ -489,7 +489,7 @@ char *ssh_path_expand_tilde(const char *d) {
   }
   lh = strlen(h);
 
-  r = static_cast<char *>(malloc(ld + lh + 1));
+  r = static_cast<char*>(malloc(ld + lh + 1));
   if (r == NULL) {
     SAFE_FREE(h);
     return NULL;
@@ -504,11 +504,11 @@ char *ssh_path_expand_tilde(const char *d) {
   return r;
 }
 
-char *ssh_path_expand_escape(struct Options *options, const char *s) {
+char* ssh_path_expand_escape(struct Options* options, const char* s) {
   char host[NI_MAXHOST];
   char buf[MAX_BUF_SIZE];
   char *r, *x = NULL;
-  const char *p;
+  const char* p;
   int i, l;
 
   r = ssh_path_expand_tilde(s);
@@ -798,9 +798,9 @@ char *ssh_path_expand_escape(struct Options *options, const char *s) {
  *
  * @return       0 on success, < 0 on error.
  */
-int ssh_options_set(struct Options *options, enum ssh_options_e type,
-                    const void *value) {
-  const char *v;
+int ssh_options_set(struct Options* options, enum ssh_options_e type,
+                    const void* value) {
+  const char* v;
   char *p, *q;
   long int i;
   int rc;
@@ -811,12 +811,12 @@ int ssh_options_set(struct Options *options, enum ssh_options_e type,
 
   switch (type) {
     case SSH_OPTIONS_HOST:
-      v = static_cast<const char *>(value);
+      v = static_cast<const char*>(value);
       if (v == NULL || v[0] == '\0') {
         CLOG(INFO, "stdout") << "invalid error" << endl;
         return -1;
       } else {
-        q = strdup(static_cast<const char *>(value));
+        q = strdup(static_cast<const char*>(value));
         if (q == NULL) {
           CLOG(INFO, "stdout") << "error" << endl;
           return -1;
@@ -851,7 +851,7 @@ int ssh_options_set(struct Options *options, enum ssh_options_e type,
         CLOG(INFO, "stdout") << "invalid error" << endl;
         return -1;
       } else {
-        int *x = (int *)value;
+        int* x = (int*)value;
         if (*x <= 0) {
           CLOG(INFO, "stdout") << "invalid error" << endl;
           return -1;
@@ -861,7 +861,7 @@ int ssh_options_set(struct Options *options, enum ssh_options_e type,
       }
       break;
     case SSH_OPTIONS_PORT_STR:
-      v = static_cast<const char *>(value);
+      v = static_cast<const char*>(value);
       if (v == NULL || v[0] == '\0') {
         CLOG(INFO, "stdout") << "invalid error" << endl;
         return -1;
@@ -885,7 +885,7 @@ int ssh_options_set(struct Options *options, enum ssh_options_e type,
       }
       break;
     case SSH_OPTIONS_USER:
-      v = static_cast<const char *>(value);
+      v = static_cast<const char*>(value);
       SAFE_FREE(options->username);
       if (v == NULL) {
         q = ssh_get_local_username();
@@ -898,7 +898,7 @@ int ssh_options_set(struct Options *options, enum ssh_options_e type,
         CLOG(INFO, "stdout") << "invalid error" << endl;
         return -1;
       } else { /* username provided */
-        options->username = strdup(static_cast<const char *>(value));
+        options->username = strdup(static_cast<const char*>(value));
         if (options->username == NULL) {
           CLOG(INFO, "stdout") << "error" << endl;
           return -1;
@@ -906,13 +906,13 @@ int ssh_options_set(struct Options *options, enum ssh_options_e type,
       }
       break;
     case SSH_OPTIONS_PROXYJUMP:
-      v = static_cast<const char *>(value);
+      v = static_cast<const char*>(value);
       SAFE_FREE(options->ProxyJump);
       if (v == NULL || v[0] == '\0') {
         CLOG(INFO, "stdout") << "invalid error" << endl;
         return -1;
       } else { /* ProxyJump provided */
-        options->ProxyJump = strdup(static_cast<const char *>(value));
+        options->ProxyJump = strdup(static_cast<const char*>(value));
         if (options->ProxyJump == NULL) {
           CLOG(INFO, "stdout") << "error" << endl;
           return -1;
@@ -920,7 +920,7 @@ int ssh_options_set(struct Options *options, enum ssh_options_e type,
       }
       break;
     case SSH_OPTIONS_KNOWNHOSTS:
-      v = static_cast<const char *>(value);
+      v = static_cast<const char*>(value);
       SAFE_FREE(options->knownhosts);
       if (v == NULL) {
         options->knownhosts = ssh_path_expand_escape(options, "%d/known_hosts");
@@ -944,7 +944,7 @@ int ssh_options_set(struct Options *options, enum ssh_options_e type,
         CLOG(INFO, "stdout") << "invalid error" << endl;
         return -1;
       } else {
-        long *x = (long *)value;
+        long* x = (long*)value;
         if (*x < 0) {
           CLOG(INFO, "stdout") << "invalid error" << endl;
           return -1;
@@ -958,7 +958,7 @@ int ssh_options_set(struct Options *options, enum ssh_options_e type,
         CLOG(INFO, "stdout") << "invalid error" << endl;
         return -1;
       } else {
-        int *x = (int *)value;
+        int* x = (int*)value;
         if (*x < 0) {
           CLOG(INFO, "stdout") << "invalid error" << endl;
           return -1;
@@ -972,7 +972,7 @@ int ssh_options_set(struct Options *options, enum ssh_options_e type,
         CLOG(INFO, "stdout") << "invalid error" << endl;
         return -1;
       } else {
-        int *x = (int *)value;
+        int* x = (int*)value;
         if (*x < 0) {
           CLOG(INFO, "stdout") << "invalid error" << endl;
           return -1;
@@ -986,14 +986,14 @@ int ssh_options_set(struct Options *options, enum ssh_options_e type,
         CLOG(INFO, "stdout") << "invalid error" << endl;
         return -1;
       } else {
-        int *x = (int *)value;
+        int* x = (int*)value;
 
         options->StrictHostKeyChecking = (*x & 0xff) > 0 ? 1 : 0;
       }
-      options->StrictHostKeyChecking = *(int *)value;
+      options->StrictHostKeyChecking = *(int*)value;
       break;
     case SSH_OPTIONS_PROXYCOMMAND:
-      v = static_cast<const char *>(value);
+      v = static_cast<const char*>(value);
       if (v == NULL || v[0] == '\0') {
         CLOG(INFO, "stdout") << "invalid error" << endl;
         return -1;
@@ -1011,7 +1011,7 @@ int ssh_options_set(struct Options *options, enum ssh_options_e type,
       }
       break;
     case SSH_OPTIONS_GSSAPI_SERVER_IDENTITY:
-      v = static_cast<const char *>(value);
+      v = static_cast<const char*>(value);
       if (v == NULL || v[0] == '\0') {
         CLOG(INFO, "stdout") << "invalid error" << endl;
         return -1;
@@ -1025,7 +1025,7 @@ int ssh_options_set(struct Options *options, enum ssh_options_e type,
       }
       break;
     case SSH_OPTIONS_GSSAPI_CLIENT_IDENTITY:
-      v = static_cast<const char *>(value);
+      v = static_cast<const char*>(value);
       if (v == NULL || v[0] == '\0') {
         CLOG(INFO, "stdout") << "invalid error" << endl;
         return -1;
@@ -1043,7 +1043,7 @@ int ssh_options_set(struct Options *options, enum ssh_options_e type,
         CLOG(INFO, "stdout") << "invalid error" << endl;
         return -1;
       } else {
-        int x = *(int *)value;
+        int x = *(int*)value;
 
         options->gss_delegate_creds = (x & 0xff);
       }
@@ -1053,12 +1053,12 @@ int ssh_options_set(struct Options *options, enum ssh_options_e type,
         CLOG(INFO, "stdout") << "invalid error" << endl;
         return -1;
       } else {
-        int x = *(int *)value;
+        int x = *(int*)value;
         options->forward_agent = (x & 0xff);
       }
       break;
     case SSH_OPTIONS_IDENTITYAGENT:
-      v = static_cast<const char *>(value);
+      v = static_cast<const char*>(value);
       if (v == NULL || v[0] == '\0') {
         CLOG(INFO, "stdout") << "invalid error" << endl;
         return -1;
@@ -1072,25 +1072,25 @@ int ssh_options_set(struct Options *options, enum ssh_options_e type,
       }
       break;
     case SSH_OPTIONS_LOCALFORWARD:
-      v = static_cast<const char *>(value);
+      v = static_cast<const char*>(value);
       if (v == NULL || v[0] == '\0') {
         CLOG(INFO, "stdout") << "invalid error" << endl;
         return -1;
       } else {
-        char *forward_entry = strdup(v);
+        char* forward_entry = strdup(v);
         if (forward_entry == NULL) {
           CLOG(INFO, "stdout") << "error" << endl;
           return -1;
         }
 
         // Format is [bind_address:]port host:hostport
-        char *local_port_str = strtok(forward_entry, " ");
-        char *remote_part = strtok(NULL, " ");
+        char* local_port_str = strtok(forward_entry, " ");
+        char* remote_part = strtok(NULL, " ");
 
         // TODO: Support bind_address before the local port.
         if (local_port_str && remote_part) {
           int local_port = atoi(local_port_str);
-          char *colon_pos = strrchr(remote_part, ':');
+          char* colon_pos = strrchr(remote_part, ':');
           if (colon_pos) {
             int remote_port = atoi(colon_pos + 1);
             options->local_forwards.push_back(
@@ -1102,18 +1102,18 @@ int ssh_options_set(struct Options *options, enum ssh_options_e type,
       }
       break;
     case SSH_OPTIONS_SETENV:
-      v = static_cast<const char *>(value);
+      v = static_cast<const char*>(value);
       if (v == NULL || v[0] == '\0') {
         CLOG(INFO, "stdout") << "invalid error" << endl;
         return -1;
       } else {
-        char *setenv_entry = strdup(v);
+        char* setenv_entry = strdup(v);
         if (setenv_entry == NULL) {
           CLOG(INFO, "stdout") << "error" << endl;
           return -1;
         }
 
-        char *eq_pos = strchr(setenv_entry, '=');
+        char* eq_pos = strchr(setenv_entry, '=');
         if (eq_pos) {
           *eq_pos = '\0';
           options->env_vars.push_back(make_pair(setenv_entry, eq_pos + 1));
@@ -1132,9 +1132,9 @@ int ssh_options_set(struct Options *options, enum ssh_options_e type,
   return 0;
 }
 
-static char *ssh_config_get_cmd(char **str) {
-  char *c;
-  char *r;
+static char* ssh_config_get_cmd(char** str) {
+  char* c;
+  char* r;
 
   /* Ignore leading spaces */
   for (c = *str; *c; c++) {
@@ -1165,10 +1165,10 @@ out:
   return r;
 }
 
-static char *ssh_config_get_token(char **str) {
-  char *c;
+static char* ssh_config_get_token(char** str) {
+  char* c;
   bool had_equal = false;
-  char *r = NULL;
+  char* r = NULL;
 
   /* Ignore leading spaces */
   for (c = *str; *c; c++) {
@@ -1213,7 +1213,7 @@ out:
   return r;
 }
 
-static int ssh_config_get_int(char **str, int notfound) {
+static int ssh_config_get_int(char** str, int notfound) {
   char *p, *endp;
   int i;
 
@@ -1229,8 +1229,8 @@ static int ssh_config_get_int(char **str, int notfound) {
   return notfound;
 }
 
-static const char *ssh_config_get_str_tok(char **str, const char *def) {
-  char *p;
+static const char* ssh_config_get_str_tok(char** str, const char* def) {
+  char* p;
 
   p = ssh_config_get_token(str);
   if (p && *p) {
@@ -1240,8 +1240,8 @@ static const char *ssh_config_get_str_tok(char **str, const char *def) {
   return def;
 }
 
-static int ssh_config_get_yesno(char **str, int notfound) {
-  const char *p;
+static int ssh_config_get_yesno(char** str, int notfound) {
+  const char* p;
 
   p = ssh_config_get_str_tok(str, NULL);
   if (p == NULL) {
@@ -1260,8 +1260,8 @@ static int ssh_config_get_yesno(char **str, int notfound) {
   return notfound;
 }
 
-static void local_parse_file(const char *targethost, struct Options *options,
-                             const char *filename, int *parsing, int seen[]) {
+static void local_parse_file(const char* targethost, struct Options* options,
+                             const char* filename, int* parsing, int seen[]) {
   string line;
   int len = 0;
 
@@ -1285,14 +1285,14 @@ static void local_parse_file(const char *targethost, struct Options *options,
   return;
 }
 
-static int ssh_config_parse_line(const char *targethost,
-                                 struct Options *options, const char *line,
-                                 unsigned int count, int *parsing, int seen[]) {
+static int ssh_config_parse_line(const char* targethost,
+                                 struct Options* options, const char* line,
+                                 unsigned int count, int* parsing, int seen[]) {
   enum ssh_config_opcode_e opcode;
-  const char *p;
+  const char* p;
   char *s, *x;
-  char *keyword;
-  char *lowertargethost;
+  char* keyword;
+  char* lowertargethost;
   int len;
   int i;
 
@@ -1333,7 +1333,7 @@ static int ssh_config_parse_line(const char *targethost,
 
       p = ssh_config_get_str_tok(&s, NULL);
       if (p) {
-        char *filename = ssh_path_expand_tilde(p);
+        char* filename = ssh_path_expand_tilde(p);
         if (filename) {
           if (strchr(filename, '*') || strchr(filename, '?')) {
             std::string dir = fs::path(filename).parent_path().string();
@@ -1341,7 +1341,7 @@ static int ssh_config_parse_line(const char *targethost,
             std::regex pattern_regex(std::regex_replace(
                 std::regex_replace(pattern, std::regex(R"(\.)"), R"(\.)"),
                 std::regex(R"(\*)"), ".*"));
-            for (const auto &entry :
+            for (const auto& entry :
                  fs::directory_iterator(dir.empty() ? "." : dir)) {
               if (std::regex_match(entry.path().filename().string(),
                                    pattern_regex)) {
@@ -1378,7 +1378,7 @@ static int ssh_config_parse_line(const char *targethost,
     case SOC_HOSTNAME:
       p = ssh_config_get_str_tok(&s, NULL);
       if (p && *parsing) {
-        char *z = ssh_path_expand_escape(options, p);
+        char* z = ssh_path_expand_escape(options, p);
         if (z == NULL) {
           z = strdup(p);
         }
@@ -1503,7 +1503,7 @@ static int ssh_config_parse_line(const char *targethost,
     case SOC_IDENTITYAGENT:
       p = ssh_config_get_str_tok(&s, NULL);
       if (p && *parsing) {
-        char *filename = ssh_path_expand_tilde(p);
+        char* filename = ssh_path_expand_tilde(p);
         if (filename) {
           ssh_options_set(options, SSH_OPTIONS_IDENTITYAGENT, filename);
         }
@@ -1513,7 +1513,7 @@ static int ssh_config_parse_line(const char *targethost,
     case SOC_LOCALFORWARD:
       p = ssh_config_get_str_tok(&s, NULL);
       if (p && *parsing) {
-        const char *remote_part = ssh_config_get_str_tok(&s, NULL);
+        const char* remote_part = ssh_config_get_str_tok(&s, NULL);
         if (remote_part) {
           char forward_str[1024];
           snprintf(forward_str, sizeof(forward_str), "%s %s", p, remote_part);
@@ -1541,7 +1541,7 @@ static int ssh_config_parse_line(const char *targethost,
   return 0;
 }
 
-int parse_ssh_config_file(const char *targethost, struct Options *options,
+int parse_ssh_config_file(const char* targethost, struct Options* options,
                           string filename) {
   string line;
   int len = 0;
@@ -1550,7 +1550,7 @@ int parse_ssh_config_file(const char *targethost, struct Options *options,
   int parsing;
   int seen[SOC_END - SOC_UNSUPPORTED] = {0};
 
-  char *expandedFilename = ssh_path_expand_tilde(filename.c_str());
+  char* expandedFilename = ssh_path_expand_tilde(filename.c_str());
   if (!expandedFilename) {
     LOG(INFO) << filename << " was invalid";
     return 0;

--- a/src/terminal/TerminalClient.cpp
+++ b/src/terminal/TerminalClient.cpp
@@ -351,9 +351,9 @@ void TerminalClient::run(const string& command, const bool noexit) {
         TerminalInfo ti = console->getTerminalInfo();
 
         if (ti != lastTerminalInfo) {
-          LOG(INFO) << "Window size changed: row: " << ti.row()
-                    << " column: " << ti.column() << " width: " << ti.width()
-                    << " height: " << ti.height();
+          VLOG(1) << "Window size changed: row: " << ti.row()
+                  << " column: " << ti.column() << " width: " << ti.width()
+                  << " height: " << ti.height();
           lastTerminalInfo = ti;
           connection->writePacket(
               Packet(TerminalPacketType::TERMINAL_INFO, protoToString(ti)));

--- a/src/terminal/TerminalServer.cpp
+++ b/src/terminal/TerminalServer.cpp
@@ -8,9 +8,9 @@
 namespace et {
 TerminalServer::TerminalServer(
     std::shared_ptr<SocketHandler> _socketHandler,
-    const SocketEndpoint &_serverEndpoint,
+    const SocketEndpoint& _serverEndpoint,
     std::shared_ptr<PipeSocketHandler> _pipeSocketHandler,
-    const SocketEndpoint &_routerEndpoint)
+    const SocketEndpoint& _routerEndpoint)
     : ServerConnection(_socketHandler, _serverEndpoint),
       routerEndpoint(_routerEndpoint) {
   terminalRouter = shared_ptr<UserTerminalRouter>(
@@ -99,7 +99,7 @@ void TerminalServer::run() {
 
 void TerminalServer::runJumpHost(
     shared_ptr<ServerClientConnection> serverClientState,
-    const InitialPayload &payload) {
+    const InitialPayload& payload) {
   InitialResponse response;
   serverClientState->writePacket(
       Packet(uint8_t(EtPacketType::INITIAL_RESPONSE), protoToString(response)));
@@ -160,7 +160,7 @@ void TerminalServer::runJumpHost(
           if (terminalSocketHandler->readPacket(terminalFd, &packet)) {
             serverClientState->writePacket(packet);
           }
-        } catch (const std::runtime_error &ex) {
+        } catch (const std::runtime_error& ex) {
           LOG(INFO) << "Terminal session ended" << ex.what();
           run = false;
           break;
@@ -178,7 +178,7 @@ void TerminalServer::runJumpHost(
           try {
             terminalSocketHandler->writePacket(terminalFd, packet);
             VLOG(4) << "Jumphost wrote to router " << terminalFd;
-          } catch (const std::runtime_error &ex) {
+          } catch (const std::runtime_error& ex) {
             LOG(INFO) << "Unix socket died between global daemon and terminal "
                          "router: "
                       << ex.what();
@@ -187,7 +187,7 @@ void TerminalServer::runJumpHost(
           }
         }
       }
-    } catch (const runtime_error &re) {
+    } catch (const runtime_error& re) {
       STERROR << "Jumphost Error: " << re.what();
       CLOG(INFO, "stdout") << "ERROR: " << re.what();
       serverClientState->closeSocket();
@@ -202,7 +202,7 @@ void TerminalServer::runJumpHost(
 
 void TerminalServer::runTerminal(
     shared_ptr<ServerClientConnection> serverClientState,
-    const InitialPayload &payload) {
+    const InitialPayload& payload) {
   auto maybeUserInfo =
       terminalRouter->tryGetInfoForConnection(serverClientState);
   if (!maybeUserInfo) {
@@ -220,13 +220,13 @@ void TerminalServer::runTerminal(
       new PortForwardHandler(serverSocketHandler, pipeSocketHandler));
   map<string, string> environmentVariables;
 
-  for (const auto &envVar : payload.environmentvariables()) {
+  for (const auto& envVar : payload.environmentvariables()) {
     environmentVariables[envVar.first] = envVar.second;
     LOG(INFO) << "SetEnv: " << envVar.first << "=" << envVar.second;
   }
 
   vector<string> pipePaths;
-  for (const PortForwardSourceRequest &pfsr : payload.reversetunnels()) {
+  for (const PortForwardSourceRequest& pfsr : payload.reversetunnels()) {
     string sourceName;
     PortForwardSourceResponse pfsresponse;
     if (pfsr.has_environmentvariable()) {
@@ -264,7 +264,7 @@ void TerminalServer::runTerminal(
       terminalRouter->getSocketHandler();
 
   TermInit termInit;
-  for (auto &it : environmentVariables) {
+  for (auto& it : environmentVariables) {
     *(termInit.add_environmentnames()) = it.first;
     *(termInit.add_environmentvalues()) = it.second;
   }
@@ -345,12 +345,12 @@ void TerminalServer::runTerminal(
       vector<PortForwardDestinationRequest> requests;
       vector<PortForwardData> dataToSend;
       portForwardHandler->update(&requests, &dataToSend);
-      for (auto &pfr : requests) {
+      for (auto& pfr : requests) {
         serverClientState->writePacket(
             Packet(TerminalPacketType::PORT_FORWARD_DESTINATION_REQUEST,
                    protoToString(pfr)));
       }
-      for (auto &pwd : dataToSend) {
+      for (auto& pwd : dataToSend) {
         serverClientState->writePacket(
             Packet(TerminalPacketType::PORT_FORWARD_DATA, protoToString(pwd)));
       }
@@ -408,7 +408,7 @@ void TerminalServer::runTerminal(
           }
         }
       }
-    } catch (const runtime_error &re) {
+    } catch (const runtime_error& re) {
       STERROR << "Error: " << re.what();
       CLOG(INFO, "stdout") << "Error: " << re.what();
       serverClientState->closeSocket();

--- a/src/terminal/TerminalServer.hpp
+++ b/src/terminal/TerminalServer.hpp
@@ -25,17 +25,17 @@ class TerminalServer : public ServerConnection {
  public:
   /** @brief Initializes the server with socket helpers and router endpoint. */
   TerminalServer(std::shared_ptr<SocketHandler> _socketHandler,
-                 const SocketEndpoint &_serverEndpoint,
+                 const SocketEndpoint& _serverEndpoint,
                  std::shared_ptr<PipeSocketHandler> _pipeSocketHandler,
-                 const SocketEndpoint &_routerEndpoint);
+                 const SocketEndpoint& _routerEndpoint);
   /** @brief Tears down the server, closing any active router connections. */
   virtual ~TerminalServer();
   /** @brief Drives a jumphost proxy session for the authenticated client. */
   void runJumpHost(shared_ptr<ServerClientConnection> serverClientState,
-                   const InitialPayload &payload);
+                   const InitialPayload& payload);
   /** @brief Launches the interactive terminal session for a client. */
   void runTerminal(shared_ptr<ServerClientConnection> serverClientState,
-                   const InitialPayload &payload);
+                   const InitialPayload& payload);
   /** @brief Sets up the client state and pushes it into the terminal router. */
   void handleConnection(shared_ptr<ServerClientConnection> serverClientState);
   /** @brief Callback from ServerConnection when a new client is authenticated.

--- a/src/terminal/TerminalServerMain.cpp
+++ b/src/terminal/TerminalServerMain.cpp
@@ -11,7 +11,7 @@ namespace gflags {}
 using namespace google;
 using namespace gflags;
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   // Setup easylogging configurations
   el::Configurations defaultConf = LogHandler::setupLogHandler(&argc, &argv);
   LogHandler::setupStdoutLogger();
@@ -88,14 +88,14 @@ int main(int argc, char **argv) {
       SI_Error rc = ini.LoadFile(cfgfilename.c_str());
       if (rc == 0) {
         if (!result.count("port")) {
-          const char *portString = ini.GetValue("Networking", "port", NULL);
+          const char* portString = ini.GetValue("Networking", "port", NULL);
           if (portString) {
             port = stoi(portString);
           }
         }
 
         if (!result.count("bindip")) {
-          const char *bindIpPtr = ini.GetValue("Networking", "bind_ip", NULL);
+          const char* bindIpPtr = ini.GetValue("Networking", "bind_ip", NULL);
           if (bindIpPtr) {
             bindIp = string(bindIpPtr);
           }
@@ -103,14 +103,14 @@ int main(int argc, char **argv) {
 
         enableTelemetry = ini.GetBoolValue("Debug", "telemetry", false);
         // read verbose level (prioritize command line option over cfgfile)
-        const char *vlevel = ini.GetValue("Debug", "verbose", NULL);
+        const char* vlevel = ini.GetValue("Debug", "verbose", NULL);
         if (result.count("verbose")) {
           el::Loggers::setVerboseLevel(result["verbose"].as<int>());
         } else if (vlevel) {
           el::Loggers::setVerboseLevel(atoi(vlevel));
         }
 
-        const char *fifoName = ini.GetValue("Debug", "serverfifo", NULL);
+        const char* fifoName = ini.GetValue("Debug", "serverfifo", NULL);
         if (fifoName) {
           const string fifoNameStr(fifoName);
           if (!fifoNameStr.empty()) {
@@ -119,20 +119,20 @@ int main(int argc, char **argv) {
         }
 
         // read silent setting
-        const char *silent = ini.GetValue("Debug", "silent", NULL);
+        const char* silent = ini.GetValue("Debug", "silent", NULL);
         if (silent && atoi(silent) != 0) {
           defaultConf.setGlobally(el::ConfigurationType::Enabled, "false");
         }
 
         // read log file size limit
-        const char *logsize = ini.GetValue("Debug", "logsize", NULL);
+        const char* logsize = ini.GetValue("Debug", "logsize", NULL);
         if (logsize && atoi(logsize) != 0) {
           // make sure maxlogsize is a string of int value
           maxlogsize = string(logsize);
         }
 
         // log file directory (TODO path validation and trailing slash cleanup)
-        const char *logdir = ini.GetValue("Debug", "logdirectory", NULL);
+        const char* logdir = ini.GetValue("Debug", "logdirectory", NULL);
         if (logdir) {
           logDirectory = string(logdir);
         }
@@ -202,7 +202,7 @@ int main(int argc, char **argv) {
                                   pipeSocketHandler, routerFifo);
     terminalServer.run();
 
-  } catch (cxxopts::exceptions::exception &oe) {
+  } catch (cxxopts::exceptions::exception& oe) {
     CLOG(INFO, "stdout") << "Exception: " << oe.what() << "\n" << endl;
     CLOG(INFO, "stdout") << options.help({}) << endl;
     exit(1);

--- a/src/terminal/UserJumphostHandler.cpp
+++ b/src/terminal/UserJumphostHandler.cpp
@@ -7,7 +7,7 @@
 namespace et {
 UserJumphostHandler::UserJumphostHandler(
     shared_ptr<SocketHandler> _jumpClientSocketHandler,
-    const string &_idpasskey, const SocketEndpoint &_dstSocketEndpoint,
+    const string& _idpasskey, const SocketEndpoint& _dstSocketEndpoint,
     shared_ptr<SocketHandler> _routerSocketHandler,
     const optional<SocketEndpoint> routerEndpoint)
     : routerSocketHandler(_routerSocketHandler),
@@ -33,7 +33,7 @@ void UserJumphostHandler::run() {
     routerSocketHandler->writePacket(
         routerFd,
         Packet(TerminalPacketType::TERMINAL_USER_INFO, protoToString(tui)));
-  } catch (const std::runtime_error &re) {
+  } catch (const std::runtime_error& re) {
     STFATAL << "Cannot send idpasskey to router: " << re.what();
   }
 
@@ -108,7 +108,7 @@ void UserJumphostHandler::run() {
           throw std::runtime_error("Connect Timeout");
         }
       }
-    } catch (const runtime_error &err) {
+    } catch (const runtime_error& err) {
       LOG(INFO) << "Could not make initial connection to dst server";
       CLOG(INFO, "stdout") << "Could not make initial connection to "
                            << dstSocketEndpoint << ": " << err.what() << endl;
@@ -195,7 +195,7 @@ void UserJumphostHandler::run() {
         jumpclient->closeSocket();
         is_reconnecting = false;
       }
-    } catch (const runtime_error &re) {
+    } catch (const runtime_error& re) {
       STERROR << "Error: " << re.what();
       CLOG(INFO, "stdout") << "Connection closing because of error: "
                            << re.what() << endl;

--- a/src/terminal/UserJumphostHandler.hpp
+++ b/src/terminal/UserJumphostHandler.hpp
@@ -14,8 +14,8 @@ class UserJumphostHandler {
    * endpoint.
    */
   UserJumphostHandler(shared_ptr<SocketHandler> _jumpClientSocketHandler,
-                      const string &_idpasskey,
-                      const SocketEndpoint &_dstSocketEndpoint,
+                      const string& _idpasskey,
+                      const SocketEndpoint& _dstSocketEndpoint,
                       shared_ptr<SocketHandler> routerSocketHandler,
                       const optional<SocketEndpoint> routerEndpoint);
 

--- a/src/terminal/UserTerminalHandler.cpp
+++ b/src/terminal/UserTerminalHandler.cpp
@@ -11,7 +11,7 @@ namespace et {
 UserTerminalHandler::UserTerminalHandler(
     shared_ptr<SocketHandler> _socketHandler, shared_ptr<UserTerminal> _term,
     bool _noratelimit, const optional<SocketEndpoint> routerEndpoint,
-    const string &idPasskey)
+    const string& idPasskey)
     : socketHandler(_socketHandler),
       term(_term),
       noratelimit(_noratelimit),
@@ -32,7 +32,7 @@ UserTerminalHandler::UserTerminalHandler(
         routerFd,
         Packet(TerminalPacketType::TERMINAL_USER_INFO, protoToString(tui)));
 
-  } catch (const std::runtime_error &re) {
+  } catch (const std::runtime_error& re) {
     STFATAL << "Error connecting to router: " << re.what();
   }
 }
@@ -221,7 +221,7 @@ void UserTerminalHandler::runUserTerminal(int masterFd) {
           break;
         }
       }
-    } catch (const std::exception &ex) {
+    } catch (const std::exception& ex) {
       LOG(INFO) << ex.what();
       lock_guard<recursive_mutex> guard(shutdownMutex);
       shuttingDown = true;

--- a/src/terminal/UserTerminalHandler.hpp
+++ b/src/terminal/UserTerminalHandler.hpp
@@ -19,7 +19,7 @@ class UserTerminalHandler {
   UserTerminalHandler(shared_ptr<SocketHandler> _socketHandler,
                       shared_ptr<UserTerminal> _term, bool noratelimit,
                       const optional<SocketEndpoint> _routerEndpoint,
-                      const string &idPasskey);
+                      const string& idPasskey);
   /** @brief Drives the terminal session until cleanup is requested. */
   void run();
   /** @brief Sets a flag to stop the loop and shut down the terminal. */

--- a/src/terminal/UserTerminalRouter.cpp
+++ b/src/terminal/UserTerminalRouter.cpp
@@ -6,7 +6,7 @@
 namespace et {
 UserTerminalRouter::UserTerminalRouter(
     shared_ptr<PipeSocketHandler> _socketHandler,
-    const SocketEndpoint &_routerEndpoint)
+    const SocketEndpoint& _routerEndpoint)
     : socketHandler(_socketHandler) {
   serverFd = *(socketHandler->listen(_routerEndpoint).begin());
   FATAL_FAIL(::chown(_routerEndpoint.name().c_str(), getuid(), getgid()));
@@ -49,7 +49,7 @@ IdKeyPair UserTerminalRouter::acceptNewConnection() {
     }
 
     return IdKeyPair({tui.id(), tui.passkey()});
-  } catch (const std::runtime_error &re) {
+  } catch (const std::runtime_error& re) {
     LOG(ERROR) << "Router can't talk to terminal: " << re.what();
     socketHandler->close(terminalFd);
     return IdKeyPair({"", ""});
@@ -60,7 +60,7 @@ IdKeyPair UserTerminalRouter::acceptNewConnection() {
 }
 
 std::optional<TerminalUserInfo> UserTerminalRouter::tryGetInfoForConnection(
-    const shared_ptr<ServerClientConnection> &serverClientState) {
+    const shared_ptr<ServerClientConnection>& serverClientState) {
   lock_guard<recursive_mutex> guard(routerMutex);
   auto it = idInfoMap.find(serverClientState->getId());
   if (it == idInfoMap.end()) {

--- a/test/Main.cpp
+++ b/test/Main.cpp
@@ -8,7 +8,7 @@
 
 using namespace et;
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   srand(1);
 
   bool listOnly = false;

--- a/test/integration_tests/TerminalTest.cpp
+++ b/test/integration_tests/TerminalTest.cpp
@@ -4,6 +4,8 @@
 
 #if __APPLE__
 #include <util.h>
+#elif __FreeBSD__
+#include <libutil.h>
 #else
 #include <pty.h>
 #endif

--- a/test/system_tests/backwards_compatibility.sh
+++ b/test/system_tests/backwards_compatibility.sh
@@ -73,6 +73,25 @@ fi
 
 git -C "$OLD_ROOT" fetch --tags "$ROOT"
 git -C "$OLD_ROOT" checkout --force "$OLD_COMMIT"
+git -C "$OLD_ROOT" apply --unidiff-zero <<'PATCH'
+diff --git a/src/base/DaemonCreator.cpp b/src/base/DaemonCreator.cpp
+index 20bdea530..f34a526db 100644
+--- a/src/base/DaemonCreator.cpp
++++ b/src/base/DaemonCreator.cpp
+@@ -50,2 +50,7 @@ int DaemonCreator::create(bool parentExit, string childPidFile) {
+-    write(pidFilehandle, pid_str.c_str(), pid_str.length());
+-    close(pidFilehandle);
++    ssize_t bytesWritten =
++        write(pidFilehandle, pid_str.c_str(), pid_str.length());
++    FATAL_FAIL(bytesWritten);
++    if (static_cast<size_t>(bytesWritten) != pid_str.length()) {
++      STFATAL << "Error writing pidfile: " << childPidFile;
++    }
++    FATAL_FAIL(close(pidFilehandle));
+@@ -56 +61 @@ int DaemonCreator::create(bool parentExit, string childPidFile) {
+-  chdir("/");
++  FATAL_FAIL(chdir("/"));
+PATCH
 
 rm -rf "$OLD_BUILD"
 mkdir -p "$OLD_BUILD"

--- a/test/system_tests/connect_with_jumphost.sh
+++ b/test/system_tests/connect_with_jumphost.sh
@@ -2,6 +2,19 @@
 set -x
 set -e
 
+first_server_pid=""
+second_server_pid=""
+
+cleanup() {
+  if [ -n "$first_server_pid" ]; then
+    kill -9 "$first_server_pid" 2>/dev/null || true
+  fi
+  if [ -n "$second_server_pid" ]; then
+    kill -9 "$second_server_pid" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
 ssh -o 'PreferredAuthentications=publickey' localhost "echo" || exit 1 # Fails if we can't ssh into localhost without a password
 
 # Bypass host check
@@ -24,4 +37,6 @@ build/et -c "echo 'Hello World 2!'" --serverfifo=/tmp/etserver.idpasskey.fifo2 -
 build/et -c "echo 'Hello World 3!'" --serverfifo=/tmp/etserver.idpasskey.fifo2 --logtostdout --terminal-path $PWD/build/etterminal --jumphost localhost --jport 9900 --jserverfifo=/tmp/etserver.idpasskey.fifo1 127.0.0.1:9901 # We can't use 'localhost' for both the jumphost and the destination because ssh doesn't support keeping them the same.
 
 kill -9 $first_server_pid
+first_server_pid=""
 kill -9 $second_server_pid
+second_server_pid=""

--- a/test/unit_tests/SubprocessUtilsTest.cpp
+++ b/test/unit_tests/SubprocessUtilsTest.cpp
@@ -1,6 +1,5 @@
-#include "TestHeaders.hpp"
-
 #include "SubprocessUtils.hpp"
+#include "TestHeaders.hpp"
 
 using namespace et;
 

--- a/test/unit_tests/SubprocessUtilsTest.cpp
+++ b/test/unit_tests/SubprocessUtilsTest.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch_test_macros.hpp>
+#include "TestHeaders.hpp"
 
 #include "SubprocessUtils.hpp"
 


### PR DESCRIPTION
Move Ubuntu PPA, Arch AUR, and Debian repository deployment into manually triggered GitHub Actions so release publishing can be exercised and controlled from CI. The workflows import signing and SSH credentials from GitHub secrets, keep Ubuntu uploads simulated for now, and let Debian builds publish packages into a local aptly repository before optionally pushing repository contents.

Add local act wrapper scripts for the deployment workflows so the same paths can be tested from a developer machine with dry-run defaults. The Debian wrapper limits local runs to practical defaults, keeps cowbuilder output manageable, and the Debian workflow supports suite, architecture, verbosity, and job-count overrides for targeted validation.

Also improve portability CI and local act behavior, including FreeBSD/Fedora/Arch setup fixes, sshd cleanup for Linux CI, daemon write/chdir error handling, less noisy terminal resize logging, Catch2/easylogging include cleanup, and old-version compatibility patching.