### PR TITLE
Survive etserver restarts: etterminal re-registration, RETRY_LATER grace, session resume

### DIFF
--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -182,6 +182,12 @@ jobs:
       - name: Connect with jumphost
         run: ./test/system_tests/connect_with_jumphost.sh
 
+      - name: Named sessions survive client death
+        run: ./test/system_tests/named_sessions.sh
+
+      - name: Sessions survive etserver restart
+        run: ./test/system_tests/router_restart.sh
+
       - name: Stop sshd for act
         if: ${{ always() }}
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -475,6 +475,8 @@ add_library(
   src/terminal/SshSetupHandler.cpp
   src/terminal/UserTerminalHandler.hpp
   src/terminal/UserTerminalHandler.cpp
+  src/terminal/SessionStore.hpp
+  src/terminal/SessionStore.cpp
   src/terminal/UserJumphostHandler.hpp
   src/terminal/UserJumphostHandler.cpp
   src/terminal/TelemetryService.hpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -622,7 +622,10 @@ else(WIN32)
       TEST_PREFIX "et-test."
       WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
       ADD_TAGS_AS_LABELS
-      PROPERTIES TIMEOUT 300
+      # The router-restart integration tests spin up full client/server/terminal
+      # stacks (one with 14 concurrent sessions) and need wall-clock headroom on
+      # a loaded CI runner.
+      PROPERTIES TIMEOUT 900
     )
     add_sanitizers(et-test)
     if(TARGET test)

