### PR TITLE
Fix GCC 15 build failure — Ubuntu 26.04 (Resolute) PPA

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -326,8 +326,16 @@ else()
     util
     resolv
     atomic
-    stdc++fs
   )
+  # stdc++fs was a separate library for <filesystem> in GCC 8 and earlier.
+  # Starting with GCC 9, filesystem support is part of libstdc++ proper, and
+  # the separate -lstdc++fs was removed entirely in GCC 15.
+  # Only link it if the compiler still ships it.
+  include(CheckLibraryExists)
+  check_library_exists(stdc++fs "" "" HAVE_STDCXXFS)
+  if(HAVE_STDCXXFS)
+    list(APPEND CORE_LIBRARIES stdc++fs)
+  endif()
 endif()
 
 IF(Unwind_FOUND)

--- a/src/base/BackedWriter.cpp
+++ b/src/base/BackedWriter.cpp
@@ -1,5 +1,6 @@
-#include "BackedWriter.hpp"
 #include <cstdint>
+
+#include "BackedWriter.hpp"
 
 namespace et {
 BackedWriter::BackedWriter(std::shared_ptr<SocketHandler> socketHandler_,

--- a/src/base/BackedWriter.cpp
+++ b/src/base/BackedWriter.cpp
@@ -1,4 +1,5 @@
 #include "BackedWriter.hpp"
+#include <cstdint>
 
 namespace et {
 BackedWriter::BackedWriter(std::shared_ptr<SocketHandler> socketHandler_,

--- a/src/base/BackedWriter.cpp
+++ b/src/base/BackedWriter.cpp
@@ -1,6 +1,6 @@
-#include <cstdint>
-
 #include "BackedWriter.hpp"
+
+#include <cstdint>
 
 namespace et {
 BackedWriter::BackedWriter(std::shared_ptr<SocketHandler> socketHandler_,

--- a/src/base/UnixSocketHandler.cpp
+++ b/src/base/UnixSocketHandler.cpp
@@ -1,6 +1,6 @@
-#include <cstdint>
-
 #include "UnixSocketHandler.hpp"
+
+#include <cstdint>
 
 namespace et {
 UnixSocketHandler::UnixSocketHandler() {}

--- a/src/base/UnixSocketHandler.cpp
+++ b/src/base/UnixSocketHandler.cpp
@@ -1,4 +1,5 @@
 #include "UnixSocketHandler.hpp"
+#include <cstdint>
 
 namespace et {
 UnixSocketHandler::UnixSocketHandler() {}

--- a/src/base/UnixSocketHandler.cpp
+++ b/src/base/UnixSocketHandler.cpp
@@ -1,5 +1,6 @@
-#include "UnixSocketHandler.hpp"
 #include <cstdint>
+
+#include "UnixSocketHandler.hpp"
 
 namespace et {
 UnixSocketHandler::UnixSocketHandler() {}

--- a/src/htm/HtmServer.cpp
+++ b/src/htm/HtmServer.cpp
@@ -1,10 +1,11 @@
+#include <cstdint>
+
 #include "HtmServer.hpp"
 
 #include "HtmHeaderCodes.hpp"
 #include "LogHandler.hpp"
 #include "MultiplexerState.hpp"
 #include "base64.h"
-#include <cstdint>
 
 namespace et {
 HtmServer::HtmServer(shared_ptr<SocketHandler> _socketHandler,

--- a/src/htm/HtmServer.cpp
+++ b/src/htm/HtmServer.cpp
@@ -4,6 +4,7 @@
 #include "LogHandler.hpp"
 #include "MultiplexerState.hpp"
 #include "base64.h"
+#include <cstdint>
 
 namespace et {
 HtmServer::HtmServer(shared_ptr<SocketHandler> _socketHandler,

--- a/src/htm/HtmServer.cpp
+++ b/src/htm/HtmServer.cpp
@@ -1,6 +1,6 @@
-#include <cstdint>
-
 #include "HtmServer.hpp"
+
+#include <cstdint>
 
 #include "HtmHeaderCodes.hpp"
 #include "LogHandler.hpp"

--- a/src/htm/MultiplexerState.cpp
+++ b/src/htm/MultiplexerState.cpp
@@ -1,8 +1,9 @@
+#include <cstdint>
+
 #include "MultiplexerState.hpp"
 
 #include "HtmHeaderCodes.hpp"
 #include "JsonLib.hpp"
-#include <cstdint>
 
 namespace et {
 struct MultiplexerState::Pane {

--- a/src/htm/MultiplexerState.cpp
+++ b/src/htm/MultiplexerState.cpp
@@ -1,6 +1,6 @@
-#include <cstdint>
-
 #include "MultiplexerState.hpp"
+
+#include <cstdint>
 
 #include "HtmHeaderCodes.hpp"
 #include "JsonLib.hpp"

--- a/src/htm/MultiplexerState.cpp
+++ b/src/htm/MultiplexerState.cpp
@@ -2,6 +2,7 @@
 
 #include "HtmHeaderCodes.hpp"
 #include "JsonLib.hpp"
+#include <cstdint>
 
 namespace et {
 struct MultiplexerState::Pane {

--- a/src/terminal/TerminalClient.cpp
+++ b/src/terminal/TerminalClient.cpp
@@ -1,8 +1,9 @@
+#include <cstdint>
+
 #include "TerminalClient.hpp"
 
 #include "TelemetryService.hpp"
 #include "TunnelUtils.hpp"
-#include <cstdint>
 
 namespace et {
 

--- a/src/terminal/TerminalClient.cpp
+++ b/src/terminal/TerminalClient.cpp
@@ -1,6 +1,6 @@
-#include <cstdint>
-
 #include "TerminalClient.hpp"
+
+#include <cstdint>
 
 #include "TelemetryService.hpp"
 #include "TunnelUtils.hpp"

--- a/src/terminal/TerminalClient.cpp
+++ b/src/terminal/TerminalClient.cpp
@@ -2,6 +2,7 @@
 
 #include "TelemetryService.hpp"
 #include "TunnelUtils.hpp"
+#include <cstdint>
 
 namespace et {
 

--- a/src/terminal/TerminalServer.cpp
+++ b/src/terminal/TerminalServer.cpp
@@ -1,8 +1,9 @@
 #ifndef WIN32
+#include <cstdint>
+
 #include "TerminalServer.hpp"
 
 #include "TelemetryService.hpp"
-#include <cstdint>
 
 #define BUF_SIZE (16 * 1024)
 

--- a/src/terminal/TerminalServer.cpp
+++ b/src/terminal/TerminalServer.cpp
@@ -1,7 +1,7 @@
 #ifndef WIN32
-#include <cstdint>
-
 #include "TerminalServer.hpp"
+
+#include <cstdint>
 
 #include "TelemetryService.hpp"
 

--- a/src/terminal/TerminalServer.cpp
+++ b/src/terminal/TerminalServer.cpp
@@ -2,6 +2,7 @@
 #include "TerminalServer.hpp"
 
 #include "TelemetryService.hpp"
+#include <cstdint>
 
 #define BUF_SIZE (16 * 1024)
 

--- a/src/terminal/UserTerminalHandler.cpp
+++ b/src/terminal/UserTerminalHandler.cpp
@@ -6,6 +6,7 @@
 #include "ServerConnection.hpp"
 #include "ServerFifoPath.hpp"
 #include "UserTerminalRouter.hpp"
+#include <cstdint>
 
 namespace et {
 UserTerminalHandler::UserTerminalHandler(

--- a/src/terminal/UserTerminalHandler.cpp
+++ b/src/terminal/UserTerminalHandler.cpp
@@ -1,4 +1,6 @@
 #ifndef WIN32
+#include <cstdint>
+
 #include "UserTerminalHandler.hpp"
 
 #include "ETerminal.pb.h"
@@ -6,7 +8,6 @@
 #include "ServerConnection.hpp"
 #include "ServerFifoPath.hpp"
 #include "UserTerminalRouter.hpp"
-#include <cstdint>
 
 namespace et {
 UserTerminalHandler::UserTerminalHandler(

--- a/src/terminal/UserTerminalHandler.cpp
+++ b/src/terminal/UserTerminalHandler.cpp
@@ -1,7 +1,7 @@
 #ifndef WIN32
-#include <cstdint>
-
 #include "UserTerminalHandler.hpp"
+
+#include <cstdint>
 
 #include "ETerminal.pb.h"
 #include "RawSocketUtils.hpp"

--- a/src/terminal/forwarding/PortForwardHandler.cpp
+++ b/src/terminal/forwarding/PortForwardHandler.cpp
@@ -1,6 +1,6 @@
-#include <cstdint>
-
 #include "PortForwardHandler.hpp"
+
+#include <cstdint>
 
 namespace et {
 PortForwardHandler::PortForwardHandler(

--- a/src/terminal/forwarding/PortForwardHandler.cpp
+++ b/src/terminal/forwarding/PortForwardHandler.cpp
@@ -1,5 +1,6 @@
-#include "PortForwardHandler.hpp"
 #include <cstdint>
+
+#include "PortForwardHandler.hpp"
 
 namespace et {
 PortForwardHandler::PortForwardHandler(

--- a/src/terminal/forwarding/PortForwardHandler.cpp
+++ b/src/terminal/forwarding/PortForwardHandler.cpp
@@ -1,4 +1,5 @@
 #include "PortForwardHandler.hpp"
+#include <cstdint>
 
 namespace et {
 PortForwardHandler::PortForwardHandler(


### PR DESCRIPTION
## Problem

The PPA build for Ubuntu 26.04 (Resolute) fails on Launchpad ([build #33370536](https://launchpad.net/~jgmath2000/+archive/ubuntu/et/+build/33370536) — FAILEDTOBUILD). Tracked in #744.

Ubuntu 26.04 ships **GCC 15**, which introduces two breaking changes:

### 1. `-lstdc++fs` no longer exists (linker error)

GCC 15 completely removed the separate `stdc++fs` library — filesystem support was merged into `libstdc++` proper since GCC 9. The CMakeLists.txt unconditionally links `stdc++fs` on Linux, causing:

```
/usr/bin/ld: cannot find -lstdc++fs: No such file or directory
```

Same class of issue as #581.

### 2. Implicit `<cstdint>` includes removed (compiler errors)

GCC 15 removed transitive header inclusions. Source files using `uint64_t`/`uint32_t` without explicit `#include <cstdint>` now fail:

```
error: 'uint64_t' does not name a type
```

## Fix

**CMakeLists.txt** — Replace unconditional `stdc++fs` linking with `check_library_exists()` so it only links when the library is present (GCC ≤ 8). Backwards compatible.

**8 source files** — Added `#include <cstdint>` to files using fixed-width integer types without the explicit include:
- `src/htm/MultiplexerState.cpp`
- `src/htm/HtmServer.cpp`
- `src/terminal/UserTerminalHandler.cpp`
- `src/terminal/TerminalServer.cpp`
- `src/terminal/TerminalClient.cpp`
- `src/terminal/forwarding/PortForwardHandler.cpp`
- `src/base/BackedWriter.cpp`
- `src/base/UnixSocketHandler.cpp`

## Related

- #744 — Installation fails on Ubuntu 26.04
- #581 — `-lstdc++fs` linker error (same root cause, different distro)
