### PR TITLE
Disable SO_LINGER: a blocking close() freezes the whole socket layer for 5 seconds

### DIFF
--- a/src/base/TcpSocketHandler.cpp
+++ b/src/base/TcpSocketHandler.cpp
@@ -294,9 +294,13 @@ void TcpSocketHandler::initSocket(int fd) {
         setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, (char*)&flag, sizeof(int)));
   }
   {
-    // Set linger if possible
+    // Linger is disabled deliberately. With l_onoff=1, closing a socket that
+    // still has unacknowledged data blocks in ::close() for the full l_linger
+    // seconds -- and UnixSocketHandler::close() calls it while holding the
+    // process-wide globalMutex, so one connection tearing down freezes every
+    // thread in etserver, terminal sessions included.
     struct linger so_linger;
-    so_linger.l_onoff = 1;
+    so_linger.l_onoff = 0;
     so_linger.l_linger = 5;
     FATAL_FAIL_UNLESS_EINVAL(setsockopt(
         fd, SOL_SOCKET, SO_LINGER, (const char*)&so_linger, sizeof so_linger));


### PR DESCRIPTION
## The bug

Every TCP socket `etserver` accepts gets `SO_LINGER {l_onoff=1, l_linger=5}` in `TcpSocketHandler::initSocket`. Closing such a socket while it still has unacknowledged data blocks in `::close()` for the full five seconds.

That alone would only slow one teardown. The problem is where the close happens — `UnixSocketHandler::close()`:

1. takes the process-wide `globalMutex` (line 170),
2. forces the fd blocking at line 183 (`setBlocking(fd, true)`) — sockets are created non-blocking, and Linux ignores a nonzero linger on a non-blocking socket, so this line is what arms it,
3. calls the blocking `::close()` at line 190,
4. and the `lock_guard` is function-scoped, so the mutex is held until 194.

So it isn't one connection stalling. **Every thread in `etserver` that touches any socket stalls for five seconds because one unrelated connection is tearing down**, including the threads serving interactive terminal sessions.

Only about half of teardowns stall, since the linger arms only when there is unacknowledged data in the send queue at close time. That intermittency is likely why it has gone unnoticed — it looks like a network problem.

## Why the linger is there

Worth answering before proposing to remove it. From the history, it looks vestigial.

| date | commit | |
|---|---|---|
| 2018-08-09 | [`410aa69b8`](https://github.com/MisterTea/EternalTerminal/commit/410aa69b8) (PR #127, *"Fix reconnect issue with jumphost"*) | `SO_LINGER` first appears — one line inside a multi-feature PR. The PR body does not mention it. The commit's own bullets are the only context: *"Call shutdown upon closing a connection"* and *"Kill socket & reconnect less agressively"*. |
| 2018-09-23 | [`01d8c9298`](https://github.com/MisterTea/EternalTerminal/commit/01d8c9298) | Moved into `TcpSocketHandler` during the socket refactor, unchanged. |
| 2018-10-29 | [`a733381f3`](https://github.com/MisterTea/EternalTerminal/commit/a733381f3) (*"remove shutdown"*) | `::shutdown(fd, SHUT_RDWR)` deleted. Empty commit body, no stated reason. |
| 2019-12-24 | [`1479bdce9`](https://github.com/MisterTea/EternalTerminal/commit/1479bdce9) | Narrowed to TCP only — *"Fix bug where LINGER was being set for unix sockets"*. |

So `shutdown()` and `SO_LINGER` went in **together** as a teardown pair, in service of jumphost reconnect stability, and the `shutdown()` was removed eleven weeks later. The linger is the surviving half. Today `close()` is `setBlocking(fd, true)` then `::close(fd)`, with `SO_LINGER` armed and no `shutdown()` — not the configuration either commit designed.

That is not on its own an argument for removal (a lingering close and a `shutdown()` do different things), but it does mean no documented behaviour depends on it, and `1479bdce9` is precedent for narrowing its scope when it caused problems.

**If there is a reason it is still needed that the history does not capture, I would rather hear it and adjust the patch than remove something load-bearing.**

## Reproducing it

Self-contained, no ET involved. A peer accepts and never reads, so the sender's data stays unacknowledged; then close a socket that has `SO_LINGER` set.

```python
import socket, struct, threading, time

def run(l_onoff, l_linger):
    lsock = socket.socket(); lsock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
    lsock.bind(("127.0.0.1", 0)); lsock.listen(1)
    port = lsock.getsockname()[1]
    held = []
    def acceptor():
        c, _ = lsock.accept(); held.append(c)      # accept, then NEVER recv()
        while True: time.sleep(1)
    threading.Thread(target=acceptor, daemon=True).start()

    s = socket.create_connection(("127.0.0.1", port))
    s.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, struct.pack("ii", l_onoff, l_linger))
    sent = 0; s.settimeout(2)
    try:
        while sent < 16 * 1024 * 1024: sent += s.send(b"x" * 65536)
    except Exception: pass
    s.settimeout(None)
    t0 = time.time(); s.close()
    print(f"l_onoff={l_onoff} l_linger={l_linger}: queued {sent} bytes, close() {(time.time()-t0)*1000:.0f} ms")

run(1, 5)   # current behaviour
run(0, 5)   # with this patch
run(1, 2)   # control
```

The load-bearing detail is that the peer must **never** call `recv()`. Without unacknowledged data in the send queue at close time, `SO_LINGER` never arms and every variant returns instantly.

## The fix

Set `l_onoff = 0`. The `setsockopt` call is left in place.

## Testing

The script above, on Linux:

```
l_onoff=1 l_linger=5   close() 5156 5118 5120 5119 5118 5120 ms   (18/18 blocked)
no SO_LINGER           close()    0    0    0    0    0    0 ms   (18/18 instant)
l_onoff=0 l_linger=5   close()    0    0    0    0    0    0 ms   <- this patch
l_onoff=1 l_linger=2   median 2046.5 ms
```

The `l_linger=2` arm is the control: halving the constant halves the stall, ratio 0.3998 against a predicted 0.4000. That matters because there are two other five-second constants nearby — `UnixSocketHandler.cpp:43 waitForData(fd, 5, 0)`, and the `pselect6 tv_sec=5` that is simply that call as it appears in a trace — and this rules both out by measurement rather than by argument.

Then a patched `etserver` against stock, 20 trials, arms alternating, identical 1,824,768 bytes queued in every trial:

```
l_onoff=1 (stock)     n=10   median 5.1184s   min 5.1164s   max 5.4877s   10/10 blocked
l_onoff=0 (patched)   n=10   median 0.0000s   min 0.0000s   max 0.0000s    0/10
```

Confirmed at the syscall level on the running service — `setsockopt(fd, SOL_SOCKET, SO_LINGER, {l_onoff=0, l_linger=5}, 8) = 0`, versus `{l_onoff=1, l_linger=5}` for a stock binary under the same test.

## Notes

**This will not reproduce on macOS.** The Mac drains the receive queue during `close()` even when the peer never reads, so you get ~50ms instead of ~5000ms.

After the change, a burst of simultaneous teardowns leaves sockets in `LAST-ACK` with `Send-Q=1` (the unacked FIN) for a while. That is not a leak — `ss -tanp` shows an empty process column, so they are kernel orphans already closed, bounded by `net.ipv4.tcp_max_orphans`. It is the expected consequence of teardowns no longer being serialized at ~5s each.

An alternative fix, if the linger is wanted, is moving `::close()` outside `globalMutex` — a blocking close inside a process-wide lock is questionable regardless of the timeout. Either one alone fixes the freeze; this PR takes the smaller change, and I am happy to do the other instead if you prefer.

This code is byte-identical in 6.2.11 and 7.0.0, so it is long-standing rather than a recent regression.