--- a/proto/ET.proto
+++ b/proto/ET.proto
@@ -19,6 +19,7 @@ enum ConnectStatus {
   RETURNING_CLIENT = 2;
   INVALID_KEY = 3;
   MISMATCHED_PROTOCOL = 4;
+  RETRY_LATER = 5;
 }
 
 message ConnectResponse {
@@ -28,6 +29,10 @@ message ConnectResponse {
 
 message SequenceHeader {
   optional int32 sequenceNumber = 1;
+  // Set when either side's sequence state is unusable (fresh process on one
+  // side). Both peers then zero their BackedReader/BackedWriter state and
+  // exchange empty catchup buffers instead of replaying history.
+  optional bool reset = 2;
 }
 
 message CatchupBuffer {

--- a/proto/ETerminal.proto
+++ b/proto/ETerminal.proto
@@ -83,4 +83,8 @@ message TerminalUserInfo {
   optional int64 uid = 3;
   optional int64 gid = 4;
   optional int64 fd = 5;
+  // Set when a terminal re-registers after its router went away: the pty and
+  // its shell are already running, so the server must resume the session
+  // instead of bootstrapping a fresh one.
+  optional bool ptyactive = 6;
 }

--- a/src/base/BackedReader.cpp
+++ b/src/base/BackedReader.cpp
@@ -104,6 +104,15 @@ void BackedReader::revive(int newSocketFd,
   socketFd = newSocketFd;
 }
 
+void BackedReader::reset() {
+  // Caller must hold recoverMutex (see getRecoverMutex), mirroring revive().
+  localBuffer.clear();
+  partialMessage.clear();
+  sequenceNumber = 0;
+  // Restart the stream nonce so a fresh peer process stays in lockstep.
+  cryptoHandler->resetNonce();
+}
+
 int BackedReader::getPartialMessageLength() {
   if (partialMessage.length() < 4) {
     STFATAL << "Tried to construct a message header that wasn't complete";

--- a/src/base/BackedReader.hpp
+++ b/src/base/BackedReader.hpp
@@ -53,6 +53,13 @@ class BackedReader {
    * @param newLocalEntries Serialized packets buffered while reconnecting.
    */
   void revive(int newSocketFd, const vector<string>& newLocalEntries);
+  /**
+   * @brief Discards all buffered state and sequence tracking so the next
+   * packet starts at sequence 0. Used by the reset handshake when the
+   * peer's sequence history is unusable (fresh process on one side).
+   * @note Caller must hold the recover mutex (see getRecoverMutex).
+   */
+  void reset();
 
   /**
    * @brief Marks the reader as disconnected so callers stop issuing reads.

--- a/src/base/BackedWriter.cpp
+++ b/src/base/BackedWriter.cpp
@@ -117,4 +117,14 @@ void BackedWriter::revive(int newSocketFd) {
   socketFd = newSocketFd;
   disconnectedBytes = 0;
 }
+
+void BackedWriter::reset() {
+  // Caller must hold recoverMutex (see getRecoverMutex), mirroring recover().
+  backupBuffer.clear();
+  backupSize = 0;
+  disconnectedBytes = 0;
+  sequenceNumber = 0;
+  // Restart the stream nonce so a fresh peer process stays in lockstep.
+  cryptoHandler->resetNonce();
+}
 }  // namespace et

--- a/src/base/BackedWriter.hpp
+++ b/src/base/BackedWriter.hpp
@@ -54,6 +54,13 @@ class BackedWriter {
    * peer.
    */
   vector<std::string> recover(int64_t lastValidSequenceNumber);
+  /**
+   * @brief Discards all buffered state so the next packet starts at
+   * sequence 0. Used by the reset handshake when the peer's sequence
+   * history is unusable (fresh process on one side).
+   * @note Caller must hold the recover mutex (see getRecoverMutex).
+   */
+  void reset();
 
   /**
    * @brief Points the writer at a new socket fd so writes can resume.

--- a/src/base/ClientConnection.cpp
+++ b/src/base/ClientConnection.cpp
@@ -32,6 +32,7 @@ bool ClientConnection::connect() {
     VLOG(1) << "Receiving client id";
     et::ConnectResponse response =
         socketHandler->readProto<et::ConnectResponse>(socketFd, true);
+    lastStatus_ = response.status();
     if (response.status() != NEW_CLIENT &&
         response.status() != RETURNING_CLIENT) {
       // Note: the response can be returning client if the client died while
@@ -58,6 +59,18 @@ bool ClientConnection::connect() {
                          shared_ptr<CryptoHandler>(
                              new CryptoHandler(key, CLIENT_SERVER_NONCE_MSB)),
                          socketFd));
+    if (response.status() == RETURNING_CLIENT) {
+      // The server already holds state for this id but our process is fresh,
+      // so the sequence history on one side is unusable. Recover with a
+      // reset so both sides start at sequence 0 and the INITIAL_PAYLOAD
+      // bootstrap is skipped by the caller.
+      VLOG(1) << "Returning client: performing reset recovery";
+      if (!recover(socketFd, /*forceReset=*/true)) {
+        LOG(WARNING) << "Reset recovery failed during connect";
+        return false;
+      }
+      recovered_ = true;
+    }
     VLOG(1) << "Client Connection established";
     return true;
   } catch (const runtime_error& err) {

--- a/src/base/ClientConnection.cpp
+++ b/src/base/ClientConnection.cpp
@@ -30,9 +30,28 @@ bool ClientConnection::connect() {
     request.set_version(PROTOCOL_VERSION);
     socketHandler->writeProto(socketFd, request, true);
     VLOG(1) << "Receiving client id";
+    // Bound the wait: a server that accepted into its listen backlog but
+    // never answers (e.g. mid-restart) must not wedge the caller's retry
+    // loop.
+    bool responded = false;
+    for (int a = 0; a < 50; a++) {
+      if (socketHandler->hasData(socketFd)) {
+        responded = true;
+        break;
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+    if (!responded) {
+      throw std::runtime_error("Server did not answer the connect handshake");
+    }
     et::ConnectResponse response =
         socketHandler->readProto<et::ConnectResponse>(socketFd, true);
     lastStatus_ = response.status();
+    if (response.status() == RETRY_LATER) {
+      // The server is still recovering after a restart; surface a plain
+      // failure so the caller's retry loop continues without error spam.
+      throw std::runtime_error("Server is recovering; retry later");
+    }
     if (response.status() != NEW_CLIENT &&
         response.status() != RETURNING_CLIENT) {
       // Note: the response can be returning client if the client died while
@@ -122,6 +141,23 @@ void ClientConnection::pollReconnect() {
           request.set_clientid(id);
           request.set_version(PROTOCOL_VERSION);
           socketHandler->writeProto(newSocketFd, request, true);
+          // A half-dead server can complete the TCP/pipe handshake into its
+          // listen backlog but never answer; bound the wait so the loop can
+          // retry instead of wedging on readProto.
+          bool responded = false;
+          for (int a = 0; a < 50; a++) {
+            if (socketHandler->hasData(newSocketFd)) {
+              responded = true;
+              break;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+          }
+          if (!responded) {
+            LOG(INFO) << "Server did not answer the reconnect handshake; "
+                         "retrying.";
+            socketHandler->close(newSocketFd);
+            continue;
+          }
           et::ConnectResponse response =
               socketHandler->readProto<et::ConnectResponse>(newSocketFd, true);
           LOG(INFO) << "Got response with status: " << response.status() << " "
@@ -134,7 +170,13 @@ void ClientConnection::pollReconnect() {
             socketHandler->close(newSocketFd);
             return;
           }
-          if (response.status() != RETURNING_CLIENT) {
+          if (response.status() == RETRY_LATER) {
+            // The server restarted and the terminal has not re-registered
+            // yet; keep retrying quietly at the loop's 1 Hz pace.
+            LOG(INFO) << "Server is still recovering; retrying reconnect "
+                         "shortly.";
+            socketHandler->close(newSocketFd);
+          } else if (response.status() != RETURNING_CLIENT) {
             STERROR << "Error reconnecting to server: " << response.status()
                     << ": " << response.error();
             CLOG(INFO, "stdout")

--- a/src/base/ClientConnection.cpp
+++ b/src/base/ClientConnection.cpp
@@ -166,6 +166,7 @@ void ClientConnection::pollReconnect() {
             LOG(INFO) << "Got invalid key on reconnect, assume that server has "
                          "terminated the session.";
             // This means that the server has terminated the connection.
+            lastStatus_ = INVALID_KEY;
             shuttingDown = true;
             socketHandler->close(newSocketFd);
             return;

--- a/src/base/ClientConnection.hpp
+++ b/src/base/ClientConnection.hpp
@@ -34,6 +34,19 @@ class ClientConnection : public Connection {
   virtual void closeSocketAndMaybeReconnect();
 
   /**
+   * @brief True when the last successful connect used the reset handshake
+   * (the server already held state for this id, so no bootstrap exchange
+   * is needed).
+   */
+  bool wasRecovered() const { return recovered_; }
+
+  /**
+   * @brief The ConnectStatus received on the most recent connect attempt.
+   * Only meaningful when connect() returned false.
+   */
+  et::ConnectStatus lastStatus() const { return lastStatus_; }
+
+  /**
    * @brief Blocks until any running reconnect thread has finished.
    */
   void waitReconnect();
@@ -46,6 +59,10 @@ class ClientConnection : public Connection {
 
   /** @brief Server endpoint we try to connect to. */
   SocketEndpoint remoteEndpoint;
+  /** @brief Set when connect() completed via the reset handshake. */
+  bool recovered_ = false;
+  /** @brief ConnectStatus from the most recent connect attempt. */
+  et::ConnectStatus lastStatus_ = et::ConnectStatus::NEW_CLIENT;
   /** @brief Thread that keeps retrying the handshake after disconnects. */
   std::shared_ptr<std::thread> reconnectThread;
 };

--- a/src/base/Connection.cpp
+++ b/src/base/Connection.cpp
@@ -102,17 +102,23 @@ void Connection::closeSocket() {
   VLOG(1) << "Closed socket";
 }
 
-bool Connection::recover(int newSocketFd) {
+bool Connection::recover(int newSocketFd, bool forceReset) {
   LOG(INFO) << "Locking reader/writer to recover...";
   lock_guard<std::recursive_mutex> guard(connectionMutex);
   lock_guard<std::mutex> readerGuard(reader->getRecoverMutex());
   lock_guard<std::mutex> writerGuard(writer->getRecoverMutex());
-  LOG(INFO) << "Recovering with socket fd " << newSocketFd << "...";
+  LOG(INFO) << "Recovering with socket fd " << newSocketFd
+            << (forceReset ? " (reset)" : "") << "...";
   try {
     {
       // Write the current sequence number
       et::SequenceHeader sh;
-      sh.set_sequencenumber(reader->getSequenceNumber());
+      if (forceReset) {
+        sh.set_sequencenumber(0);
+        sh.set_reset(true);
+      } else {
+        sh.set_sequencenumber(reader->getSequenceNumber());
+      }
       socketHandler->writeProto(newSocketFd, sh, true);
     }
 
@@ -120,6 +126,25 @@ bool Connection::recover(int newSocketFd) {
     et::SequenceHeader remoteHeader =
         socketHandler->readProto<et::SequenceHeader>(
             newSocketFd, true, SocketHandler::MAX_HANDSHAKE_PROTO_LENGTH);
+
+    if (forceReset || remoteHeader.reset()) {
+      // At least one side has unusable sequence history (a fresh process).
+      // Zero both sides and exchange empty catchup buffers so the
+      // handshake wire sequence stays identical to a normal recover.
+      LOG(INFO) << "Performing reset recovery";
+      writer->reset();
+      reader->reset();
+
+      et::CatchupBuffer emptyCatchup;
+      socketHandler->writeProto(newSocketFd, emptyCatchup, true);
+      socketHandler->readProto<et::CatchupBuffer>(newSocketFd, true);
+
+      socketFd = newSocketFd;
+      reader->revive(socketFd, {});
+      writer->revive(socketFd);
+      LOG(INFO) << "Finished reset recovery with socket fd: " << socketFd;
+      return true;
+    }
 
     {
       // Fetch the catchup bytes and send

--- a/src/base/Connection.hpp
+++ b/src/base/Connection.hpp
@@ -101,10 +101,13 @@ class Connection {
  protected:
   /**
    * @brief Exchanges sequence headers and catchup buffers with a peer.
+   * When `forceReset` is true (or the remote header requests a reset), both
+   * BackedReader and BackedWriter state is zeroed and empty catchup buffers
+   * are exchanged instead of replaying history.
    * @return true if recovery succeeds and the new socket is owned by this
    * object.
    */
-  bool recover(int newSocketFd);
+  bool recover(int newSocketFd, bool forceReset = false);
 
   /** @brief Socket API used by all derived connection types. */
   shared_ptr<SocketHandler> socketHandler;

--- a/src/base/CryptoHandler.cpp
+++ b/src/base/CryptoHandler.cpp
@@ -7,7 +7,8 @@
   }
 namespace et {
 
-CryptoHandler::CryptoHandler(const string& _key, unsigned char nonceMSB) {
+CryptoHandler::CryptoHandler(const string& _key, unsigned char nonceMSB)
+    : nonceMSB(nonceMSB) {
   lock_guard<std::mutex> guard(cryptoMutex);
   if (-1 == sodium_init()) {
     STFATAL << "libsodium init failed";
@@ -16,6 +17,12 @@ CryptoHandler::CryptoHandler(const string& _key, unsigned char nonceMSB) {
     STFATAL << "Invalid key length";
   }
   memcpy(key, &_key[0], _key.length());
+  memset(nonce, 0, crypto_secretbox_NONCEBYTES);
+  nonce[crypto_secretbox_NONCEBYTES - 1] = nonceMSB;
+}
+
+void CryptoHandler::resetNonce() {
+  lock_guard<std::mutex> guard(cryptoMutex);
   memset(nonce, 0, crypto_secretbox_NONCEBYTES);
   nonce[crypto_secretbox_NONCEBYTES - 1] = nonceMSB;
 }

--- a/src/base/CryptoHandler.hpp
+++ b/src/base/CryptoHandler.hpp
@@ -34,6 +34,17 @@ class CryptoHandler {
    * @return Original plaintext payload.
    */
   string decrypt(const string& buffer);
+  /**
+   * @brief Restores the nonce to its initial value (base nonce with only the
+   * MSB byte set). Used by the reset handshake: when both sides agree to
+   * discard all buffered history and restart at sequence 0, their per-message
+   * nonces must also restart from the base so the fresh streams stay in
+   * lockstep.
+   * @note This deliberately reuses nonces that were consumed before the reset.
+   * That is only safe because the reset discards the old session's buffered
+   * packets on both sides, so no two live ciphertexts share a nonce.
+   */
+  void resetNonce();
 
  protected:
   /**
@@ -45,6 +56,8 @@ class CryptoHandler {
   unsigned char nonce[crypto_secretbox_NONCEBYTES];
   /** @brief Shared secret key used for encrypt/decrypt operations. */
   unsigned char key[crypto_secretbox_KEYBYTES];
+  /** @brief MSB byte used to seed the nonce (see constructor). */
+  unsigned char nonceMSB;
 
  private:
   /** @brief Guards the nonce/key pair to keep operations thread-safe. */

--- a/src/base/ServerClientConnection.cpp
+++ b/src/base/ServerClientConnection.cpp
@@ -24,7 +24,7 @@ ServerClientConnection::~ServerClientConnection() {
   }
 }
 
-bool ServerClientConnection::recoverClient(int newSocketFd) {
+bool ServerClientConnection::recoverClient(int newSocketFd, bool forceReset) {
   // Detach the live session without closing it until recover succeeds, so a
   // failed/malicious reconnect cannot force-disconnect the victim.
   int oldSocketFd = -1;
@@ -40,9 +40,11 @@ bool ServerClientConnection::recoverClient(int newSocketFd) {
     socketFd = -1;
   }
 
-  bool success = recover(newSocketFd);
+  bool success = recover(newSocketFd, forceReset);
   if (success) {
-    if (oldSocketFd != -1) {
+    // On the resume path the connection was constructed with this very fd
+    // (oldSocketFd == newSocketFd); closing it would kill the live session.
+    if (oldSocketFd != -1 && oldSocketFd != newSocketFd) {
       socketHandler->close(oldSocketFd);
     }
     return true;

--- a/src/base/ServerClientConnection.hpp
+++ b/src/base/ServerClientConnection.hpp
@@ -22,8 +22,10 @@ class ServerClientConnection : public Connection {
   /**
    * @brief Attempts recovery on the new fd; closes the old socket only after
    * recover succeeds.
+   * @param forceReset When true, request the reset handshake (both sides
+   * zero their sequence/crypto state) instead of replaying history.
    */
-  bool recoverClient(int newSocketFd);
+  bool recoverClient(int newSocketFd, bool forceReset = false);
 
   /**
    * @brief Constant-time comparison of the stored key and a supplied passkey.

--- a/src/base/ServerConnection.cpp
+++ b/src/base/ServerConnection.cpp
@@ -5,6 +5,7 @@ ServerConnection::ServerConnection(
     const SocketEndpoint& _serverEndpoint)
     : socketHandler(_socketHandler),
       serverEndpoint(_serverEndpoint),
+      startTime_(time(NULL)),
       clientHandlerThreadPool(new ThreadPool(8)) {
   socketHandler->listen(serverEndpoint);
 }
@@ -26,9 +27,15 @@ bool ServerConnection::acceptNewConnection(int fd) {
 }
 
 void ServerConnection::shutdown() {
-  lock_guard<std::recursive_mutex> guard(classMutex);
-  socketHandler->stopListening(serverEndpoint);
+  {
+    lock_guard<std::recursive_mutex> guard(classMutex);
+    socketHandler->stopListening(serverEndpoint);
+  }
+  // Join the worker pool WITHOUT holding classMutex: an in-flight
+  // clientHandler needs classMutex to finish, so joining the pool while
+  // holding it is an AB-BA deadlock.
   clientHandlerThreadPool.reset();
+  lock_guard<std::recursive_mutex> guard(classMutex);
   for (const auto& it : clientConnections) {
     it.second->shutdown();
   }
@@ -92,26 +99,53 @@ void ServerConnection::clientHandler(int clientSocketFd) {
       std::ostringstream errorStream;
       errorStream << "Client is not registered";
       response.set_error(errorStream.str());
-      response.set_status(INVALID_KEY);
+      // Right after an etserver restart, the terminals' re-registrations (and
+      // with them the client keys) have not landed yet.  Ask the client to
+      // retry during the grace window instead of declaring the session gone.
+      if (time(NULL) - startTime_ < recoveryGraceSeconds) {
+        LOG(INFO) << "Within the recovery grace window; asking client "
+                  << clientId << " to retry.";
+        response.set_status(RETRY_LATER);
+      } else {
+        response.set_status(INVALID_KEY);
+      }
       socketHandler->writeProto(clientSocketFd, response, true);
 
       socketHandler->close(clientSocketFd);
     } else if (createdClientConnection) {
+      // The key is known but no connection survived: either this is a brand
+      // new session (NEW_CLIENT, the client bootstraps) or the terminal
+      // re-registered after an etserver restart with its pty still running
+      // (resume: the session's bootstrap already happened).
+      const bool resume = shouldResumeAsReturning(clientId);
       et::ConnectResponse response;
-      response.set_status(NEW_CLIENT);
+      response.set_status(resume ? RETURNING_CLIENT : NEW_CLIENT);
       socketHandler->writeProto(clientSocketFd, response, true);
 
-      LOG(INFO) << "New client.  Setting up connection";
-      VLOG(1) << "Created client with id " << clientId;
+      if (resume) {
+        LOG(INFO) << "Resuming existing session for " << clientId;
+        if (!serverClientState->recoverClient(clientSocketFd,
+                                              /*forceReset=*/true)) {
+          LOG(WARNING) << "Resume handshake failed for " << clientId;
+          // recoverClient closed the new socket on failure; the connection
+          // entry must go, but the key stays (the terminal is still live).
+          destroyPartialConnection(clientId);
+        } else {
+          resumeClient(serverClientState);
+        }
+      } else {
+        LOG(INFO) << "New client.  Setting up connection";
+        VLOG(1) << "Created client with id " << clientId;
 
-      {
-        lock_guard<std::recursive_mutex> guard(classMutex);
+        {
+          lock_guard<std::recursive_mutex> guard(classMutex);
 
-        if (!newClient(serverClientState)) {
-          VLOG(1) << "newClient failed";
-          // Client creation failed, Destroy the new client
-          removeClient(clientId);
-          socketHandler->close(clientSocketFd);
+          if (!newClient(serverClientState)) {
+            VLOG(1) << "newClient failed";
+            // Client creation failed, Destroy the new client
+            removeClient(clientId);
+            socketHandler->close(clientSocketFd);
+          }
         }
       }
     } else {

--- a/src/base/ServerConnection.hpp
+++ b/src/base/ServerConnection.hpp
@@ -81,6 +81,19 @@ class ServerConnection {
   virtual bool newClient(
       shared_ptr<ServerClientConnection> serverClientState) = 0;
 
+  /**
+   * @brief Returns true when a known client id maps to a session that is
+   * already running (its terminal re-registered with an active pty) and must
+   * be resumed instead of bootstrapped fresh.
+   */
+  virtual bool shouldResumeAsReturning(const string& clientId) { return false; }
+
+  /**
+   * @brief Invoked after a successful resume handshake for a client whose
+   * session is already running.
+   */
+  virtual void resumeClient(shared_ptr<ServerClientConnection> state) {}
+
  protected:
   /**
    * @brief Discards a partially initialized connection if its thread fails.
@@ -102,6 +115,14 @@ class ServerConnection {
   recursive_mutex classMutex;
   /** @brief Serializes connect/disconnect events. */
   mutex connectMutex;
+  /**
+   * @brief Seconds after startup during which an unknown client id receives
+   * RETRY_LATER instead of INVALID_KEY: after an etserver restart the
+   * terminals need a moment to re-register and restore their keys.
+   */
+  int recoveryGraceSeconds = 60;
+  /** @brief When this server instance started (wall clock). */
+  time_t startTime_;
 };
 }  // namespace et
 

--- a/src/terminal/SessionStore.cpp
+++ b/src/terminal/SessionStore.cpp
@@ -1,0 +1,234 @@
+#include "SessionStore.hpp"
+
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#include <cerrno>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <regex>
+
+#include "Headers.hpp"
+
+#ifndef WIN32
+#include <pwd.h>
+#include <unistd.h>
+#endif
+
+namespace et {
+namespace {
+constexpr const char kSessionVersion[] = "1";
+const std::regex kSessionNameRegex{
+    R"regex(^[A-Za-z0-9][A-Za-z0-9._-]{0,62}$)regex"};
+namespace fs = std::filesystem;
+string homeDir() {
+  // Prefer the environment so the location is predictable and testable.
+  const char* envHome = getenv("HOME");
+  if (envHome != nullptr && envHome[0] != '\0') {
+    return string(envHome);
+  }
+#ifdef WIN32
+  const char* userProfile = getenv("USERPROFILE");
+  if (userProfile != nullptr && userProfile[0] != '\0') {
+    return string(userProfile);
+  }
+#else
+  // Fall back to the passwd entry.
+  struct passwd pwd;
+  struct passwd* pwdbuf;
+  long pwSize = sysconf(_SC_GETPW_R_SIZE_MAX);
+  if (pwSize > 0) {
+    char* buf = static_cast<char*>(malloc(pwSize));
+    if (buf != nullptr) {
+      if (getpwuid_r(getuid(), &pwd, buf, pwSize, &pwdbuf) == 0 &&
+          pwdbuf != nullptr && pwdbuf->pw_dir[0] != '\0') {
+        string result = string(pwdbuf->pw_dir);
+        free(buf);
+        return result;
+      }
+      free(buf);
+    }
+  }
+#endif
+  throw std::runtime_error("Could not determine user home directory");
+}
+
+bool isPrintableNoBreaks(const string& value) {
+  return !value.empty() && value.find_first_of("\r\n") == string::npos;
+}
+
+void ensureDir(const fs::path& path) {
+  std::error_code ec;
+  fs::create_directories(path, ec);
+  if (ec) {
+    throw std::runtime_error("Could not create directory " + path.string() +
+                             ": " + ec.message());
+  }
+#ifndef WIN32
+  if (chmod(path.c_str(), 0700) != 0) {
+    throw std::runtime_error("Could not set permissions on " + path.string() +
+                             ": " + strerror(errno));
+  }
+#endif
+}
+}  // namespace
+
+bool isValidSessionName(const string& name) {
+  return std::regex_match(name, kSessionNameRegex);
+}
+
+string sessionDirPath() { return homeDir() + "/.et/sessions"; }
+
+void saveSession(const SessionInfo& info) {
+  if (!isValidSessionName(info.name)) {
+    throw std::runtime_error("Invalid session name: " + info.name);
+  }
+  if (!isPrintableNoBreaks(info.host) || !isPrintableNoBreaks(info.id) ||
+      !isPrintableNoBreaks(info.passkey) || info.port <= 0 ||
+      info.port > 65535) {
+    throw std::runtime_error("Session fields must be non-empty and printable");
+  }
+
+  const fs::path dir = sessionDirPath();
+  ensureDir(homeDir() + "/.et");
+  ensureDir(dir);
+
+  // Write to a temp file in the same directory, then rename into place so a
+  // crashed writer can never leave a half-written session file behind.
+  const fs::path tmpPath = dir / ("." + info.name + "." + genRandomAlphaNum(8));
+  const fs::path finalPath = dir / info.name;
+
+  string contents = string("version=") + kSessionVersion + string("\nname=") +
+                    info.name + string("\nhost=") + info.host +
+                    string("\nport=") + std::to_string(info.port) +
+                    string("\nid=") + info.id + string("\npasskey=") +
+                    info.passkey + string("\nsavedat=") +
+                    std::to_string(info.savedAt) + "\n";
+  {
+    std::ofstream out(tmpPath, std::ios::binary | std::ios::trunc);
+    if (!out) {
+      throw std::runtime_error("Could not create temp session file");
+    }
+    out << contents;
+    out.flush();
+    if (!out) {
+      throw std::runtime_error("Could not write session file");
+    }
+  }
+  std::error_code ec;
+  fs::rename(tmpPath, finalPath, ec);
+  if (ec) {
+    fs::remove(tmpPath);
+    throw std::runtime_error("Could not move session file into place: " +
+                             ec.message());
+  }
+#ifndef WIN32
+  if (chmod(finalPath.c_str(), 0600) != 0) {
+    LOG(WARNING) << "Could not set session file permissions: "
+                 << strerror(errno);
+  }
+#endif
+}
+
+optional<SessionInfo> loadSession(const string& name) {
+  if (!isValidSessionName(name)) {
+    return std::nullopt;
+  }
+  const fs::path path = sessionDirPath() + "/" + name;
+  if (!fs::is_regular_file(path)) {
+    return std::nullopt;
+  }
+
+  std::ifstream in(path);
+  if (!in) {
+    return std::nullopt;
+  }
+
+  SessionInfo info;
+  bool haveVersion = false;
+  bool havePort = false;
+  bool haveSavedAt = false;
+  string line;
+  while (std::getline(in, line)) {
+    if (line.empty()) {
+      continue;
+    }
+    const auto eq = line.find('=');
+    if (eq == string::npos || eq == 0) {
+      return std::nullopt;
+    }
+    const string key = line.substr(0, eq);
+    const string value = line.substr(eq + 1);
+    if (key == "version") {
+      haveVersion = (value == kSessionVersion);
+    } else if (key == "name") {
+      info.name = value;
+    } else if (key == "host") {
+      info.host = value;
+    } else if (key == "port") {
+      info.port = std::stoi(value);
+      havePort = true;
+    } else if (key == "id") {
+      info.id = value;
+    } else if (key == "passkey") {
+      info.passkey = value;
+    } else if (key == "savedat") {
+      info.savedAt = std::stoll(value);
+      haveSavedAt = true;
+    }
+  }
+
+  if (!haveVersion || !havePort || !haveSavedAt || info.name != name ||
+      info.host.empty() || info.id.empty() || info.passkey.empty() ||
+      info.port <= 0 || info.port > 65535) {
+    return std::nullopt;
+  }
+  return info;
+}
+
+vector<SessionInfo> listSessions() {
+  vector<SessionInfo> sessions;
+  string dir;
+  try {
+    dir = sessionDirPath();
+  } catch (const std::exception& e) {
+    LOG(WARNING) << "Could not list sessions: " << e.what();
+    return sessions;
+  }
+  std::error_code ec;
+  if (!fs::is_directory(dir, ec)) {
+    // No session directory yet is not an error.
+    return sessions;
+  }
+  for (const auto& entry : fs::directory_iterator(dir, ec)) {
+    const string name = entry.path().filename().string();
+    if (!isValidSessionName(name)) {
+      continue;
+    }
+    optional<SessionInfo> info = loadSession(name);
+    if (!info) {
+      LOG(WARNING) << "Skipping unreadable or corrupt session file: " << name;
+      continue;
+    }
+    sessions.push_back(*info);
+  }
+
+  sort(sessions.begin(), sessions.end(),
+       [](const SessionInfo& a, const SessionInfo& b) {
+         return a.name < b.name;
+       });
+  return sessions;
+}
+
+void deleteSession(const string& name) {
+  if (!isValidSessionName(name)) {
+    return;
+  }
+  const fs::path path = sessionDirPath() + "/" + name;
+  std::error_code ec;
+  if (fs::is_regular_file(path) && fs::remove(path, ec) && ec) {
+    LOG(WARNING) << "Could not delete session file: " << path.string();
+  }
+}
+}  // namespace et

--- a/src/terminal/SessionStore.hpp
+++ b/src/terminal/SessionStore.hpp
@@ -1,0 +1,69 @@
+#ifndef __ET_SESSION_STORE__
+#define __ET_SESSION_STORE__
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "Headers.hpp"
+
+namespace et {
+/**
+ * @brief A persisted et session that can be reattached to after the client
+ * process (or machine) restarts.
+ */
+struct SessionInfo {
+  /** @brief User-facing name; must satisfy isValidSessionName. */
+  string name;
+  /** @brief Hostname or IP the ET server listens on. */
+  string host;
+  /** @brief ET server port. */
+  int port;
+  /** @brief Session id assigned during setup. */
+  string id;
+  /** @brief Session passkey. Secret material. */
+  string passkey;
+  /** @brief Unix time when the session was saved. */
+  int64_t savedAt;
+};
+
+/**
+ * @brief Checks that a name is safe to use as a session file name:
+ * 1-63 characters of [A-Za-z0-9._-] starting with an alphanumeric.
+ */
+bool isValidSessionName(const string& name);
+
+/**
+ * @brief Returns the session directory (<home>/.et/sessions) without
+ * creating it.
+ * @throws std::runtime_error if the user's home directory is unknown.
+ */
+string sessionDirPath();
+
+/**
+ * @brief Persists a session atomically. The session directory and file are
+ * created with owner-only permissions because the file contains a passkey.
+ * @throws std::runtime_error if the name is invalid or writing fails.
+ */
+void saveSession(const SessionInfo& info);
+
+/**
+ * @brief Lists all valid saved sessions, sorted by name. Corrupt entries are
+ * skipped with a warning.
+ */
+vector<SessionInfo> listSessions();
+
+/**
+ * @brief Loads one saved session, or nullopt if it is missing or corrupt.
+ */
+optional<SessionInfo> loadSession(const string& name);
+
+/**
+ * @brief Removes a saved session file if present.
+ */
+void deleteSession(const string& name);
+
+}  // namespace et
+
+#endif  // __ET_SESSION_STORE__

--- a/src/terminal/TerminalClient.cpp
+++ b/src/terminal/TerminalClient.cpp
@@ -134,9 +134,19 @@ TerminalClient::TerminalClient(
       if (fail) {
         LOG(WARNING) << "Connecting to server failed: Connect timeout";
         connectFailCount++;
+        if (!_exitOnConnectFailure && connection &&
+            connection->lastStatus() == et::ConnectStatus::INVALID_KEY) {
+          // The server knows this id no longer exists; surface a distinct
+          // error so callers can discard the saved session.
+          throw std::runtime_error(INVALID_SESSION_CONNECT_ERROR);
+        }
         if (connectFailCount >= _maxConnectAttempts) {
           throw std::runtime_error("Connect Timeout");
         }
+        // Actually retry: without the continue the loop falls through to the
+        // break below and runs with a dead connection.
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+        continue;
       }
     } catch (const runtime_error& err) {
       LOG(INFO) << "Could not make initial connection to server";

--- a/src/terminal/TerminalClient.cpp
+++ b/src/terminal/TerminalClient.cpp
@@ -7,6 +7,9 @@
 
 namespace et {
 
+const string TerminalClient::INVALID_SESSION_CONNECT_ERROR =
+    "Server has no session for this client id";
+
 TerminalClient::TerminalClient(
     shared_ptr<SocketHandler> _socketHandler,
     shared_ptr<SocketHandler> _pipeSocketHandler,
@@ -14,7 +17,8 @@ TerminalClient::TerminalClient(
     const string& passkey, shared_ptr<Console> _console, bool jumphost,
     const string& tunnels, const string& reverseTunnels, bool forwardSshAgent,
     const string& identityAgent, int _keepaliveDuration,
-    const vector<pair<string, string>>& envVars)
+    const vector<pair<string, string>>& envVars, int _maxConnectAttempts,
+    bool _exitOnConnectFailure)
     : console(_console),
       shuttingDown(false),
       keepaliveDuration(_keepaliveDuration) {
@@ -84,38 +88,45 @@ TerminalClient::TerminalClient(
     try {
       bool fail = true;
       if (connection->connect()) {
-        connection->writePacket(
-            Packet(EtPacketType::INITIAL_PAYLOAD, protoToString(payload)));
-        fd_set rfd;
-        timeval tv;
-        for (int a = 0; a < 3; a++) {
-          FD_ZERO(&rfd);
-          int clientFd = connection->getSocketFd();
-          if (clientFd < 0) {
-            std::this_thread::sleep_for(std::chrono::seconds(1));
-            continue;
-          }
-          FD_SET(clientFd, &rfd);
-          tv.tv_sec = 1;
-          tv.tv_usec = 0;
-          select(clientFd + 1, &rfd, NULL, NULL, &tv);
-          if (FD_ISSET(clientFd, &rfd)) {
-            Packet initialResponsePacket;
-            if (connection->readPacket(&initialResponsePacket)) {
-              if (initialResponsePacket.getHeader() !=
-                  EtPacketType::INITIAL_RESPONSE) {
-                CLOG(INFO, "stdout") << "Error: Missing initial response\n";
-                STFATAL << "Missing initial response!";
+        if (connection->wasRecovered()) {
+          // Reattaching to a session whose server-side connection survived:
+          // the bootstrap exchange (INITIAL_PAYLOAD/INITIAL_RESPONSE) already
+          // happened when the session started, so skip it.
+          fail = false;
+        } else {
+          connection->writePacket(
+              Packet(EtPacketType::INITIAL_PAYLOAD, protoToString(payload)));
+          fd_set rfd;
+          timeval tv;
+          for (int a = 0; a < 3; a++) {
+            FD_ZERO(&rfd);
+            int clientFd = connection->getSocketFd();
+            if (clientFd < 0) {
+              std::this_thread::sleep_for(std::chrono::seconds(1));
+              continue;
+            }
+            FD_SET(clientFd, &rfd);
+            tv.tv_sec = 1;
+            tv.tv_usec = 0;
+            select(clientFd + 1, &rfd, NULL, NULL, &tv);
+            if (FD_ISSET(clientFd, &rfd)) {
+              Packet initialResponsePacket;
+              if (connection->readPacket(&initialResponsePacket)) {
+                if (initialResponsePacket.getHeader() !=
+                    EtPacketType::INITIAL_RESPONSE) {
+                  CLOG(INFO, "stdout") << "Error: Missing initial response\n";
+                  STFATAL << "Missing initial response!";
+                }
+                auto initialResponse = stringToProto<InitialResponse>(
+                    initialResponsePacket.getPayload());
+                if (initialResponse.has_error()) {
+                  CLOG(INFO, "stdout") << "Error initializing connection: "
+                                       << initialResponse.error() << endl;
+                  exit(1);
+                }
+                fail = false;
+                break;
               }
-              auto initialResponse = stringToProto<InitialResponse>(
-                  initialResponsePacket.getPayload());
-              if (initialResponse.has_error()) {
-                CLOG(INFO, "stdout") << "Error initializing connection: "
-                                     << initialResponse.error() << endl;
-                exit(1);
-              }
-              fail = false;
-              break;
             }
           }
         }
@@ -123,15 +134,24 @@ TerminalClient::TerminalClient(
       if (fail) {
         LOG(WARNING) << "Connecting to server failed: Connect timeout";
         connectFailCount++;
-        if (connectFailCount == 3) {
+        if (connectFailCount >= _maxConnectAttempts) {
           throw std::runtime_error("Connect Timeout");
         }
       }
     } catch (const runtime_error& err) {
       LOG(INFO) << "Could not make initial connection to server";
-      CLOG(INFO, "stdout") << "Could not make initial connection to "
-                           << _socketEndpoint << ": " << err.what() << endl;
-      exit(1);
+      if (!_exitOnConnectFailure && connection &&
+          connection->lastStatus() == et::ConnectStatus::INVALID_KEY) {
+        // The server knows this id no longer exists; surface a distinct
+        // error so callers can discard the saved session.
+        throw std::runtime_error(INVALID_SESSION_CONNECT_ERROR);
+      }
+      if (_exitOnConnectFailure) {
+        CLOG(INFO, "stdout") << "Could not make initial connection to "
+                             << _socketEndpoint << ": " << err.what() << endl;
+        exit(1);
+      }
+      throw;
     }
 
     TelemetryService::get()->logToDatadog("Connection Established",

--- a/src/terminal/TerminalClient.hpp
+++ b/src/terminal/TerminalClient.hpp
@@ -22,8 +22,17 @@ namespace et {
 class TerminalClient {
  public:
   /**
+   * @brief Message thrown when a reattach fails because the server has no
+   * session for the saved id anymore (ConnectStatus INVALID_KEY).
+   */
+  static const string INVALID_SESSION_CONNECT_ERROR;
+
+  /**
    * @brief Configures the client with the required sockets, console, and
    * tunnels.
+   * @param _maxConnectAttempts Initial connect attempts before giving up.
+   * @param _exitOnConnectFailure When false, a failed initial connect throws
+   * instead of exiting so callers can clean up (used by --attach).
    */
   TerminalClient(std::shared_ptr<SocketHandler> _socketHandler,
                  std::shared_ptr<SocketHandler> _pipeSocketHandler,
@@ -32,7 +41,9 @@ class TerminalClient {
                  bool jumphost, const string& tunnels,
                  const string& reverseTunnels, bool forwardSshAgent,
                  const string& identityAgent, int _keepaliveDuration,
-                 const vector<pair<string, string>>& envVars);
+                 const vector<pair<string, string>>& envVars,
+                 int _maxConnectAttempts = 3,
+                 bool _exitOnConnectFailure = true);
   /** @brief Tears down the client, closing sockets and stopping background
    * threads. */
   virtual ~TerminalClient();

--- a/src/terminal/TerminalClient.hpp
+++ b/src/terminal/TerminalClient.hpp
@@ -51,6 +51,15 @@ class TerminalClient {
    * alive. */
   void run(const string& command, const bool noexit);
   /**
+   * @brief True when run() ended because the server reported the session is
+   * gone (INVALID_KEY on reconnect), as opposed to the local console going
+   * away.  Used to decide whether the saved session file may be deleted.
+   */
+  bool sessionEndedByServer() {
+    return connection &&
+           connection->lastStatus() == et::ConnectStatus::INVALID_KEY;
+  }
+  /**
    * @brief Flags the client loop to exit gracefully on the next iteration.
    */
   void shutdown() {

--- a/src/terminal/TerminalClientMain.cpp
+++ b/src/terminal/TerminalClientMain.cpp
@@ -1,10 +1,13 @@
+#include <ctime>
 #include <cxxopts.hpp>
+#include <iomanip>
 
 #include "Headers.hpp"
 #include "HostParsing.hpp"
 #include "ParseConfigFile.hpp"
 #include "PipeSocketHandler.hpp"
 #include "PseudoTerminalConsole.hpp"
+#include "SessionStore.hpp"
 #include "SshSetupHandler.hpp"
 #include "SubprocessUtils.hpp"
 #include "TelemetryService.hpp"
@@ -92,6 +95,10 @@ int main(int argc, char** argv) {
   et::HandleTerminate();
 
   // Override easylogging handler for sigint
+
+  // Name of the session being started (empty when unnamed); deleted on a
+  // clean exit, kept on signal exits so the session can be reattached.
+  string sessionName = "";
   ::signal(SIGINT, et::InterruptSignalHandler);
 
   Options sshConfigOptions = {
@@ -181,6 +188,11 @@ int main(int argc, char** argv) {
         ("telemetry",
          "Allow et to anonymously send errors to guide future improvements",
          cxxopts::value<bool>()->default_value("true"))  //
+        ("name", "Name this session so it can be reattached later",
+         cxxopts::value<std::string>())  //
+        ("attach", "Reattach to a previously named session",
+         cxxopts::value<std::string>())           //
+        ("list", "List saved sessions and exit")  //
         ("serverfifo",
          "If set, communicate to etserver on the matching fifo name",
          cxxopts::value<std::string>()->default_value(""))  //
@@ -198,6 +210,30 @@ int main(int argc, char** argv) {
     if (result.count("version")) {
       CLOG(INFO, "stdout") << "et version " << ET_VERSION << endl;
       exit(0);
+    }
+
+    if (result.count("list")) {
+      // Local-only operation: no connection is made.
+      CLOG(INFO, "stdout") << left << setw(24) << "NAME" << setw(24) << "HOST"
+                           << setw(8) << "PORT" << "SAVED" << endl;
+      for (const auto& session : listSessions()) {
+        char saved[32];
+        struct tm savedTm;
+        localtime_r(&session.savedAt, &savedTm);
+        strftime(saved, sizeof(saved), "%Y-%m-%d %H:%M:%S", &savedTm);
+        CLOG(INFO, "stdout")
+            << left << setw(24) << session.name << setw(24) << session.host
+            << setw(8) << session.port << saved << endl;
+      }
+      exit(0);
+    }
+
+    if (result.count("attach") &&
+        (result.count("name") || result.count("host"))) {
+      CLOG(INFO, "stdout") << "--attach takes a session name; it cannot be "
+                              "combined with --name or a host"
+                           << endl;
+      exit(1);
     }
 
     el::Loggers::setVerboseLevel(result["verbose"].as<int>());
@@ -224,6 +260,73 @@ int main(int argc, char** argv) {
     TelemetryService::create(result["telemetry"].as<bool>(),
                              tmpDir + "/.sentry-native-et", "Client");
 
+    if (result.count("attach")) {
+      // Reattach to a previously named session. The server-side session
+      // (terminal + router entry) outlived the client, so skip ssh bootstrap
+      // and connect straight to the saved endpoint with the saved id/key.
+      const string attachName = result["attach"].as<string>();
+      if (!isValidSessionName(attachName)) {
+        CLOG(INFO, "stdout") << "Invalid session name: " << attachName << endl;
+        exit(1);
+      }
+      optional<SessionInfo> session = loadSession(attachName);
+      if (!session) {
+        CLOG(INFO, "stdout")
+            << "No saved session named '" << attachName << "'" << endl;
+        for (const auto& s : listSessions()) {
+          CLOG(INFO, "stdout") << "  " << s.name << " (" << s.host << ":"
+                               << s.port << ")" << endl;
+        }
+        exit(1);
+      }
+
+      SocketEndpoint attachEndpoint;
+      attachEndpoint.set_name(session->host);
+      attachEndpoint.set_port(session->port);
+      shared_ptr<SocketHandler> attachSocket(new TcpSocketHandler());
+      shared_ptr<SocketHandler> attachPipeSocket(new PipeSocketHandler());
+
+      if (!ping(attachEndpoint, attachSocket)) {
+        CLOG(INFO, "stdout")
+            << "Could not reach the ET server: " << attachEndpoint.name() << ":"
+            << attachEndpoint.port() << endl;
+        exit(1);
+      }
+
+      shared_ptr<Console> attachConsole;
+      if (!result.count("N")) {
+        attachConsole.reset(new PseudoTerminalConsole());
+      }
+      int attachKeepalive = extractSingleOptionWithDefault<int>(
+          result, options, "keepalive", MAX_CLIENT_KEEP_ALIVE_DURATION);
+      try {
+        TerminalClient attachClient(
+            attachSocket, attachPipeSocket, attachEndpoint, session->id,
+            session->passkey, attachConsole, /*jumphost=*/false,
+            /*tunnels=*/"", /*reverseTunnels=*/"",
+            /*forwardSshAgent=*/false, /*identityAgent=*/"", attachKeepalive,
+            /*envVars=*/{}, /*maxConnectAttempts=*/15,
+            /*exitOnConnectFailure=*/false);
+        attachClient.run(
+            result.count("command") ? result["command"].as<string>() : "",
+            result.count("noexit"));
+      } catch (const runtime_error& err) {
+        if (string(err.what()) ==
+            TerminalClient::INVALID_SESSION_CONNECT_ERROR) {
+          deleteSession(attachName);
+          CLOG(INFO, "stdout")
+              << "Session '" << attachName << "' is no longer running on "
+              << session->host << endl;
+        } else {
+          CLOG(INFO, "stdout") << "Could not attach to session '" << attachName
+                               << "': " << err.what() << endl;
+        }
+        exit(1);
+      }
+      // Clean exit: the session is done, drop the saved file.
+      deleteSession(attachName);
+      exit(0);
+    }
     string username = "";
     if (result.count("username")) {
       username = result["username"].as<string>();
@@ -307,6 +410,29 @@ int main(int argc, char** argv) {
         destinationHost = string(sshConfigOptions.host);
       }
       free(home_dir);
+    }
+
+    // Every session gets a name so it can be reattached after the client
+    // (or machine) restarts: explicit --name, or a host+timestamp default.
+    if (result.count("name")) {
+      sessionName = result["name"].as<string>();
+      if (!isValidSessionName(sessionName)) {
+        CLOG(INFO, "stdout") << "Invalid session name: " << sessionName << endl;
+        exit(1);
+      }
+      if (loadSession(sessionName).has_value()) {
+        CLOG(INFO, "stdout")
+            << "session '" << sessionName << "' already exists; use --attach "
+            << sessionName << " or choose another --name" << endl;
+        exit(1);
+      }
+    } else {
+      char ts[32];
+      time_t now = time(NULL);
+      struct tm localTm;
+      localtime_r(&now, &localTm);
+      strftime(ts, sizeof(ts), "%Y%m%d-%H%M%S", &localTm);
+      sessionName = destinationHost + "-" + ts;
     }
 
     // Parse username: cmdline > sshconfig > localuser
@@ -443,6 +569,19 @@ int main(int argc, char** argv) {
         clientSocket, clientPipeSocket, socketEndpoint, idpasskeypair.first,
         idpasskeypair.second, console, is_jumphost, tunnel_arg, r_tunnel_arg,
         forwardAgent, sshSocket, keepaliveDuration, sshConfigOptions.env_vars);
+
+    // The connection is up: persist the session so a rebooted or killed
+    // client can reattach with --attach.
+    if (!sessionName.empty()) {
+      SessionInfo sessionInfo;
+      sessionInfo.name = sessionName;
+      sessionInfo.host = socketEndpoint.name();
+      sessionInfo.port = socketEndpoint.port();
+      sessionInfo.id = idpasskeypair.first;
+      sessionInfo.passkey = idpasskeypair.second;
+      sessionInfo.savedAt = (int64_t)time(NULL);
+      saveSession(sessionInfo);
+    }
     terminalClient.run(
         result.count("command") ? result["command"].as<string>() : "",
         result.count("noexit"));
@@ -461,6 +600,13 @@ int main(int argc, char** argv) {
 
   TelemetryService::get()->shutdown();
   TelemetryService::destroy();
+
+  // A clean exit ends the session: drop the saved session file. Signal
+  // exits (and crashes) skip this on purpose so the session can be
+  // reattached later.
+  if (!sessionName.empty()) {
+    deleteSession(sessionName);
+  }
 
   // Uninstall log rotation callback
   el::Helpers::uninstallPreRollOutCallback();

--- a/src/terminal/TerminalClientMain.cpp
+++ b/src/terminal/TerminalClientMain.cpp
@@ -96,9 +96,12 @@ int main(int argc, char** argv) {
 
   // Override easylogging handler for sigint
 
-  // Name of the session being started (empty when unnamed); deleted on a
-  // clean exit, kept on signal exits so the session can be reattached.
+  // Name of the session being started (empty when unnamed).  The saved file
+  // is deleted when the server ends the session, and kept otherwise so the
+  // session can be reattached later.
   string sessionName = "";
+  // Set after run() returns: true when the server ended the session.
+  bool sessionEndedByServer = false;
   ::signal(SIGINT, et::InterruptSignalHandler);
 
   Options sshConfigOptions = {
@@ -302,6 +305,7 @@ int main(int argc, char** argv) {
       }
       int attachKeepalive = extractSingleOptionWithDefault<int>(
           result, options, "keepalive", MAX_CLIENT_KEEP_ALIVE_DURATION);
+      bool attachSessionEnded = false;
       try {
         TerminalClient attachClient(
             attachSocket, attachPipeSocket, attachEndpoint, session->id,
@@ -313,6 +317,7 @@ int main(int argc, char** argv) {
         attachClient.run(
             result.count("command") ? result["command"].as<string>() : "",
             result.count("noexit"));
+        attachSessionEnded = attachClient.sessionEndedByServer();
       } catch (const runtime_error& err) {
         if (string(err.what()) ==
             TerminalClient::INVALID_SESSION_CONNECT_ERROR) {
@@ -326,8 +331,12 @@ int main(int argc, char** argv) {
         }
         exit(1);
       }
-      // Clean exit: the session is done, drop the saved file.
-      deleteSession(attachName);
+      // Only drop the saved file when the server says the session is gone
+      // (the remote shell ended).  A local exit — console closed, window
+      // died — leaves the remote shell running, so the file stays.
+      if (attachSessionEnded) {
+        deleteSession(attachName);
+      }
       exit(0);
     }
     string username = "";
@@ -588,6 +597,7 @@ int main(int argc, char** argv) {
     terminalClient.run(
         result.count("command") ? result["command"].as<string>() : "",
         result.count("noexit"));
+    sessionEndedByServer = terminalClient.sessionEndedByServer();
   } catch (TunnelParseException& tpe) {
     handleParseException(tpe, options);
   } catch (cxxopts::exceptions::exception& oe) {
@@ -604,10 +614,11 @@ int main(int argc, char** argv) {
   TelemetryService::get()->shutdown();
   TelemetryService::destroy();
 
-  // A clean exit ends the session: drop the saved session file. Signal
-  // exits (and crashes) skip this on purpose so the session can be
-  // reattached later.
-  if (!sessionName.empty()) {
+  // Drop the saved session file only when the server ended the session
+  // (the remote shell exited; observed as INVALID_KEY).  Any other exit —
+  // console EOF from a closed window, signal, crash — leaves the remote
+  // shell running, so the file stays and the session can be reattached.
+  if (!sessionName.empty() && sessionEndedByServer) {
     deleteSession(sessionName);
   }
 

--- a/src/terminal/TerminalClientMain.cpp
+++ b/src/terminal/TerminalClientMain.cpp
@@ -219,7 +219,10 @@ int main(int argc, char** argv) {
       for (const auto& session : listSessions()) {
         char saved[32];
         struct tm savedTm;
-        localtime_r(&session.savedAt, &savedTm);
+        // time_t is long on some platforms and long long on others; go
+        // through an explicit time_t so this compiles everywhere.
+        const time_t savedAt = static_cast<time_t>(session.savedAt);
+        localtime_r(&savedAt, &savedTm);
         strftime(saved, sizeof(saved), "%Y-%m-%d %H:%M:%S", &savedTm);
         CLOG(INFO, "stdout")
             << left << setw(24) << session.name << setw(24) << session.host

--- a/src/terminal/TerminalServer.cpp
+++ b/src/terminal/TerminalServer.cpp
@@ -204,7 +204,7 @@ void TerminalServer::runJumpHost(
 
 void TerminalServer::runTerminal(
     shared_ptr<ServerClientConnection> serverClientState,
-    const InitialPayload& payload) {
+    const InitialPayload& payload, bool resume) {
   auto maybeUserInfo =
       terminalRouter->tryGetInfoForConnection(serverClientState);
   if (!maybeUserInfo) {
@@ -227,31 +227,33 @@ void TerminalServer::runTerminal(
     LOG(INFO) << "SetEnv: " << envVar.first << "=" << envVar.second;
   }
 
-  vector<string> pipePaths;
-  for (const PortForwardSourceRequest& pfsr : payload.reversetunnels()) {
-    string sourceName;
-    PortForwardSourceResponse pfsresponse;
-    if (pfsr.has_environmentvariable()) {
-      pfsresponse = portForwardHandler->createSource(
-          pfsr, &sourceName, userInfo.uid(), userInfo.gid());
-    } else {
-      pfsresponse = portForwardHandler->createSource(
-          pfsr, nullptr, userInfo.uid(), userInfo.gid());
+  if (!resume) {
+    vector<string> pipePaths;
+    for (const PortForwardSourceRequest& pfsr : payload.reversetunnels()) {
+      string sourceName;
+      PortForwardSourceResponse pfsresponse;
+      if (pfsr.has_environmentvariable()) {
+        pfsresponse = portForwardHandler->createSource(
+            pfsr, &sourceName, userInfo.uid(), userInfo.gid());
+      } else {
+        pfsresponse = portForwardHandler->createSource(
+            pfsr, nullptr, userInfo.uid(), userInfo.gid());
+      }
+      if (pfsresponse.has_error()) {
+        InitialResponse response;
+        response.set_error(pfsresponse.error());
+        serverClientState->writePacket(Packet(
+            uint8_t(EtPacketType::INITIAL_RESPONSE), protoToString(response)));
+        return;
+      }
+      if (pfsr.has_environmentvariable()) {
+        environmentVariables[pfsr.environmentvariable()] = sourceName;
+        pipePaths.push_back(sourceName);
+      }
     }
-    if (pfsresponse.has_error()) {
-      InitialResponse response;
-      response.set_error(pfsresponse.error());
-      serverClientState->writePacket(Packet(
-          uint8_t(EtPacketType::INITIAL_RESPONSE), protoToString(response)));
-      return;
-    }
-    if (pfsr.has_environmentvariable()) {
-      environmentVariables[pfsr.environmentvariable()] = sourceName;
-      pipePaths.push_back(sourceName);
-    }
+    serverClientState->writePacket(Packet(
+        uint8_t(EtPacketType::INITIAL_RESPONSE), protoToString(response)));
   }
-  serverClientState->writePacket(
-      Packet(uint8_t(EtPacketType::INITIAL_RESPONSE), protoToString(response)));
 
   // Set thread name
   el::Helpers::setThreadName(serverClientState->getId());
@@ -265,14 +267,16 @@ void TerminalServer::runTerminal(
   shared_ptr<SocketHandler> terminalSocketHandler =
       terminalRouter->getSocketHandler();
 
-  TermInit termInit;
-  for (auto& it : environmentVariables) {
-    *(termInit.add_environmentnames()) = it.first;
-    *(termInit.add_environmentvalues()) = it.second;
+  if (!resume) {
+    TermInit termInit;
+    for (auto& it : environmentVariables) {
+      *(termInit.add_environmentnames()) = it.first;
+      *(termInit.add_environmentvalues()) = it.second;
+    }
+    terminalSocketHandler->writePacket(
+        terminalFd,
+        Packet(TerminalPacketType::TERMINAL_INIT, protoToString(termInit)));
   }
-  terminalSocketHandler->writePacket(
-      terminalFd,
-      Packet(TerminalPacketType::TERMINAL_INIT, protoToString(termInit)));
 
   while (run) {
     {
@@ -425,6 +429,19 @@ void TerminalServer::runTerminal(
     string id = serverClientState->getId();
     serverClientState.reset();
     removeClient(id);
+    // Drop the router entry only when the terminal side ended the session
+    // (its pipe hit EOF or errored), so a future same-id registration is not
+    // rejected (also fixes the MisterTea#428 leak).  On a server halt the
+    // terminal is still alive: the entry must survive so a clean shutdown
+    // can close the pipe and hand the terminal its EOF.
+    bool serverHalted;
+    {
+      lock_guard<std::mutex> guard(terminalThreadMutex);
+      serverHalted = halt;
+    }
+    if (!serverHalted) {
+      terminalRouter->removeTerminal(id);
+    }
   }
 }
 
@@ -456,6 +473,27 @@ bool TerminalServer::newClient(
       new thread(&TerminalServer::handleConnection, this, serverClientState));
   terminalThreads.push_back(t);
   return true;
+}
+
+bool TerminalServer::shouldResumeAsReturning(const string& clientId) {
+  return terminalRouter->isPtyActive(clientId);
+}
+
+void TerminalServer::resumeClient(
+    shared_ptr<ServerClientConnection> serverClientState) {
+  lock_guard<std::mutex> guard(terminalThreadMutex);
+  shared_ptr<thread> t = shared_ptr<thread>(new thread(
+      &TerminalServer::handleConnectionResume, this, serverClientState));
+  terminalThreads.push_back(t);
+}
+
+void TerminalServer::handleConnectionResume(
+    shared_ptr<ServerClientConnection> serverClientState) {
+  // The session's bootstrap (INITIAL_PAYLOAD / INITIAL_RESPONSE /
+  // TERMINAL_INIT) already ran before the server restart; the pty is alive.
+  // Go straight to the pump for the existing terminal.
+  LOG(INFO) << "RESUMING TERMINAL";
+  runTerminal(serverClientState, InitialPayload(), /*resume=*/true);
 }
 }  // namespace et
 #endif

--- a/src/terminal/TerminalServer.hpp
+++ b/src/terminal/TerminalServer.hpp
@@ -35,12 +35,23 @@ class TerminalServer : public ServerConnection {
                    const InitialPayload& payload);
   /** @brief Launches the interactive terminal session for a client. */
   void runTerminal(shared_ptr<ServerClientConnection> serverClientState,
-                   const InitialPayload& payload);
+                   const InitialPayload& payload, bool resume = false);
   /** @brief Sets up the client state and pushes it into the terminal router. */
   void handleConnection(shared_ptr<ServerClientConnection> serverClientState);
+  /**
+   * @brief Resumes a session whose terminal re-registered after a server
+   * restart: skips the INITIAL_PAYLOAD bootstrap and goes straight to the
+   * pump for the existing pty.
+   */
+  void handleConnectionResume(
+      shared_ptr<ServerClientConnection> serverClientState);
   /** @brief Callback from ServerConnection when a new client is authenticated.
    */
   virtual bool newClient(shared_ptr<ServerClientConnection> serverClientState);
+  /** @brief ServerConnection hook: a known id whose pty is live resumes. */
+  virtual bool shouldResumeAsReturning(const string& clientId);
+  /** @brief ServerConnection hook: spawns the resume pump thread. */
+  virtual void resumeClient(shared_ptr<ServerClientConnection> state);
 
   /** @brief Main loop that accepts client connections and relays to handlers.
    */
@@ -49,6 +60,17 @@ class TerminalServer : public ServerConnection {
   void shutdown() {
     lock_guard<std::mutex> guard(terminalThreadMutex);
     halt = true;
+  }
+
+  /**
+   * @brief Closes client connections and terminal pipes so remote ends
+   * observe a clean EOF instead of a silently abandoned socket.  Call only
+   * after `run()` has exited (closing fds while the select loop still uses
+   * them is a classic select/close race).
+   */
+  void shutdownConnections() {
+    ServerConnection::shutdown();
+    terminalRouter->shutdown();
   }
 
   /** @brief Router that hands reconnecting clients to their terminals. */

--- a/src/terminal/UserTerminalHandler.cpp
+++ b/src/terminal/UserTerminalHandler.cpp
@@ -17,50 +17,95 @@ UserTerminalHandler::UserTerminalHandler(
     : socketHandler(_socketHandler),
       term(_term),
       noratelimit(_noratelimit),
-      shuttingDown(false) {
+      routerEndpoint(routerEndpoint),
+      shuttingDown(false),
+      ptyActive(false) {
   auto idpasskey_splited = split(idPasskey, '/');
-  string id = idpasskey_splited[0];
-  string passkey = idpasskey_splited[1];
-  TerminalUserInfo tui;
-  tui.set_id(id);
-  tui.set_passkey(passkey);
-  tui.set_uid(getuid());
-  tui.set_gid(getgid());
-
-  routerFd = ServerFifoPath::detectAndConnect(routerEndpoint, socketHandler);
+  id = idpasskey_splited[0];
+  passkey = idpasskey_splited[1];
 
   try {
-    socketHandler->writePacket(
-        routerFd,
-        Packet(TerminalPacketType::TERMINAL_USER_INFO, protoToString(tui)));
-
+    registerWithRouter();
   } catch (const std::runtime_error& re) {
     STFATAL << "Error connecting to router: " << re.what();
   }
 }
 
-void UserTerminalHandler::run() {
+void UserTerminalHandler::registerWithRouter() {
+  TerminalUserInfo tui;
+  tui.set_id(id);
+  tui.set_passkey(passkey);
+  tui.set_uid(getuid());
+  tui.set_gid(getgid());
+  tui.set_ptyactive(ptyActive);
+
+  routerFd = ServerFifoPath::detectAndConnect(routerEndpoint, socketHandler);
+
+  socketHandler->writePacket(
+      routerFd,
+      Packet(TerminalPacketType::TERMINAL_USER_INFO, protoToString(tui)));
+}
+
+int UserTerminalHandler::reconnectRouter() {
+  if (routerFd >= 0) {
+    // Go through the socket handler so its fd bookkeeping stays in sync;
+    // a raw close() would leave a stale entry and the next connect() could
+    // reuse the number and trip "fd already exists".
+    socketHandler->close(routerFd);
+    routerFd = -1;
+  }
+  LOG(INFO) << "Router connection lost; the session stays alive and waits for "
+               "the router to come back.";
+  int backoffSec = 1;
   while (true) {
-    Packet termInitPacket;
-    if (!socketHandler->readPacket(routerFd, &termInitPacket)) {
-      continue;
+    // Bound the shutdown latency: check the flag every second while sleeping.
+    for (int a = 0; a < backoffSec; a++) {
+      sleep(1);
+      {
+        lock_guard<recursive_mutex> guard(shutdownMutex);
+        if (shuttingDown) {
+          return -1;
+        }
+      }
     }
-    if (termInitPacket.getHeader() != TerminalPacketType::TERMINAL_INIT) {
-      STFATAL << "Invalid terminal init packet header: "
-              << termInitPacket.getHeader();
+    try {
+      registerWithRouter();
+      LOG(INFO) << "Reconnected to the router; resuming the session.";
+      return routerFd;
+    } catch (const std::exception& re) {
+      LOG(INFO) << "Router not available yet: " << re.what();
     }
-    TermInit ti = stringToProto<TermInit>(termInitPacket.getPayload());
-    for (int a = 0; a < ti.environmentnames_size(); a++) {
-      setenv(ti.environmentnames(a).c_str(), ti.environmentvalues(a).c_str(),
-             true);
+    if (backoffSec < 10) {
+      backoffSec *= 2;
     }
-    break;
+  }
+}
+
+void UserTerminalHandler::run() {
+  if (!ptyActive) {
+    while (true) {
+      Packet termInitPacket;
+      if (!socketHandler->readPacket(routerFd, &termInitPacket)) {
+        continue;
+      }
+      if (termInitPacket.getHeader() != TerminalPacketType::TERMINAL_INIT) {
+        STFATAL << "Invalid terminal init packet header: "
+                << termInitPacket.getHeader();
+      }
+      TermInit ti = stringToProto<TermInit>(termInitPacket.getPayload());
+      for (int a = 0; a < ti.environmentnames_size(); a++) {
+        setenv(ti.environmentnames(a).c_str(), ti.environmentvalues(a).c_str(),
+               true);
+      }
+      break;
+    }
   }
 
   int masterfd = term->setup(routerFd);
   VLOG(1) << "pty opened " << masterfd;
+  ptyActive = true;
   runUserTerminal(masterfd);
-  close(routerFd);
+  socketHandler->close(routerFd);
 }
 
 void UserTerminalHandler::runUserTerminal(int masterFd) {
@@ -177,8 +222,13 @@ void UserTerminalHandler::runUserTerminal(int masterFd) {
                                    strerror(readErrno));
         }
         if (rc == 0) {
-          throw std::runtime_error(
-              "Router has ended abruptly.  Killing terminal session.");
+          // The router (etserver) went away.  Keep the pty child alive and
+          // wait for the replacement router instead of killing the session.
+          routerFd = reconnectRouter();
+          if (routerFd < 0) {
+            break;
+          }
+          continue;
         }
         switch (packetType) {
           case TERMINAL_BUFFER: {
@@ -224,10 +274,14 @@ void UserTerminalHandler::runUserTerminal(int masterFd) {
         }
       }
     } catch (const std::exception& ex) {
+      // Router-side failure (read error, write failure, or a desynchronized
+      // stream): the pty child is still fine, so wait for the router to come
+      // back instead of ending the session.
       LOG(INFO) << ex.what();
-      lock_guard<recursive_mutex> guard(shutdownMutex);
-      shuttingDown = true;
-      break;
+      routerFd = reconnectRouter();
+      if (routerFd < 0) {
+        break;
+      }
     }
   }
 

--- a/src/terminal/UserTerminalHandler.hpp
+++ b/src/terminal/UserTerminalHandler.hpp
@@ -41,9 +41,33 @@ class UserTerminalHandler {
   bool shuttingDown;
   /** @brief Guards `shuttingDown` across threads. */
   recursive_mutex shutdownMutex;
+  /** @brief Client id used for router registration. */
+  string id;
+  /** @brief Passkey used for router registration. */
+  string passkey;
+  /** @brief Router endpoint used for (re)connection attempts. */
+  optional<SocketEndpoint> routerEndpoint;
+  /** @brief True once the pty has been set up (the session has started). */
+  bool ptyActive;
 
   /** @brief Reads from the master fd and forwards data to the client socket. */
   void runUserTerminal(int masterFd);
+
+  /**
+   * @brief Connects to the router and sends the TERMINAL_USER_INFO
+   * registration for this session.
+   * @throws runtime_error when the router cannot be reached.
+   */
+  void registerWithRouter();
+
+  /**
+   * @brief Blocks with bounded backoff until the router is reachable again,
+   * re-registering this session with the same id/passkey. The pty child keeps
+   * running the whole time; because the master fd is not drained, the shell
+   * is backpressured by the kernel pty buffer instead of data being lost.
+   * @returns The new router fd, or -1 when the session must end (shutdown).
+   */
+  int reconnectRouter();
 };
 }  // namespace et
 

--- a/src/terminal/UserTerminalRouter.cpp
+++ b/src/terminal/UserTerminalRouter.cpp
@@ -43,9 +43,22 @@ IdKeyPair UserTerminalRouter::acceptNewConnection() {
     const bool inserted =
         idInfoMap.insert(std::make_pair(tui.id(), tui)).second;
     if (!inserted) {
-      LOG(ERROR) << "Rejecting duplicate terminal connection for " << tui.id();
-      socketHandler->close(terminalFd);
-      return IdKeyPair({"", ""});
+      // A registration for this id already exists.  If the previous owner's
+      // pipe is dead (the connection dropped without the session ending),
+      // replace it so the terminal can re-attach; a live owner always wins.
+      // MSG_PEEK tests for EOF without consuming terminal data.
+      char peek;
+      const int alive = recv(idInfoMap.at(tui.id()).fd(), &peek, 1, MSG_PEEK);
+      if (alive == 0) {
+        LOG(INFO) << "Replacing dead terminal registration for " << tui.id();
+        idInfoMap.erase(tui.id());
+        idInfoMap.insert(std::make_pair(tui.id(), tui));
+      } else {
+        LOG(ERROR) << "Rejecting duplicate terminal connection for "
+                   << tui.id();
+        socketHandler->close(terminalFd);
+        return IdKeyPair({"", ""});
+      }
     }
 
     return IdKeyPair({tui.id(), tui.passkey()});
@@ -76,6 +89,33 @@ std::optional<TerminalUserInfo> UserTerminalRouter::tryGetInfoForConnection(
   }
 
   return it->second;
+}
+
+bool UserTerminalRouter::isPtyActive(const string& id) {
+  lock_guard<recursive_mutex> guard(routerMutex);
+  auto it = idInfoMap.find(id);
+  return it != idInfoMap.end() && it->second.ptyactive();
+}
+
+void UserTerminalRouter::removeTerminal(const string& id) {
+  lock_guard<recursive_mutex> guard(routerMutex);
+  idInfoMap.erase(id);
+}
+
+void UserTerminalRouter::shutdown() {
+  lock_guard<recursive_mutex> guard(routerMutex);
+  LOG(INFO) << "Router shutdown: closing " << idInfoMap.size()
+            << " terminal pipes";
+  for (auto& it : idInfoMap) {
+    socketHandler->close(it.second.fd());
+  }
+  idInfoMap.clear();
+  if (serverFd >= 0) {
+    // Listen fds are not tracked by the socket handler's active-socket map;
+    // close it directly.
+    ::close(serverFd);
+    serverFd = -1;
+  }
 }
 
 }  // namespace et

--- a/src/terminal/UserTerminalRouter.hpp
+++ b/src/terminal/UserTerminalRouter.hpp
@@ -42,6 +42,26 @@ class UserTerminalRouter {
     return socketHandler;
   }
 
+  /**
+   * @brief Returns true when the terminal for `id` re-registered with its pty
+   * already running (a resumed session, not a fresh bootstrap).
+   */
+  bool isPtyActive(const string& id);
+
+  /**
+   * @brief Drops the registration for `id` so its terminal slot no longer
+   * blocks a future same-id registration (a terminal whose shell ended must
+   * not linger; also fixes the stale-entry leak behind MisterTea#428).
+   */
+  void removeTerminal(const string& id);
+
+  /**
+   * @brief Closes the listen fd and every registered terminal pipe.  On a
+   * clean server shutdown this makes connected terminals observe EOF (they
+   * keep their pty alive and wait for a replacement router).  Idempotent.
+   */
+  void shutdown();
+
  protected:
   /** @brief File descriptor used by external clients to reach the router. */
   int serverFd;

--- a/test/FakeConsole.hpp
+++ b/test/FakeConsole.hpp
@@ -222,6 +222,15 @@ class FakeUserTerminal : public UserTerminal {
   virtual void cleanup() { didCleanUp = true; }
   virtual void setInfo(const winsize& tmpwin) { lastWinInfo = tmpwin; }
 
+  bool wasCleanedUp() { return didCleanUp; }
+  bool sessionEndHandled() { return didHandleSessionEnd; }
+
+  /** @brief True once setup() has both pipe ends connected. */
+  bool isSetup() {
+    lock_guard<recursive_mutex> lock(_mutex);
+    return serverClientFd >= 0 && clientServerFd >= 0;
+  }
+
  protected:
   recursive_mutex _mutex;
   shared_ptr<PipeSocketHandler> socketHandler;

--- a/test/integration_tests/RouterRestartTest.cpp
+++ b/test/integration_tests/RouterRestartTest.cpp
@@ -1,0 +1,403 @@
+#ifndef WIN32
+// Integration tests for etserver (router) restarts: sessions must survive.
+// The "kill" is modeled in-process by shutting the TerminalServer down
+// completely (listen fds, client connections, and router pipes all close, so
+// remote ends observe EOF exactly as they do when the etserver process dies)
+// and then binding a brand new TerminalServer on the same pipe paths.
+#include <atomic>
+#include <chrono>
+#include <functional>
+
+#if __APPLE__
+#include <util.h>
+#elif __FreeBSD__
+#include <libutil.h>
+#else
+#include <pty.h>
+#endif
+#include <fcntl.h>
+#include <sys/wait.h>
+#include <termios.h>
+
+#include "FakeConsole.hpp"
+#include "FakeSshSetupHandler.hpp"
+#include "TerminalClient.hpp"
+#include "TerminalServer.hpp"
+#include "TestHeaders.hpp"
+
+namespace et {
+namespace {
+
+// Polls `fn` until it returns true; fails the test after `seconds`.
+void requireEventually(const std::function<bool()>& fn, int seconds,
+                       const string& what) {
+  const auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::seconds(seconds);
+  while (std::chrono::steady_clock::now() < deadline) {
+    if (fn()) {
+      return;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  }
+  FAIL("Timed out waiting for " << what);
+}
+
+// A TerminalServer that can be killed and replaced on the same pipe paths,
+// standing in for an etserver process restart.
+struct RestartableServer {
+  void start() {
+    serverSocketHandler.reset(new PipeSocketHandler());
+    routerSocketHandler.reset(new PipeSocketHandler());
+    server = shared_ptr<TerminalServer>(
+        new TerminalServer(serverSocketHandler, serverEndpoint,
+                           routerSocketHandler, routerEndpoint));
+    serverThread = thread([this]() { server->run(); });
+    sleep(1);
+  }
+
+  // Simulates the etserver process dying.  Order matters: halt the accept
+  // loop and let run() finish (it joins the pump threads) BEFORE closing any
+  // fd, so no thread is selecting on a descriptor we close.  Only then do
+  // client connections and terminal pipes see their EOF, exactly as when the
+  // kernel reaps a dead process.
+  void kill() {
+    server->shutdown();
+    serverThread.join();
+    server->shutdownConnections();
+    server.reset();
+    serverSocketHandler.reset();
+    routerSocketHandler.reset();
+  }
+
+  shared_ptr<TerminalServer> server;
+  thread serverThread;
+  shared_ptr<SocketHandler> serverSocketHandler;
+  shared_ptr<PipeSocketHandler> routerSocketHandler;
+  SocketEndpoint serverEndpoint;
+  SocketEndpoint routerEndpoint;
+};
+
+// One client+etterminal session pair.
+struct SessionFixture {
+  void start(RestartableServer& target) {
+    auto fakeSubprocessUtils = make_shared<FakeSubprocessUtils>();
+    auto sshSetupHandler =
+        make_shared<FakeSshSetupHandler>(fakeSubprocessUtils);
+    auto idpass = sshSetupHandler->SetupSsh("", "localhost", "localhost", 2022,
+                                            "", "", false, 0, "", "", {});
+    id = idpass.first;
+    passkey = idpass.second;
+
+    consoleSocketHandler.reset(new PipeSocketHandler());
+    userTerminalSocketHandler.reset(new PipeSocketHandler());
+    console.reset(new FakeConsole(consoleSocketHandler));
+    userTerminal.reset(new FakeUserTerminal(userTerminalSocketHandler));
+
+    handler = shared_ptr<UserTerminalHandler>(
+        new UserTerminalHandler(userTerminalSocketHandler, userTerminal, true,
+                                target.routerEndpoint, id + "/" + passkey));
+    handlerThread = thread([this]() { handler->run(); });
+
+    clientSocketHandler.reset(new PipeSocketHandler());
+    clientPipeSocketHandler.reset(new PipeSocketHandler());
+    client = shared_ptr<TerminalClient>(new TerminalClient(
+        clientSocketHandler, clientPipeSocketHandler, target.serverEndpoint, id,
+        passkey, console, false, "", "", false, "",
+        MAX_CLIENT_KEEP_ALIVE_DURATION, vector<pair<string, string>>()));
+    clientThread = thread([this]() { client->run("", false); });
+
+    requireEventually([this]() { return console->isSetup(); }, 30,
+                      "console setup");
+    // The terminal pipe is only wired up after the client bootstrap delivers
+    // TERMINAL_INIT and the handler runs term->setup().
+    requireEventually([this]() { return userTerminal->isSetup(); }, 30,
+                      "terminal setup");
+  }
+
+  void stop() {
+    client->shutdown();
+    clientThread.join();
+    client.reset();
+    handler->shutdown();
+    handlerThread.join();
+    handler.reset();
+  }
+
+  string id;
+  string passkey;
+  shared_ptr<PipeSocketHandler> consoleSocketHandler;
+  shared_ptr<PipeSocketHandler> userTerminalSocketHandler;
+  shared_ptr<SocketHandler> clientSocketHandler;
+  shared_ptr<SocketHandler> clientPipeSocketHandler;
+  shared_ptr<FakeConsole> console;
+  shared_ptr<FakeUserTerminal> userTerminal;
+  shared_ptr<UserTerminalHandler> handler;
+  shared_ptr<TerminalClient> client;
+  thread handlerThread;
+  thread clientThread;
+};
+
+// A UserTerminal backed by a real pty running `cat` (raw, no echo), so the
+// restart tests also cover a genuine forked child process.
+class RealPtyCatTerminal : public UserTerminal {
+ public:
+  RealPtyCatTerminal() : masterFd(-1), childPid(-1) {}
+  virtual ~RealPtyCatTerminal() {}
+
+  virtual int setup(int routerFd) {
+    struct termios tios;
+    memset(&tios, 0, sizeof(tios));
+    cfmakeraw(&tios);
+    tios.c_cc[VMIN] = 1;
+    tios.c_cc[VTIME] = 0;
+    childPid = forkpty(&masterFd, NULL, &tios, NULL);
+    if (childPid == -1) {
+      FATAL_FAIL(childPid);
+    }
+    if (childPid == 0) {
+      // The child must not hold copies of the server/router sockets (the
+      // whole suite runs in one process): keeping them open would mask the
+      // EOF the handler relies on when the server side closes its end.
+      for (int fd = 3; fd < 1024; fd++) {
+        close(fd);
+      }
+      execl("/bin/cat", "cat", (char*)NULL);
+      _exit(127);
+    }
+    int flags = fcntl(masterFd, F_GETFL, 0);
+    if (flags != -1) {
+      fcntl(masterFd, F_SETFL, flags | O_NONBLOCK);
+    }
+    return masterFd;
+  }
+  virtual void runTerminal() {}
+  virtual void handleSessionEnd() {}
+  virtual void cleanup() {
+    if (masterFd >= 0) {
+      close(masterFd);
+      masterFd = -1;
+    }
+    if (childPid > 0) {
+      int status = 0;
+      waitpid(childPid, &status, 0);
+      childPid = -1;
+    }
+  }
+  virtual int getFd() { return masterFd; }
+  virtual void setInfo(const winsize& tmpwin) {}
+
+  pid_t getChildPid() { return childPid; }
+
+ private:
+  int masterFd;
+  pid_t childPid;
+};
+
+string makePipeDir() {
+  string tmpPath = GetTempDirectory() + string("et_restart_test_XXXXXXXX");
+  return string(mkdtemp(&tmpPath[0]));
+}
+
+}  // namespace
+
+TEST_CASE("RouterRestartSurvival", "[RouterRestart]") {
+  const string pipeDirectory = makePipeDir();
+  RestartableServer target;
+  target.serverEndpoint.set_name(pipeDirectory + "/pipe_server");
+  target.routerEndpoint.set_name(pipeDirectory + "/pipe_router");
+  target.start();
+
+  SessionFixture session;
+  session.start(target);
+
+  // Baseline round trip before the restart.
+  session.console->simulateKeystrokes("a");
+  REQUIRE(session.userTerminal->getKeystrokes(1) == "a");
+
+  // Kill the "etserver process".  The handler must keep its terminal alive.
+  target.kill();
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  REQUIRE_FALSE(session.userTerminal->wasCleanedUp());
+  REQUIRE_FALSE(session.userTerminal->sessionEndHandled());
+
+  // Replacement etserver on the same paths: the terminal re-registers and
+  // the client resumes without any bootstrap.
+  target.start();
+  requireEventually(
+      [&]() { return target.server->terminalRouter->isPtyActive(session.id); },
+      60, "terminal re-registration");
+  requireEventually(
+      [&]() { return target.server->clientConnectionExists(session.id); }, 60,
+      "client reconnect");
+
+  // The session still works, in both directions.
+  session.console->simulateKeystrokes("b");
+  REQUIRE(session.userTerminal->getKeystrokes(1) == "b");
+  session.userTerminal->simulateTerminalResponse("R");
+  REQUIRE(session.console->getTerminalData(1) == "R");
+
+  session.stop();
+  target.kill();
+  FATAL_FAIL(::remove((pipeDirectory + "/pipe_server").c_str()));
+  FATAL_FAIL(::remove((pipeDirectory + "/pipe_router").c_str()));
+  FATAL_FAIL(::remove(pipeDirectory.c_str()));
+}
+
+TEST_CASE("RouterRestartOutageBackpressure", "[RouterRestart]") {
+  const string pipeDirectory = makePipeDir();
+  RestartableServer target;
+  target.serverEndpoint.set_name(pipeDirectory + "/pipe_server");
+  target.routerEndpoint.set_name(pipeDirectory + "/pipe_router");
+  target.start();
+
+  SessionFixture session;
+  session.start(target);
+
+  // Kill the router, then produce terminal output during the outage: the
+  // handler must not consume it until a replacement router is up.
+  target.kill();
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
+  session.userTerminal->simulateTerminalResponse("OUTAGE");
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
+  REQUIRE_FALSE(session.userTerminal->wasCleanedUp());
+
+  target.start();
+  requireEventually(
+      [&]() { return target.server->terminalRouter->isPtyActive(session.id); },
+      60, "terminal re-registration");
+  requireEventually(
+      [&]() { return target.server->clientConnectionExists(session.id); }, 60,
+      "client reconnect");
+
+  // The bytes produced during the outage arrive intact and in order.
+  REQUIRE(session.console->getTerminalData(6) == "OUTAGE");
+
+  session.stop();
+  target.kill();
+  FATAL_FAIL(::remove((pipeDirectory + "/pipe_server").c_str()));
+  FATAL_FAIL(::remove((pipeDirectory + "/pipe_router").c_str()));
+  FATAL_FAIL(::remove(pipeDirectory.c_str()));
+}
+
+TEST_CASE("RouterRestartConcurrentReregistration", "[RouterRestart]") {
+  // The 2026-08-19 incident killed 14 sessions; model exactly that count.
+  const int kSessionCount = 14;
+  const string pipeDirectory = makePipeDir();
+  RestartableServer target;
+  target.serverEndpoint.set_name(pipeDirectory + "/pipe_server");
+  target.routerEndpoint.set_name(pipeDirectory + "/pipe_router");
+  target.start();
+
+  vector<shared_ptr<SessionFixture>> sessions;
+  for (int i = 0; i < kSessionCount; i++) {
+    auto session = make_shared<SessionFixture>();
+    session->start(target);
+    sessions.push_back(session);
+  }
+
+  target.kill();
+
+  target.start();
+  for (auto& session : sessions) {
+    requireEventually(
+        [&]() {
+          return target.server->terminalRouter->isPtyActive(session->id);
+        },
+        90, "terminal re-registration for " + session->id);
+  }
+  for (auto& session : sessions) {
+    requireEventually(
+        [&]() { return target.server->clientConnectionExists(session->id); },
+        90, "client reconnect for " + session->id);
+  }
+
+  // Every session is functional after the restart.
+  for (int i = 0; i < kSessionCount; i++) {
+    const char marker = char('a' + i);
+    sessions[i]->console->simulateKeystrokes(string(1, marker));
+  }
+  for (int i = 0; i < kSessionCount; i++) {
+    const char marker = char('a' + i);
+    REQUIRE(sessions[i]->userTerminal->getKeystrokes(1) == string(1, marker));
+  }
+
+  for (auto& session : sessions) {
+    session->stop();
+  }
+  target.kill();
+  FATAL_FAIL(::remove((pipeDirectory + "/pipe_server").c_str()));
+  FATAL_FAIL(::remove((pipeDirectory + "/pipe_router").c_str()));
+  FATAL_FAIL(::remove(pipeDirectory.c_str()));
+}
+
+TEST_CASE("RouterRestartRealPtySurvives", "[RouterRestart]") {
+  const string pipeDirectory = makePipeDir();
+  RestartableServer target;
+  target.serverEndpoint.set_name(pipeDirectory + "/pipe_server");
+  target.routerEndpoint.set_name(pipeDirectory + "/pipe_router");
+  target.start();
+
+  auto fakeSubprocessUtils = make_shared<FakeSubprocessUtils>();
+  auto sshSetupHandler = make_shared<FakeSshSetupHandler>(fakeSubprocessUtils);
+  auto idpass = sshSetupHandler->SetupSsh("", "localhost", "localhost", 2022,
+                                          "", "", false, 0, "", "", {});
+  const string id = idpass.first;
+  const string passkey = idpass.second;
+
+  auto consoleSocketHandler = make_shared<PipeSocketHandler>();
+  auto console = make_shared<FakeConsole>(consoleSocketHandler);
+  auto realPty = make_shared<RealPtyCatTerminal>();
+  auto handlerSocketHandler = make_shared<PipeSocketHandler>();
+  auto handler = shared_ptr<UserTerminalHandler>(
+      new UserTerminalHandler(handlerSocketHandler, realPty, true,
+                              target.routerEndpoint, id + "/" + passkey));
+  thread handlerThread([handler]() { handler->run(); });
+
+  auto clientSocketHandler = make_shared<PipeSocketHandler>();
+  auto clientPipeSocketHandler = make_shared<PipeSocketHandler>();
+  auto client = shared_ptr<TerminalClient>(new TerminalClient(
+      clientSocketHandler, clientPipeSocketHandler, target.serverEndpoint, id,
+      passkey, console, false, "", "", false, "",
+      MAX_CLIENT_KEEP_ALIVE_DURATION, vector<pair<string, string>>()));
+  thread clientThread([client]() { client->run("", false); });
+  requireEventually([console]() { return console->isSetup(); }, 30,
+                    "console setup");
+  // The pty child is forked only after the client bootstrap delivers
+  // TERMINAL_INIT to the handler.
+  requireEventually([&]() { return realPty->getChildPid() > 0; }, 30,
+                    "pty setup");
+  const pid_t childBefore = realPty->getChildPid();
+
+  // cat echoes input back through the whole chain.
+  console->simulateKeystrokes("x");
+  REQUIRE(console->getTerminalData(1) == "x");
+
+  target.kill();
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  // The pty child (the stand-in for the user's shell) is untouched.
+  REQUIRE(kill(childBefore, 0) == 0);
+
+  target.start();
+  requireEventually(
+      [&]() { return target.server->terminalRouter->isPtyActive(id); }, 60,
+      "terminal re-registration");
+  requireEventually([&]() { return target.server->clientConnectionExists(id); },
+                    60, "client reconnect");
+
+  // Same child process, and the echo path works after the restart.
+  REQUIRE(realPty->getChildPid() == childBefore);
+  console->simulateKeystrokes("y");
+  REQUIRE(console->getTerminalData(1) == "y");
+
+  client->shutdown();
+  clientThread.join();
+  handler->shutdown();
+  handlerThread.join();
+  target.kill();
+  FATAL_FAIL(::remove((pipeDirectory + "/pipe_server").c_str()));
+  FATAL_FAIL(::remove((pipeDirectory + "/pipe_router").c_str()));
+  FATAL_FAIL(::remove(pipeDirectory.c_str()));
+}
+
+}  // namespace et
+#endif

--- a/test/integration_tests/RouterRestartTest.cpp
+++ b/test/integration_tests/RouterRestartTest.cpp
@@ -79,6 +79,15 @@ struct RestartableServer {
 
 // One client+etterminal session pair.
 struct SessionFixture {
+  ~SessionFixture() {
+    // A failing REQUIRE unwinds through this dtor; destroying a joinable
+    // thread would terminate the process and mask the real failure.
+    try {
+      stop();
+    } catch (...) {
+    }
+  }
+
   void start(RestartableServer& target) {
     auto fakeSubprocessUtils = make_shared<FakeSubprocessUtils>();
     auto sshSetupHandler =

--- a/test/system_tests/named_sessions.sh
+++ b/test/system_tests/named_sessions.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+# named_sessions.sh — Phase 1 contract: a named session survives the client
+# process dying (laptop reboot proxy) and can be reattached with --attach.
+set -x
+set -e
+
+cd "$(dirname "$0")/../.."
+
+ET_PORT=9922
+ET_FIFO=/tmp/et_named_sessions.fifo
+TEST_HOME=$(mktemp -d /tmp/et_named_home_XXXXXXXX)
+LOG_DIR=/tmp/et_test_logs/named_sessions
+SERVER_LOG_DIR=$LOG_DIR/server
+CLIENT_LOG=$LOG_DIR/client.log
+ATTACH_LOG=$LOG_DIR/attach.log
+INPUT_FIFO=$LOG_DIR/input_fifo
+ATTACH_FIFO=$LOG_DIR/attach_fifo
+
+server_pid=""
+client_pid=""
+attach_pid=""
+
+cleanup() {
+  [ -n "$attach_pid" ] && kill -9 "$attach_pid" 2>/dev/null || true
+  [ -n "$client_pid" ] && kill -9 "$client_pid" 2>/dev/null || true
+  [ -n "$server_pid" ] && kill -9 "$server_pid" 2>/dev/null || true
+  pkill -9 -f "etterminal.*--serverfifo=$ET_FIFO" 2>/dev/null || true
+  rm -rf "$TEST_HOME" "$LOG_DIR" || true
+}
+trap cleanup EXIT
+
+wait_for_file() { # path, seconds
+  for _ in $(seq 1 "$(( $2 * 10 ))"); do
+    [ -f "$1" ] && return 0
+    sleep 0.1
+  done
+  echo "timed out waiting for file $1" >&2
+  return 1
+}
+
+wait_for_grep() { # pattern, file, seconds
+  for _ in $(seq 1 "$(( $3 * 10 ))"); do
+    grep -q "$1" "$2" 2>/dev/null && return 0
+    sleep 0.1
+  done
+  echo "timed out waiting for '$1' in $2" >&2
+  return 1
+}
+
+ssh -o 'PreferredAuthentications=publickey' localhost "echo" || exit 1
+ssh -o "StrictHostKeyChecking no" localhost echo "Bypassing host check"
+
+# Reap leftover fixture terminals from earlier aborted runs (with router
+# recovery they retry re-registration forever by design).
+pkill -9 -f "etterminal.*--serverfifo=$ET_FIFO" 2>/dev/null || true
+rm -rf "$LOG_DIR"
+
+mkdir -p "$SERVER_LOG_DIR"
+build/etserver --port $ET_PORT --serverfifo=$ET_FIFO -l "$SERVER_LOG_DIR" &
+server_pid=$!
+sleep 3
+
+mkfifo "$INPUT_FIFO" "$ATTACH_FIFO"
+# Hold the fifos open so the clients never see EOF on stdin.
+exec 9<>"$INPUT_FIFO"
+exec 10<>"$ATTACH_FIFO"
+
+# Start a named session in the background.  script(1) gives the client a
+# real pty for stdin: without a tty the console input path disables itself
+# and no keystrokes would reach the session.
+HOME=$TEST_HOME script -qec "build/et --name alpha --serverfifo=$ET_FIFO \
+  --terminal-path $PWD/build/etterminal --logtostdout \
+  localhost:$ET_PORT" /dev/null <"$INPUT_FIFO" >"$CLIENT_LOG" 2>&1 &
+client_pid=$!
+
+# The session file is written once the initial connect succeeds.
+wait_for_file "$TEST_HOME/.et/sessions/alpha" 30
+
+# The session works: set a sentinel variable in the remote shell.
+printf 'ET_SENTINEL=abc123\n' >&9
+printf 'echo PRE-$((6*7))\n' >&9
+wait_for_grep 'PRE-42' "$CLIENT_LOG" 30
+
+# Simulate a laptop reboot: SIGKILL the client (the script wrapper and the
+# et process under it).  The session file must stay.
+pkill -9 -P "$client_pid" 2>/dev/null || true
+kill -9 "$client_pid" 2>/dev/null || true
+pkill -9 -f "build/et --name alpha" 2>/dev/null || true
+wait "$client_pid" 2>/dev/null || true
+client_pid=""
+[ -f "$TEST_HOME/.et/sessions/alpha" ] || {
+  echo "session file vanished after client kill" >&2
+  exit 1
+}
+
+# --list shows the session without connecting.
+HOME=$TEST_HOME build/et --list | grep -q alpha
+
+# --attach reattaches to the same remote shell: the sentinel is still set.
+HOME=$TEST_HOME script -qec "build/et --attach alpha --serverfifo=$ET_FIFO \
+  --terminal-path $PWD/build/etterminal --logtostdout" /dev/null \
+  <"$ATTACH_FIFO" >"$ATTACH_LOG" 2>&1 &
+attach_pid=$!
+sleep 5
+printf 'echo POST-$ET_SENTINEL\n' >&10
+wait_for_grep 'POST-abc123' "$ATTACH_LOG" 30
+
+# A clean shell exit ends the session and drops the file.
+printf 'exit\n' >&10
+for _ in $(seq 1 100); do
+  [ ! -f "$TEST_HOME/.et/sessions/alpha" ] && break
+  sleep 0.1
+done
+[ ! -f "$TEST_HOME/.et/sessions/alpha" ] || {
+  echo "session file not removed after clean exit" >&2
+  exit 1
+}
+wait "$attach_pid" 2>/dev/null || true
+attach_pid=""
+
+echo "named_sessions.sh: OK"

--- a/test/system_tests/router_restart.sh
+++ b/test/system_tests/router_restart.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+# router_restart.sh — Phase 2 contract: an etserver (router) restart must not
+# kill sessions.  Two named sessions keep their remote etterminal processes
+# (same pids), the clients reconnect by themselves, and shell state survives.
+set -x
+set -e
+
+cd "$(dirname "$0")/../.."
+
+ET_PORT=9923
+ET_FIFO=/tmp/et_router_restart.fifo
+TEST_HOME=$(mktemp -d /tmp/et_router_home_XXXXXXXX)
+LOG_DIR=/tmp/et_test_logs/router_restart
+SERVER_LOG_DIR=$LOG_DIR/server
+
+server_pid=""
+declare -a client_pids=()
+
+cleanup() {
+  for pid in "${client_pids[@]}"; do
+    kill -9 "$pid" 2>/dev/null || true
+  done
+  [ -n "$server_pid" ] && kill -9 "$server_pid" 2>/dev/null || true
+  pkill -9 -f "etterminal.*--serverfifo=$ET_FIFO" 2>/dev/null || true
+  [ -n "$KEEP_LOGS" ] || rm -rf "$TEST_HOME" "$LOG_DIR" || true
+}
+trap cleanup EXIT
+
+wait_for_file() { # path, seconds
+  for _ in $(seq 1 "$(( $2 * 10 ))"); do
+    [ -f "$1" ] && return 0
+    sleep 0.1
+  done
+  echo "timed out waiting for file $1" >&2
+  return 1
+}
+
+wait_for_grep() { # pattern, file, seconds
+  for _ in $(seq 1 "$(( $3 * 10 ))"); do
+    grep -q "$1" "$2" 2>/dev/null && return 0
+    sleep 0.1
+  done
+  echo "timed out waiting for '$1' in $2" >&2
+  return 1
+}
+
+terminal_pids() {
+  pgrep -f "etterminal.*--serverfifo=$ET_FIFO" | sort -n | tr '\n' ' '
+}
+
+ssh -o 'PreferredAuthentications=publickey' localhost "echo" || exit 1
+ssh -o "StrictHostKeyChecking no" localhost echo "Bypassing host check"
+
+# Reap leftover fixture terminals from earlier aborted runs (with router
+# recovery they retry re-registration forever by design).
+pkill -9 -f "etterminal.*--serverfifo=$ET_FIFO" 2>/dev/null || true
+rm -rf "$LOG_DIR"
+
+mkdir -p "$SERVER_LOG_DIR"
+build/etserver --port $ET_PORT --serverfifo=$ET_FIFO -l "$SERVER_LOG_DIR" &
+server_pid=$!
+sleep 3
+
+# Two named sessions, each with a held-open stdin fifo and a sentinel.
+# script(1) gives each client a real pty for stdin (a non-tty console has
+# its input path disabled).
+for name in one two; do
+  mkfifo "$LOG_DIR/input_$name"
+  eval "exec 1$([ "$name" = one ] && echo 1 || echo 2)<>$LOG_DIR/input_$name"
+  HOME=$TEST_HOME script -qec "build/et --name $name --serverfifo=$ET_FIFO \
+    --terminal-path $PWD/build/etterminal --logtostdout \
+    localhost:$ET_PORT" /dev/null <"$LOG_DIR/input_$name" \
+    >"$LOG_DIR/client_$name.log" 2>&1 &
+  client_pids+=($!)
+  wait_for_file "$TEST_HOME/.et/sessions/$name" 30
+done
+
+printf 'S_ONE=first\n' >&11
+printf 'S_TWO=second\n' >&12
+printf 'echo READY-ONE\n' >&11
+printf 'echo READY-TWO\n' >&12
+wait_for_grep 'READY-ONE' "$LOG_DIR/client_one.log" 30
+wait_for_grep 'READY-TWO' "$LOG_DIR/client_two.log" 30
+
+pids_before=$(terminal_pids)
+[ -n "$pids_before" ] || {
+  echo "no fixture etterminal processes found" >&2
+  exit 1
+}
+count_before=$(echo $pids_before | wc -w)
+[ "$count_before" -eq 2 ] || {
+  echo "expected 2 fixture etterminals, found: $pids_before" >&2
+  exit 1
+}
+
+# Restart the router: SIGTERM, then relaunch the identical command.
+kill -TERM "$server_pid"
+wait "$server_pid" 2>/dev/null || true
+server_pid=""
+sleep 2
+build/etserver --port $ET_PORT --serverfifo=$ET_FIFO -l "$SERVER_LOG_DIR" &
+server_pid=$!
+
+# The etterminal processes (the shells) survive with identical pids.
+for _ in $(seq 1 600); do
+  pids_after=$(terminal_pids)
+  [ "$pids_after" = "$pids_before" ] && break
+  sleep 0.1
+done
+[ "$pids_after" = "$pids_before" ] || {
+  echo "etterminal pids changed: '$pids_before' -> '$pids_after'" >&2
+  exit 1
+}
+
+# Both clients reconnect on their own and the shell state survived.
+wait_for_grep 'Reconnect complete\|Reconnected' "$LOG_DIR/client_one.log" 60 || true
+printf 'echo POST-ONE-$S_ONE\n' >&11
+printf 'echo POST-TWO-$S_TWO\n' >&12
+wait_for_grep 'POST-ONE-first' "$LOG_DIR/client_one.log" 60
+wait_for_grep 'POST-TWO-second' "$LOG_DIR/client_two.log" 60
+
+# --attach still works against the restarted server.
+HOME=$TEST_HOME build/et --attach one --serverfifo=$ET_FIFO \
+  --terminal-path "$PWD/build/etterminal" --logtostdout \
+  -c 'echo ATTACH-$S_ONE' >"$LOG_DIR/attach.log" 2>&1 || true
+wait_for_grep 'ATTACH-first' "$LOG_DIR/attach.log" 60
+
+# Clean teardown of the remaining session.
+printf 'exit\n' >&12
+for _ in $(seq 1 100); do
+  [ ! -f "$TEST_HOME/.et/sessions/two" ] && break
+  sleep 0.1
+done
+
+echo "router_restart.sh: OK"

--- a/test/unit_tests/BackedIOTest.cpp
+++ b/test/unit_tests/BackedIOTest.cpp
@@ -177,6 +177,52 @@ TEST_CASE("BackedReader revive seeds local buffer", "[BackedIO]") {
   REQUIRE(reader.getSequenceNumber() == 1);
 }
 
+TEST_CASE("BackedIO reset zeroes sequences and drops buffered state",
+          "[BackedIO]") {
+  auto handler = make_shared<InMemorySocketHandler>();
+  auto encryptCrypto = make_shared<CryptoHandler>(
+      "12345678901234567890123456789012", 0 /*verbosity*/);
+  auto decryptCrypto = make_shared<CryptoHandler>(
+      "12345678901234567890123456789012", 0 /*verbosity*/);
+  const int fd = handler->createChannel();
+
+  BackedWriter writer(handler, encryptCrypto, fd);
+  BackedReader reader(handler, decryptCrypto, fd);
+
+  // Build up some history on both sides.
+  REQUIRE(writer.write(Packet(1, "one")) == BackedWriterWriteState::SUCCESS);
+  REQUIRE(writer.write(Packet(2, "two")) == BackedWriterWriteState::SUCCESS);
+  Packet output;
+  REQUIRE(reader.read(&output) == 1);
+  REQUIRE(writer.getSequenceNumber() == 2);
+  REQUIRE(reader.getSequenceNumber() == 1);
+
+  // Simulate a dead socket: new writes are buffered for replay.
+  writer.revive(-1);
+  REQUIRE(writer.write(Packet(3, "buffered")) ==
+          BackedWriterWriteState::BUFFERED_ONLY);
+
+  {
+    std::lock_guard<std::mutex> readerGuard(reader.getRecoverMutex());
+    std::lock_guard<std::mutex> writerGuard(writer.getRecoverMutex());
+    reader.reset();
+    writer.reset();
+  }
+  REQUIRE(writer.getSequenceNumber() == 0);
+  REQUIRE(reader.getSequenceNumber() == 0);
+
+  // A write after reset starts a fresh sequence at 1 and the pre-reset
+  // buffered packet is gone.
+  REQUIRE(writer.write(Packet(4, "fresh")) ==
+          BackedWriterWriteState::BUFFERED_ONLY);
+  REQUIRE(writer.getSequenceNumber() == 1);
+  auto recovered = writer.recover(0);
+  REQUIRE(recovered.size() == 1);
+  Packet replayed(recovered[0]);
+  replayed.decrypt(decryptCrypto);
+  REQUIRE(replayed.getPayload() == "fresh");
+}
+
 TEST_CASE("RawSocketUtils readAll waits for data then returns fully",
           "[RawSocketUtils]") {
   int fds[2];

--- a/test/unit_tests/ClientConnectionTest.cpp
+++ b/test/unit_tests/ClientConnectionTest.cpp
@@ -1,4 +1,5 @@
 #include <queue>
+#include <set>
 
 #include "ClientConnection.hpp"
 #include "ServerClientConnection.hpp"
@@ -55,9 +56,23 @@ class RecordingServerConnection : public ServerConnection {
     return allowNewClients;
   }
 
+  // Pretend the recovery grace window has long passed.
+  void expireGrace() { startTime_ = time(NULL) - recoveryGraceSeconds - 1; }
+
+  bool shouldResumeAsReturning(const string& clientId) override {
+    return resumeIds.count(clientId) > 0;
+  }
+
+  void resumeClient(shared_ptr<ServerClientConnection> state) override {
+    resumeClientCalled = true;
+    lastConnection = std::move(state);
+  }
+
   bool newClientCalled = false;
   bool allowNewClients = true;
   shared_ptr<ServerClientConnection> lastConnection;
+  std::set<string> resumeIds;
+  bool resumeClientCalled = false;
 };
 
 class RecoverableConnection : public Connection {
@@ -157,7 +172,8 @@ TEST_CASE("ServerConnection responds to known and unknown clients",
   endpoint.set_port(0);
   RecordingServerConnection server(handler, endpoint);
 
-  // Missing key path should return INVALID_KEY.
+  // Missing key path returns RETRY_LATER while the server is still within
+  // its post-startup recovery grace window.
   int firstPair[2];
   REQUIRE(::socketpair(AF_UNIX, SOCK_STREAM, 0, firstPair) == 0);
   ConnectRequest missingKeyRequest;
@@ -167,9 +183,21 @@ TEST_CASE("ServerConnection responds to known and unknown clients",
   server.clientHandler(firstPair[1]);
   auto missingKeyResponse =
       handler->readProto<ConnectResponse>(firstPair[0], true);
-  REQUIRE(missingKeyResponse.status() == INVALID_KEY);
+  REQUIRE(missingKeyResponse.status() == RETRY_LATER);
   handler->close(firstPair[0]);
   handler->close(firstPair[1]);
+
+  // Past the grace window an unknown id is a hard INVALID_KEY.
+  server.expireGrace();
+  int gracePair[2];
+  REQUIRE(::socketpair(AF_UNIX, SOCK_STREAM, 0, gracePair) == 0);
+  handler->writeProto(gracePair[0], missingKeyRequest, true);
+  server.clientHandler(gracePair[1]);
+  auto expiredGraceResponse =
+      handler->readProto<ConnectResponse>(gracePair[0], true);
+  REQUIRE(expiredGraceResponse.status() == INVALID_KEY);
+  handler->close(gracePair[0]);
+  handler->close(gracePair[1]);
 
   // Known key path should trigger newClient callback and NEW_CLIENT status.
   const string clientKey = "0123456789abcdef0123456789abcdef";
@@ -195,6 +223,60 @@ TEST_CASE("ServerConnection responds to known and unknown clients",
   handler->close(secondPair[0]);
   handler->close(secondPair[1]);
   server.shutdown();
+}
+
+TEST_CASE("ServerConnection resumes sessions with an active pty",
+          "[ServerConnection]") {
+  auto handler = make_shared<SocketPairHandler>();
+  SocketEndpoint endpoint;
+  endpoint.set_name("server");
+  endpoint.set_port(0);
+  RecordingServerConnection server(handler, endpoint);
+
+  // The terminal re-registered with a live pty: the key exists, no
+  // connection survived, and shouldResumeAsReturning says the pty is active.
+  const string clientKey = "0123456789abcdef0123456789abcdef";
+  server.addClientKey("live-term", clientKey);
+  server.resumeIds.insert("live-term");
+
+  int fds[2];
+  REQUIRE(::socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == 0);
+
+  std::thread client([&]() {
+    ConnectRequest request;
+    request.set_clientid("live-term");
+    request.set_version(PROTOCOL_VERSION);
+    handler->writeProto(fds[0], request, true);
+
+    auto response = handler->readProto<ConnectResponse>(fds[0], true);
+    REQUIRE(response.status() == RETURNING_CLIENT);
+
+    // The server initiates the reset recovery exchange.
+    auto seqHeader = handler->readProto<SequenceHeader>(
+        fds[0], true, SocketHandler::MAX_HANDSHAKE_PROTO_LENGTH);
+    REQUIRE(seqHeader.sequencenumber() == 0);
+    REQUIRE(seqHeader.reset());
+    SequenceHeader seqResponse;
+    seqResponse.set_sequencenumber(0);
+    seqResponse.set_reset(true);
+    handler->writeProto(fds[0], seqResponse, true);
+    auto catchup = handler->readProto<CatchupBuffer>(fds[0], true);
+    REQUIRE(catchup.buffer_size() == 0);
+    CatchupBuffer back;
+    handler->writeProto(fds[0], back, true);
+  });
+
+  server.clientHandler(fds[1]);
+  client.join();
+
+  // Resume path taken, not the fresh-bootstrap newClient path.
+  REQUIRE(server.resumeClientCalled);
+  REQUIRE_FALSE(server.newClientCalled);
+  REQUIRE(server.clientConnectionExists("live-term"));
+
+  server.shutdown();
+  handler->close(fds[0]);
+  handler->close(fds[1]);
 }
 
 TEST_CASE("ServerClientConnection verifies passkeys",

--- a/test/unit_tests/ClientConnectionTest.cpp
+++ b/test/unit_tests/ClientConnectionTest.cpp
@@ -71,7 +71,9 @@ class RecoverableConnection : public Connection {
     socketFd = fd;
   }
 
-  bool recoverPublic(int fd) { return recover(fd); }
+  bool recoverPublic(int fd, bool forceReset = false) {
+    return recover(fd, forceReset);
+  }
 
   void closeSocketAndMaybeReconnect() override { closeSocket(); }
 };
@@ -98,9 +100,23 @@ TEST_CASE("ClientConnection completes handshake over socketpair",
     ConnectResponse response;
     response.set_status(RETURNING_CLIENT);
     handler->writeProto(fds[1], response, true);
+
+    // The returning client starts a reset recovery exchange.
+    auto seqHeader = handler->readProto<SequenceHeader>(
+        fds[1], true, SocketHandler::MAX_HANDSHAKE_PROTO_LENGTH);
+    REQUIRE(seqHeader.reset());
+    SequenceHeader seqResponse;
+    seqResponse.set_sequencenumber(0);
+    seqResponse.set_reset(true);
+    handler->writeProto(fds[1], seqResponse, true);
+    auto catchup = handler->readProto<CatchupBuffer>(fds[1], true);
+    REQUIRE(catchup.buffer_size() == 0);
+    CatchupBuffer back;
+    handler->writeProto(fds[1], back, true);
   });
 
   REQUIRE(conn.connect());
+  REQUIRE(conn.wasRecovered());
 
   server.join();
   conn.shutdown();
@@ -310,4 +326,110 @@ TEST_CASE("Connection recover exchanges sequence and catchup", "[Connection]") {
   handler->close(live[1]);
   handler->close(reconnect[0]);
   remote.join();
+}
+
+TEST_CASE("Connection recover with forceReset performs clean reset exchange",
+          "[Connection]") {
+  auto handler = make_shared<SocketPairHandler>();
+  int live[2];
+  REQUIRE(::socketpair(AF_UNIX, SOCK_STREAM, 0, live) == 0);
+
+  const string key = "zyxwvutsrqponmlkjihgfedcba987654";
+  auto encryptCrypto = make_shared<CryptoHandler>(key, 0);
+  auto decryptCrypto = make_shared<CryptoHandler>(key, 0);
+
+  auto reader = make_shared<BackedReader>(handler, decryptCrypto, live[0]);
+  auto writer = make_shared<BackedWriter>(handler, encryptCrypto, live[0]);
+  RecoverableConnection conn(handler, reader, writer, live[0], key);
+
+  conn.write(Packet(1, "first"));
+  conn.write(Packet(2, "second"));
+  conn.closeSocket();
+
+  int reconnect[2];
+  REQUIRE(::socketpair(AF_UNIX, SOCK_STREAM, 0, reconnect) == 0);
+
+  std::thread remote([&]() {
+    auto seqHeader = handler->readProto<SequenceHeader>(
+        reconnect[1], true, SocketHandler::MAX_HANDSHAKE_PROTO_LENGTH);
+    REQUIRE(seqHeader.sequencenumber() == 0);
+    REQUIRE(seqHeader.reset());
+
+    // The remote peer is further ahead; with a reset its history is
+    // discarded, so this must not trigger a "client is ahead" failure.
+    SequenceHeader seqResponse;
+    seqResponse.set_sequencenumber(5);
+    seqResponse.set_reset(true);
+    handler->writeProto(reconnect[1], seqResponse, true);
+
+    auto catchup = handler->readProto<CatchupBuffer>(reconnect[1], true);
+    REQUIRE(catchup.buffer_size() == 0);
+    CatchupBuffer back;
+    handler->writeProto(reconnect[1], back, true);
+  });
+
+  REQUIRE(conn.recoverPublic(reconnect[0], true));
+  remote.join();
+
+  REQUIRE(conn.getReader()->getSequenceNumber() == 0);
+  REQUIRE(conn.getWriter()->getSequenceNumber() == 0);
+  // A write after reset starts a fresh sequence at 1.
+  conn.write(Packet(3, "after-reset"));
+  REQUIRE(conn.getWriter()->getSequenceNumber() == 1);
+}
+
+TEST_CASE(
+    "ClientConnection connect performs reset recovery for returning "
+    "clients",
+    "[ClientConnection]") {
+  auto handler = make_shared<SocketPairHandler>();
+  const string key = "zyxwvutsrqponmlkjihgfedcba987654";
+
+  // A server-side connection with existing history: the old client exited,
+  // but the server state (and its buffered output) survives.
+  int live[2];
+  REQUIRE(::socketpair(AF_UNIX, SOCK_STREAM, 0, live) == 0);
+  ServerClientConnection serverConn(handler, "client-id", live[0], key);
+  serverConn.writePacket(Packet(1, "pre-existing-output"));
+
+  // The old client disconnects.
+  handler->close(live[1]);
+
+  // A fresh client process connects with the same id.
+  int reconnect[2];
+  REQUIRE(::socketpair(AF_UNIX, SOCK_STREAM, 0, reconnect) == 0);
+  handler->queueConnectFd(reconnect[0]);
+  ClientConnection client(handler, SocketEndpoint(), "client-id", key);
+
+  std::thread server([&]() {
+    auto request = handler->readProto<ConnectRequest>(reconnect[1], true);
+    REQUIRE(request.clientid() == "client-id");
+    ConnectResponse response;
+    response.set_status(RETURNING_CLIENT);
+    handler->writeProto(reconnect[1], response, true);
+    // The client's reset request makes the server take the reset path too.
+    REQUIRE(serverConn.recoverClient(reconnect[1]));
+  });
+
+  REQUIRE(client.connect());
+  REQUIRE(client.wasRecovered());
+  server.join();
+
+  // Pre-reset output was dropped by the reset (covered at the BackedIO
+  // level); fresh data flows in both directions from here.
+
+  client.writePacket(Packet(10, "hello"));
+  Packet serverGot;
+  REQUIRE(serverConn.readPacket(&serverGot));
+  REQUIRE(serverGot.getPayload() == "hello");
+
+  serverConn.writePacket(Packet(20, "hi-back"));
+  Packet clientGot;
+  REQUIRE(client.readPacket(&clientGot));
+  REQUIRE(clientGot.getPayload() == "hi-back");
+
+  client.shutdown();
+  serverConn.shutdown();
+  handler->close(live[0]);
+  handler->close(reconnect[1]);
 }

--- a/test/unit_tests/SessionStoreTest.cpp
+++ b/test/unit_tests/SessionStoreTest.cpp
@@ -1,0 +1,230 @@
+#include <ftw.h>
+
+#include <optional>
+
+#include "SessionStore.hpp"
+#include "TestHeaders.hpp"
+
+using namespace et;
+
+namespace {
+
+int RemoveDirectory(const char* path) {
+  // Use posix file tree walk to traverse the directory and remove the contents.
+  return nftw(
+      path,
+      [](const char* fpath, const struct stat* sb, int typeflag,
+         struct FTW* ftwbuf) { return ::remove(fpath); },
+      64,  // Maximum open fds.
+      FTW_DEPTH | FTW_PHYS);
+}
+
+class TestEnvironment {
+ public:
+  string createTempDir() {
+    string tmpPath = GetTempDirectory() + string("et_session_XXXXXXXX");
+    const string dir = string(mkdtemp(&tmpPath[0]));
+
+    temporaryDirs.push_back(dir);
+    return dir;
+  }
+
+  mode_t fileMode(const string& path) {
+    struct stat fileStat;
+    if (::stat(path.c_str(), &fileStat) != 0) {
+      return 0;
+    }
+    return fileStat.st_mode & 0777;
+  }
+
+  // Codespaces and similar environments may enforce additional ACLs, so verify
+  // that the permissions are less than a certain maximum. See
+  // https://github.community/t/bug-umask-does-not-seem-to-be-respected/129638
+  void requireModeLessPrivilegedThan(const string& path, mode_t highestMode) {
+    const mode_t mode = fileMode(path);
+    INFO("path=" << path << " mode=" << oct << mode);
+    REQUIRE((mode & highestMode) == mode);
+  }
+
+  string setHomeDir(const string& newHome) {
+    backupEnv("HOME");
+    ::setenv("HOME", newHome.c_str(), 1);
+    return newHome;
+  }
+
+  ~TestEnvironment() {
+    for (const string& dir : temporaryDirs) {
+      const int removeResult = RemoveDirectory(dir.c_str());
+      if (removeResult == -1) {
+        LOG(ERROR) << "Error when removing dir: " << dir;
+        FATAL_FAIL(removeResult);
+      }
+    }
+
+    for (const auto& [key, value] : savedEnvs) {
+      if (value) {
+        ::setenv(key.c_str(), value->c_str(), 1);
+      } else {
+        ::unsetenv(key.c_str());
+      }
+    }
+  }
+
+ private:
+  void backupEnv(const char* name) {
+    if (savedEnvs.count(name)) {
+      return;
+    }
+    const char* previousValue = ::getenv(name);
+    if (previousValue) {
+      savedEnvs[string(name)] = string(previousValue);
+    } else {
+      savedEnvs[string(name)] = std::nullopt;
+    }
+  }
+
+  vector<string> temporaryDirs;
+  map<string, optional<string>> savedEnvs;
+};
+
+SessionInfo makeInfo(const string& name, const string& host = "nas",
+                     int port = 2022, const string& id = "client-id",
+                     const string& passkey = string(32, 'k')) {
+  SessionInfo info;
+  info.name = name;
+  info.host = host;
+  info.port = port;
+  info.id = id;
+  info.passkey = passkey;
+  info.savedAt = 1755645600;
+  return info;
+}
+
+}  // namespace
+
+TEST_CASE("SessionStore name validation", "[SessionStore]") {
+  REQUIRE(isValidSessionName("alpha"));
+  REQUIRE(isValidSessionName("a"));
+  REQUIRE(isValidSessionName("my-session_1.2"));
+  REQUIRE(isValidSessionName("nas-20260820-060421"));
+  // Max length is 63 characters total.
+  REQUIRE(isValidSessionName(string(63, 'a')));
+  REQUIRE_FALSE(isValidSessionName(""));
+  REQUIRE_FALSE(isValidSessionName(string(64, 'a')));
+  REQUIRE_FALSE(isValidSessionName("-leading-dash"));
+  REQUIRE_FALSE(isValidSessionName("./relative"));
+  REQUIRE_FALSE(isValidSessionName("../escape"));
+  REQUIRE_FALSE(isValidSessionName("with/slash"));
+  REQUIRE_FALSE(isValidSessionName("with space"));
+  REQUIRE_FALSE(isValidSessionName("colon:name"));
+  REQUIRE_FALSE(isValidSessionName("\nnewline"));
+}
+
+TEST_CASE("SessionStore save/load round trip", "[SessionStore]") {
+  TestEnvironment env;
+  const string home = env.setHomeDir(env.createTempDir());
+
+  const SessionInfo info =
+      makeInfo("alpha", "10.0.0.5", 9922, "id-abc", string(32, 'p'));
+  saveSession(info);
+
+  const optional<SessionInfo> loaded = loadSession("alpha");
+  REQUIRE(loaded.has_value());
+  REQUIRE(loaded->name == "alpha");
+  REQUIRE(loaded->host == "10.0.0.5");
+  REQUIRE(loaded->port == 9922);
+  REQUIRE(loaded->id == "id-abc");
+  REQUIRE(loaded->passkey == string(32, 'p'));
+  REQUIRE(loaded->savedAt == 1755645600);
+}
+
+TEST_CASE("SessionStore file permissions", "[SessionStore]") {
+  if (::geteuid() == 0) {
+    WARN("Test running as root: Skipping test");
+    return;
+  }
+  TestEnvironment env;
+  const string home = env.setHomeDir(env.createTempDir());
+
+  saveSession(makeInfo("secret"));
+
+  env.requireModeLessPrivilegedThan(home + "/.et", 0700);
+  env.requireModeLessPrivilegedThan(home + "/.et/sessions", 0700);
+  env.requireModeLessPrivilegedThan(home + "/.et/sessions/secret", 0600);
+}
+
+TEST_CASE("SessionStore load missing and invalid names", "[SessionStore]") {
+  TestEnvironment env;
+  env.setHomeDir(env.createTempDir());
+
+  REQUIRE_FALSE(loadSession("nope").has_value());
+  // Invalid names never touch the filesystem.
+  REQUIRE_FALSE(loadSession("../escape").has_value());
+  REQUIRE_FALSE(loadSession("").has_value());
+}
+
+TEST_CASE("SessionStore delete removes file", "[SessionStore]") {
+  TestEnvironment env;
+  const string home = env.setHomeDir(env.createTempDir());
+
+  saveSession(makeInfo("alpha"));
+  REQUIRE(loadSession("alpha").has_value());
+
+  deleteSession("alpha");
+  REQUIRE_FALSE(loadSession("alpha").has_value());
+  // Deleting a nonexistent session is a no-op.
+  deleteSession("alpha");
+}
+
+TEST_CASE("SessionStore list is sorted and skips corrupt entries",
+          "[SessionStore]") {
+  TestEnvironment env;
+  const string home = env.setHomeDir(env.createTempDir());
+
+  saveSession(makeInfo("zeta"));
+  saveSession(makeInfo("alpha"));
+  saveSession(makeInfo("mid"));
+
+  // Corrupt and non-session files must be skipped, not fatal.
+  const string dir = home + "/.et/sessions";
+  {
+    FILE* f = fopen((dir + "/broken").c_str(), "w");
+    REQUIRE(f != nullptr);
+    fprintf(f, "not a session file\n");
+    fclose(f);
+  }
+  {
+    FILE* f = fopen((dir + "/badversion").c_str(), "w");
+    REQUIRE(f != nullptr);
+    fprintf(f, "version=99\nname=badversion\n");
+    fclose(f);
+  }
+
+  vector<SessionInfo> sessions = listSessions();
+  REQUIRE(sessions.size() == 3);
+  REQUIRE(sessions[0].name == "alpha");
+  REQUIRE(sessions[1].name == "mid");
+  REQUIRE(sessions[2].name == "zeta");
+}
+
+TEST_CASE("SessionStore save over existing name replaces atomically",
+          "[SessionStore]") {
+  TestEnvironment env;
+  env.setHomeDir(env.createTempDir());
+
+  saveSession(makeInfo("alpha", "old-host"));
+  saveSession(makeInfo("alpha", "new-host"));
+
+  const optional<SessionInfo> loaded = loadSession("alpha");
+  REQUIRE(loaded.has_value());
+  REQUIRE(loaded->host == "new-host");
+
+  const vector<SessionInfo> sessions = listSessions();
+  REQUIRE(sessions.size() == 1);
+}
+
+TEST_CASE("SessionStore list on missing directory is empty", "[SessionStore]") {
+  TestEnvironment env;
+  env.setHomeDir(env.createTempDir());
+  REQUIRE(listSessions().empty());
+}

--- a/test/unit_tests/UserTerminalRouterTest.cpp
+++ b/test/unit_tests/UserTerminalRouterTest.cpp
@@ -79,4 +79,141 @@ TEST_CASE("UserTerminalRouter getSocketHandler returns handler",
   FATAL_FAIL(::remove(pipeDirectory.c_str()));
 }
 
+namespace {
+// Registers a fake terminal with the router over the pipe endpoint, exactly
+// like UserTerminalHandler::registerWithRouter does.  Returns the terminal
+// side fd and the accepted id/key pair via the out parameters.
+int registerFakeTerminal(shared_ptr<PipeSocketHandler> socketHandler,
+                         UserTerminalRouter& router,
+                         const SocketEndpoint& routerEndpoint, const string& id,
+                         const string& passkey, bool ptyActive,
+                         IdKeyPair* accepted) {
+  int terminalFd = socketHandler->connect(routerEndpoint);
+  REQUIRE(terminalFd >= 0);
+  TerminalUserInfo tui;
+  tui.set_id(id);
+  tui.set_passkey(passkey);
+  tui.set_uid(getuid());
+  tui.set_gid(getgid());
+  tui.set_ptyactive(ptyActive);
+  socketHandler->writePacket(
+      terminalFd,
+      Packet(TerminalPacketType::TERMINAL_USER_INFO, protoToString(tui)));
+  *accepted = router.acceptNewConnection();
+  return terminalFd;
+}
+}  // namespace
+
+TEST_CASE("UserTerminalRouter tracks ptyactive registrations",
+          "[UserTerminalRouter]") {
+  auto socketHandler = std::make_shared<PipeSocketHandler>();
+
+  string tmpPath =
+      GetTempDirectory() + string("et_test_router_ptyactive_XXXXXXXX");
+  string pipeDirectory = string(mkdtemp(&tmpPath[0]));
+  string pipePath = pipeDirectory + "/router_pipe";
+
+  SocketEndpoint routerEndpoint;
+  routerEndpoint.set_name(pipePath);
+
+  UserTerminalRouter router(socketHandler, routerEndpoint);
+  REQUIRE_FALSE(router.isPtyActive("missing"));
+
+  IdKeyPair accepted;
+  int fdA = registerFakeTerminal(socketHandler, router, routerEndpoint,
+                                 "term-a", "key-a", false, &accepted);
+  REQUIRE(accepted.id == "term-a");
+  REQUIRE(accepted.key == "key-a");
+  REQUIRE_FALSE(router.isPtyActive("term-a"));
+
+  int fdB = registerFakeTerminal(socketHandler, router, routerEndpoint,
+                                 "term-b", "key-b", true, &accepted);
+  REQUIRE(accepted.id == "term-b");
+  REQUIRE(router.isPtyActive("term-b"));
+
+  socketHandler->close(fdA);
+  socketHandler->close(fdB);
+  socketHandler->close(router.getServerFd());
+  FATAL_FAIL(::remove(pipePath.c_str()));
+  FATAL_FAIL(::remove(pipeDirectory.c_str()));
+}
+
+TEST_CASE("UserTerminalRouter replaces dead registrations only",
+          "[UserTerminalRouter]") {
+  auto socketHandler = std::make_shared<PipeSocketHandler>();
+
+  string tmpPath =
+      GetTempDirectory() + string("et_test_router_replace_XXXXXXXX");
+  string pipeDirectory = string(mkdtemp(&tmpPath[0]));
+  string pipePath = pipeDirectory + "/router_pipe";
+
+  SocketEndpoint routerEndpoint;
+  routerEndpoint.set_name(pipePath);
+
+  UserTerminalRouter router(socketHandler, routerEndpoint);
+
+  IdKeyPair accepted;
+  int fdOwner = registerFakeTerminal(socketHandler, router, routerEndpoint,
+                                     "term", "owner-key", true, &accepted);
+  REQUIRE(accepted.id == "term");
+  REQUIRE(accepted.key == "owner-key");
+
+  // A duplicate registration while the owner is live is rejected, and the
+  // original registration (and its key) stays in place.
+  int fdDup = registerFakeTerminal(socketHandler, router, routerEndpoint,
+                                   "term", "attacker-key", true, &accepted);
+  REQUIRE(accepted.id == "");
+  REQUIRE(router.isPtyActive("term"));
+  // The router closed the rejected duplicate's fd.
+  socketHandler->close(fdDup);
+
+  // Once the owner's pipe dies, the same id can register again (this is the
+  // re-attach path after the connection dropped without the session ending).
+  socketHandler->close(fdOwner);
+  int fdNew = registerFakeTerminal(socketHandler, router, routerEndpoint,
+                                   "term", "owner-key", true, &accepted);
+  REQUIRE(accepted.id == "term");
+  REQUIRE(accepted.key == "owner-key");
+  REQUIRE(router.isPtyActive("term"));
+
+  socketHandler->close(fdNew);
+  socketHandler->close(router.getServerFd());
+  FATAL_FAIL(::remove(pipePath.c_str()));
+  FATAL_FAIL(::remove(pipeDirectory.c_str()));
+}
+
+TEST_CASE("UserTerminalRouter removeTerminal frees the id",
+          "[UserTerminalRouter]") {
+  auto socketHandler = std::make_shared<PipeSocketHandler>();
+
+  string tmpPath =
+      GetTempDirectory() + string("et_test_router_remove_XXXXXXXX");
+  string pipeDirectory = string(mkdtemp(&tmpPath[0]));
+  string pipePath = pipeDirectory + "/router_pipe";
+
+  SocketEndpoint routerEndpoint;
+  routerEndpoint.set_name(pipePath);
+
+  UserTerminalRouter router(socketHandler, routerEndpoint);
+
+  IdKeyPair accepted;
+  int fdOwner = registerFakeTerminal(socketHandler, router, routerEndpoint,
+                                     "term", "owner-key", true, &accepted);
+  REQUIRE(accepted.id == "term");
+
+  router.removeTerminal("term");
+  REQUIRE_FALSE(router.isPtyActive("term"));
+
+  // Even with the old pipe still open, the id is free again.
+  int fdNew = registerFakeTerminal(socketHandler, router, routerEndpoint,
+                                   "term", "owner-key", true, &accepted);
+  REQUIRE(accepted.id == "term");
+
+  socketHandler->close(fdOwner);
+  socketHandler->close(fdNew);
+  socketHandler->close(router.getServerFd());
+  FATAL_FAIL(::remove(pipePath.c_str()));
+  FATAL_FAIL(::remove(pipeDirectory.c_str()));
+}
+
 #endif


### PR DESCRIPTION
These were opened in error. My b.

## Summary

Makes sessions survive an `etserver` restart (package upgrades, `systemctl restart et.service`, crashes). Today a restart kills every `etterminal` with "Router has ended abruptly. Killing terminal session." and all work is lost.

Stacked on #793 (named sessions); only the second commit is new here.

**etterminal side.** When the router connection drops, `UserTerminalHandler` keeps the pty and its shell alive and retries the server fifo with bounded backoff (1 s doubling to 10 s), re-registering with the same id/passkey. While the router is gone the pty master is not drained, so shell output is backpressured by the kernel pty buffer instead of being lost; input buffered for the pty is kept and drained after the reconnect.

**etserver side.**
- `TerminalUserInfo` gains `ptyactive`. A terminal that re-registers with its pty already running is resumed, not bootstrapped: the server answers `RETURNING_CLIENT`, runs the reset recovery handshake from #793, and spawns the pump directly (no `INITIAL_PAYLOAD`/`INITIAL_RESPONSE`/`TERMINAL_INIT` re-exchange).
- Unknown client ids get `RETRY_LATER` (new `ConnectStatus`) during the first 60 s after etserver startup instead of `INVALID_KEY`, giving terminals time to re-register. After the window the behavior is unchanged.
- `UserTerminalRouter` replaces a duplicate registration when the previous owner's pipe is dead (EOF detected with `MSG_PEEK`, no data consumed); a live owner is always kept. Terminal registrations are removed when the terminal side ends the session, fixing the stale-entry leak behind #428.
- New `TerminalServer::shutdownConnections()` / `UserTerminalRouter::shutdown()` give a clean close path: remote ends observe EOF exactly as if the process died.
- `ServerConnection::shutdown()` no longer holds `classMutex` while joining the handler pool (AB-BA deadlock with an in-flight `clientHandler`).
- `ServerClientConnection::recoverClient` no longer closes the live fd when recovering onto the fd the connection was just constructed with (the resume path).

**Client side.** `pollReconnect` and the initial `connect()` treat `RETRY_LATER` as a quiet retry, and the `ConnectResponse` wait is bounded (5 s) so a server that accepted into its listen backlog but never answers cannot wedge the client.

Jumphost sessions are not resumed after a server restart; they get `NEW_CLIENT` as today.

## Test plan

- New `RouterRestartTest` integration suite (in-process etserver kill + replacement on the same pipe paths): session survives with data flowing both ways after the restart; bytes produced during the outage arrive in order with no loss or duplication (backpressure semantics); 14 concurrent sessions re-register and recover (the count from a real incident); a real `forkpty` child keeps its pid across the restart and answers commands after it.
- Extended `UserTerminalRouterTest` (ptyactive tracking, dead-owner replacement, live-owner rejection, `removeTerminal`) and `ClientConnectionTest` (grace window `RETRY_LATER` then `INVALID_KEY`, server-side resume handshake).
- New system test `test/system_tests/router_restart.sh` (wired into `linux_ci.yml`): two named sessions against a fixture etserver, SIGTERM + relaunch, asserts the etterminal pids are unchanged, sentinels survive, clients reconnect on their own, and `--attach` works against the restarted server.
- Full `ctest` suite green (174 tests), plus macOS build parity.

**Session file lifecycle fix (follow-up commit).** The saved session file is now deleted only when the server reports the session is gone (`INVALID_KEY` after the remote shell exits). Console EOF (terminal window closed), signals, and crashes keep the file, since the remote shell outlives them. Previously a clean client exit always deleted the file, which raced with reboot-time pty teardown and could lose the only handle to a live session.
