### PR TITLE
Keep destination SSH options off the jumphost

### DIFF
--- a/src/terminal/SshSetupHandler.cpp
+++ b/src/terminal/SshSetupHandler.cpp
@@ -146,9 +146,8 @@ pair<string, string> SshSetupHandler::SetupSsh(
       jump_ssh_args.push_back("-p");
       jump_ssh_args.push_back(parsedJump.portSuffix.substr(1));
     }
-    for (const auto& opt : ssh_options) {
-      jump_ssh_args.push_back("-o" + opt);
-    }
+    // ssh_options configure the destination. Jump-specific options are
+    // resolved independently from the jumphost's SSH configuration.
     jump_ssh_args.push_back(jumphostDest);
     jump_ssh_args.push_back(SSH_SCRIPT_JUMP);
 

--- a/test/unit_tests/SshSetupHandlerTest.cpp
+++ b/test/unit_tests/SshSetupHandlerTest.cpp
@@ -86,6 +86,24 @@ class FakeSshSubprocessHandlerWithJumphost : public SubprocessUtils {
   }
 };
 
+/**
+ * @brief Fake subprocess handler that records both jumphost-mode SSH calls.
+ */
+class RecordingSshSubprocessHandler : public SubprocessUtils {
+ public:
+  vector<vector<string>> calls;
+
+  string SubprocessToStringInteractive(const string& command,
+                                       const vector<string>& args) override {
+    REQUIRE(command == "ssh");
+    calls.push_back(args);
+
+    string id = genRandomAlphaNum(16);
+    string passkey = genRandomAlphaNum(32);
+    return string("IDPASSKEY:") + id + "/" + passkey;
+  }
+};
+
 }  // namespace
 
 TEST_CASE("SshSetupHandler basic connection", "[SshSetupHandler]") {
@@ -157,6 +175,49 @@ TEST_CASE("SshSetupHandler with jumphost", "[SshSetupHandler]") {
   SECTION("Returns id/passkey pair with jumphost") {
     REQUIRE(id.length() == 16);
     REQUIRE(passkey.length() == 32);
+  }
+}
+
+TEST_CASE("SshSetupHandler keeps destination options off the jumphost",
+          "[SshSetupHandler]") {
+  auto fakeSubprocess = make_shared<RecordingSshSubprocessHandler>();
+  SshSetupHandler handler(fakeSubprocess);
+  const vector<string> destination_options = {
+      "User=target-user",
+      "HostKeyAlias=target",
+      "UserKnownHostsFile=/tmp/target_known_hosts",
+      "HostKeyAlgorithms=ssh-ed25519-cert-v01@openssh.com",
+      "KbdInteractiveAuthentication=no",
+  };
+
+  auto [id, passkey] = handler.SetupSsh(
+      "target-user", "target.internal", "target", 2022,
+      "jump-user@jump.example:2222", "", false, 0, "", "", destination_options);
+
+  REQUIRE(id.length() == 16);
+  REQUIRE(passkey.length() == 32);
+  REQUIRE(fakeSubprocess->calls.size() == 2);
+
+  const auto& destination_args = fakeSubprocess->calls[0];
+  REQUIRE(destination_args[0] == "-J");
+  REQUIRE(destination_args[1] == "jump-user@jump.example:2222");
+  REQUIRE(destination_args[2] == "target-user@target");
+  for (const auto& option : destination_options) {
+    REQUIRE(std::find(destination_args.begin(), destination_args.end(),
+                      "-o" + option) != destination_args.end());
+  }
+
+  const auto& jump_args = fakeSubprocess->calls[1];
+  REQUIRE(jump_args.size() == 4);
+  REQUIRE(jump_args[0] == "-p");
+  REQUIRE(jump_args[1] == "2222");
+  REQUIRE(jump_args[2] == "jump-user@jump.example");
+  REQUIRE(
+      jump_args[3].find("--jump --dsthost=target.internal --dstport=2022") !=
+      string::npos);
+  for (const auto& option : destination_options) {
+    REQUIRE(std::find(jump_args.begin(), jump_args.end(), "-o" + option) ==
+            jump_args.end());
   }
 }
 


### PR DESCRIPTION
## Summary

- stop replaying destination-scoped `--ssh-option` values on the independent jumphost relay connection
- preserve the jumphost user, port, address, alias, and IPv6 parsing added in #705
- add a regression test that records both SSH calls and verifies target options stay on the target bootstrap

## Rationale

Jumphost mode launches two SSH processes with different destinations and often different users, identities, host keys, and trust policies. Copying target-only options onto the direct jumphost call can both break valid ProxyJump setups and unintentionally weaken jumphost verification.

Jump-specific policy continues to resolve independently from the jumphost's SSH configuration.

## Testing

- source and test formatting checks pass
- Linux ASan, UBSan, MSan, TSan, jumphost system, and backwards-compatibility jobs pass
- Codecov reports all modified coverable lines exercised
- `git diff --check`; patch applies cleanly to both `master` and the `release`/v7.0.0 branch