### PR TITLE
Keep the client alive when the console fd is not a tty

### DIFF
--- a/src/terminal/TerminalClient.cpp
+++ b/src/terminal/TerminalClient.cpp
@@ -180,6 +180,13 @@ void TerminalClient::run(const string& command, const bool noexit) {
     CLOG(INFO, "stdout") << "ET running, feel free to background..." << endl;
   }
 
+  // Launchers such as nohup(1) replace stdout with a regular file while
+  // leaving the tty on stdin, so the descriptor Console exposes for input is
+  // readable-but-empty (or not readable at all). select() always reports it
+  // ready and every read yields EOF/EBADF, which must not be mistaken for the
+  // user closing an interactive session -- doing so would tear down a
+  // backgrounded client and its port forwards immediately.
+  bool consoleInputDisabled = false;
   while (!connection->isShuttingDown()) {
     {
       lock_guard<recursive_mutex> guard(shutdownMutex);
@@ -195,7 +202,7 @@ void TerminalClient::run(const string& command, const bool noexit) {
     FD_ZERO(&rfd);
     int maxfd = -1;
     int consoleFd = -1;
-    if (console) {
+    if (console && !consoleInputDisabled) {
       consoleFd = console->getFd();
       maxfd = consoleFd;
       FD_SET(consoleFd, &rfd);
@@ -217,7 +224,7 @@ void TerminalClient::run(const string& command, const bool noexit) {
     select(maxfd + 1, &rfd, NULL, NULL, &tv);
 
     try {
-      if (console) {
+      if (console && consoleFd >= 0) {
         // Check for data to send.
         if (FD_ISSET(consoleFd, &rfd)) {
           // Read from stdin and write to our client that will then send it to
@@ -265,11 +272,21 @@ void TerminalClient::run(const string& command, const bool noexit) {
                   TerminalPacketType::TERMINAL_BUFFER, protoToString(tb)));
               keepaliveTime = time(NULL) + keepaliveDuration;
             } else if (rc == 0) {
-              LOG(INFO) << "Console EOF";
-              break;
+              if (isatty(consoleFd)) {
+                LOG(INFO) << "Console EOF";
+                break;
+              }
+              LOG(INFO) << "Console is not a tty and is at EOF, disabling "
+                           "console input";
+              consoleInputDisabled = true;
             } else {
               if (savedErrno == EAGAIN || savedErrno == EWOULDBLOCK) {
                 // Transient error, retry
+              } else if (!isatty(consoleFd)) {
+                LOG(INFO) << "Console is not a tty and cannot be read ("
+                          << savedErrno << "): " << strerror(savedErrno)
+                          << ", disabling console input";
+                consoleInputDisabled = true;
               } else {
                 LOG(INFO) << "Console read error: (" << savedErrno
                           << "): " << strerror(savedErrno);

--- a/test/integration_tests/TerminalTest.cpp
+++ b/test/integration_tests/TerminalTest.cpp
@@ -279,6 +279,138 @@ void largeInputNoDeadlockTest(shared_ptr<PipeSocketHandler> routerSocketHandler,
   uth.reset();
 }
 
+// A Console whose descriptor is a regular file opened read/write, reproducing
+// what nohup(1) hands a backgrounded client: output lands in the file, and
+// reads of the same descriptor always return EOF.
+class FileBackedConsole : public Console {
+ public:
+  FileBackedConsole() : fd(-1) {
+    string tmpPath = GetTempDirectory() + string("et_test_nohup_XXXXXXXX");
+    directory = string(mkdtemp(&tmpPath[0]));
+    path = directory + "/nohup.out";
+    fd = ::open(path.c_str(), O_RDWR | O_CREAT | O_APPEND, 0600);
+    FATAL_FAIL(fd);
+  }
+
+  virtual ~FileBackedConsole() {}
+
+  virtual void setup() {}
+
+  virtual void teardown() {
+    if (fd >= 0) {
+      ::close(fd);
+      fd = -1;
+    }
+    ::remove(path.c_str());
+    ::remove(directory.c_str());
+  }
+
+  virtual TerminalInfo getTerminalInfo() {
+    TerminalInfo ti;
+    ti.set_row(24);
+    ti.set_column(80);
+    ti.set_width(640);
+    ti.set_height(480);
+    return ti;
+  }
+
+  virtual int getFd() { return fd; }
+
+  string readBackContents() {
+    string contents;
+    int readFd = ::open(path.c_str(), O_RDONLY);
+    if (readFd < 0) {
+      return contents;
+    }
+    char buf[4096];
+    int rc;
+    while ((rc = ::read(readFd, buf, sizeof(buf))) > 0) {
+      contents.append(buf, rc);
+    }
+    ::close(readFd);
+    return contents;
+  }
+
+ protected:
+  int fd;
+  string directory;
+  string path;
+};
+
+// A client whose console descriptor is not a tty must keep running: it can no
+// longer accept keyboard input, but the session and its port forwards have to
+// survive so a backgrounded client is not torn down the moment the first
+// console read returns EOF.  Console::getFd() is STDOUT_FILENO, so any
+// launcher that points stdout at something other than the tty -- nohup(1), a
+// shell redirect, a service manager -- lands here.
+void nonTtyConsoleKeepsSessionAliveTest(
+    shared_ptr<PipeSocketHandler> routerSocketHandler,
+    shared_ptr<FakeUserTerminal> fakeUserTerminal,
+    SocketEndpoint serverEndpoint,
+    shared_ptr<SocketHandler> clientSocketHandler,
+    shared_ptr<SocketHandler> clientPipeSocketHandler,
+    const SocketEndpoint& routerEndpoint) {
+  auto fakeSubprocessUtils = make_shared<FakeSubprocessUtils>();
+  auto sshSetupHandler = make_shared<FakeSshSetupHandler>(fakeSubprocessUtils);
+  auto [id, passkey] = sshSetupHandler->SetupSsh(
+      "", "localhost", "localhost", 2022, "", "", false, 0, "", "", {});
+
+  auto uth = shared_ptr<UserTerminalHandler>(
+      new UserTerminalHandler(routerSocketHandler, fakeUserTerminal, true,
+                              routerEndpoint, id + "/" + passkey));
+  thread uthThread([uth]() { uth->run(); });
+  sleep(1);
+
+  auto fileConsole = make_shared<FileBackedConsole>();
+  shared_ptr<TerminalClient> terminalClient(
+      new TerminalClient(clientSocketHandler, clientPipeSocketHandler,
+                         serverEndpoint, id, passkey, fileConsole, false, "",
+                         "", false, "", MAX_CLIENT_KEEP_ALIVE_DURATION, {}));
+
+  std::atomic<bool> runReturned(false);
+  thread terminalClientThread([terminalClient, &runReturned]() {
+    terminalClient->run("", false);
+    runReturned = true;
+  });
+  sleep(3);
+
+  // Pre-fix, the first console read returned EOF and run() exited within
+  // milliseconds of the connection coming up.
+  REQUIRE(!runReturned.load());
+
+  // The session is not merely alive, it is still usable: remote output has to
+  // reach the same descriptor.
+  const string remoteOutput = "ET_NOHUP_OUTPUT_MARKER";
+  fakeUserTerminal->simulateTerminalResponse(remoteOutput);
+
+  std::promise<bool> sawOutputPromise;
+  auto sawOutputFuture = sawOutputPromise.get_future();
+  thread readThread([&sawOutputPromise, fileConsole, remoteOutput]() {
+    while (fileConsole->readBackContents().find(remoteOutput) == string::npos) {
+      ::usleep(100 * 1000);
+    }
+    sawOutputPromise.set_value(true);
+  });
+  bool sawOutput = sawOutputFuture.wait_for(std::chrono::seconds(30)) ==
+                   std::future_status::ready;
+  REQUIRE(sawOutput);
+  if (sawOutput) {
+    readThread.join();
+  } else {
+    readThread.detach();
+  }
+
+  REQUIRE(!runReturned.load());
+
+  terminalClient->shutdown();
+  terminalClientThread.join();
+  terminalClient.reset();
+
+  uth->shutdown();
+  uthThread.join();
+  uth.reset();
+}
+
 class LogInterceptHandler : public el::LogDispatchCallback {
  public:
   void handle(const el::LogDispatchData* data) {
@@ -444,6 +576,13 @@ TEST_CASE_METHOD(EndToEndTestFixture, "LargeInputNoDeadlock",
   largeInputNoDeadlockTest(routerSocketHandler, serverEndpoint,
                            clientSocketHandler, clientPipeSocketHandler,
                            fakeConsole, routerEndpoint);
+}
+
+TEST_CASE_METHOD(EndToEndTestFixture, "NonTtyConsoleKeepsSessionAlive",
+                 "[EndToEndTest][integration]") {
+  nonTtyConsoleKeepsSessionAliveTest(routerSocketHandler, fakeUserTerminal,
+                                     serverEndpoint, clientSocketHandler,
+                                     clientPipeSocketHandler, routerEndpoint);
 }
 
 void simultaneousTerminalConnectionTest(


### PR DESCRIPTION
ddf67a5 (#739) replaced FATAL_FAIL(rc) in TerminalClient::run()'s console read loop with explicit handling of every read() outcome. That correctly fixed the spurious ENOENT crash, but it also turned rc == 0 into an unconditional "clean session end":

    } else if (rc == 0) {
      LOG(INFO) << "Console EOF";
      break;
    }

That treats EOF as "the user closed an interactive session", which only holds when the console descriptor is actually a terminal. Often it is not.

Console::getFd() returns STDOUT_FILENO, so the loop reads *stdout*, not stdin. At a normal terminal, fds 0, 1 and 2 all refer to the same tty, so reading fd 1 works and the distinction never shows. Under nohup(1) it does: nohup redirects stdout to nohup.out while leaving the tty on stdin, so the client ends up reading a regular file. select() always reports a regular file ready, and the read always returns 0 -- the file is empty at startup, and the shared offset then tracks the end of the file as the client writes terminal output to it. The client therefore exits moments after connecting, before the session can be used:

    [INFO] Got command: echo hello
    [INFO] Console EOF
    [INFO] Shutting down connection

This breaks any workflow that backgrounds the client so it outlives the process that launched it: nohup et host &, service managers, and IDE remote-development integrations that hold port forwards open across editor restarts. A plain redirect is affected too -- et host --command '...' > out.txt opens stdout O_WRONLY, so read() returns EBADF and takes the other break added by #739.

Before #739 this was invisible: FATAL_FAIL(X) fires only on X == -1, so rc == 0 fell through silently and the session survived, busy-looping on a descriptor it could never read from.

Treat EOF and hard read errors as session-fatal only when the console descriptor is a tty. Otherwise stop selecting on it and keep running. Console input is impossible either way -- it always was under nohup -- but the session and its port forwards stay up. Terminal output is unaffected: it still goes to the same descriptor.

This completes #739 rather than reverting any of it. Every read() outcome is still handled explicitly and the errno-corruption crash stays fixed; a non-interactive console simply no longer ends the session.

Testing:

Adds NonTtyConsoleKeepsSessionAlive to test/integration_tests/TerminalTest.cpp. It drives a real TerminalClient with a FileBackedConsole whose descriptor is a regular file opened O_RDWR|O_APPEND -- the shape nohup installs -- and requires that run() has not returned once the connection is up, and that remote output still reaches that descriptor. Pre-fix, run() returns within milliseconds.

Verified manually on macOS: with a patched client, a remote session launched under nohup stays up and its port forwards carry traffic, where an unpatched build exited immediately after login.