### PR TITLE
Stop a stuck client reconnect from blocking every new connection

### DIFF
--- a/etc/et.cfg
+++ b/etc/et.cfg
@@ -4,6 +4,8 @@
 [Networking]
 port = 2022
 # bind_ip = 0.0.0.0
+# Depth of the kernel accept queue. Raise it if many clients reconnect at once.
+# backlog = 128
 
 [Debug]
 verbose = 0

--- a/etc/et.cfg
+++ b/etc/et.cfg
@@ -4,7 +4,8 @@
 [Networking]
 port = 2022
 # bind_ip = 0.0.0.0
-# Depth of the kernel accept queue. Raise it if many clients reconnect at once.
+# Depth of the kernel accept queue (the listen(2) backlog). Raise it if many
+# clients reconnect at once. Linux truncates this to net.core.somaxconn.
 # backlog = 128
 
 [Debug]

--- a/src/base/Connection.cpp
+++ b/src/base/Connection.cpp
@@ -105,6 +105,13 @@ void Connection::closeSocket() {
 bool Connection::recover(int newSocketFd) {
   LOG(INFO) << "Locking reader/writer to recover...";
   lock_guard<std::recursive_mutex> guard(connectionMutex);
+  if (shuttingDown) {
+    // The session was torn down while this reconnect was in flight. Reviving
+    // the reader/writer here would resurrect a dead connection.
+    LOG(INFO) << "Not recovering: connection is shutting down";
+    socketHandler->close(newSocketFd);
+    return false;
+  }
   lock_guard<std::mutex> readerGuard(reader->getRecoverMutex());
   lock_guard<std::mutex> writerGuard(writer->getRecoverMutex());
   LOG(INFO) << "Recovering with socket fd " << newSocketFd << "...";

--- a/src/base/Headers.hpp
+++ b/src/base/Headers.hpp
@@ -182,6 +182,11 @@ const int MAX_CLIENT_KEEP_ALIVE_DURATION = 5;
 // allow enough time.
 const int SERVER_KEEP_ALIVE_DURATION = 11;
 
+// A client sends its initial payload immediately after the handshake. If it
+// never arrives, no terminal was ever started, so the handler thread gives up
+// rather than waiting for a client that is not coming back.
+const int INITIAL_PAYLOAD_TIMEOUT_DURATION = 600;
+
 #if defined(__ANDROID__)
 #define STFATAL LOG(FATAL) << "No Stack Trace on Android" << endl
 

--- a/src/base/ServerClientConnection.cpp
+++ b/src/base/ServerClientConnection.cpp
@@ -25,20 +25,21 @@ ServerClientConnection::~ServerClientConnection() {
 }
 
 bool ServerClientConnection::recoverClient(int newSocketFd) {
+  // Held across the whole recovery so two reconnects for the same client cannot
+  // interleave their socket swaps. connectionMutex is recursive, so recover()
+  // re-locking it below is fine.
+  lock_guard<std::recursive_mutex> guard(connectionMutex);
+
   // Detach the live session without closing it until recover succeeds, so a
   // failed/malicious reconnect cannot force-disconnect the victim.
-  int oldSocketFd = -1;
-  {
-    lock_guard<std::recursive_mutex> guard(connectionMutex);
-    oldSocketFd = socketFd;
-    if (reader) {
-      reader->invalidateSocket();
-    }
-    if (writer) {
-      writer->invalidateSocket();
-    }
-    socketFd = -1;
+  int oldSocketFd = socketFd;
+  if (reader) {
+    reader->invalidateSocket();
   }
+  if (writer) {
+    writer->invalidateSocket();
+  }
+  socketFd = -1;
 
   bool success = recover(newSocketFd);
   if (success) {
@@ -49,7 +50,6 @@ bool ServerClientConnection::recoverClient(int newSocketFd) {
   }
 
   if (oldSocketFd != -1) {
-    lock_guard<std::recursive_mutex> guard(connectionMutex);
     socketFd = oldSocketFd;
     if (reader) {
       reader->revive(oldSocketFd, vector<string>());

--- a/src/base/ServerClientConnection.cpp
+++ b/src/base/ServerClientConnection.cpp
@@ -1,10 +1,22 @@
 #include "ServerClientConnection.hpp"
 
 namespace et {
+namespace {
+/** @brief Clears the in-flight flag however recoverClient() returns. */
+class InFlightGuard {
+ public:
+  explicit InFlightGuard(std::atomic<bool>& _flag) : flag(_flag) {}
+  ~InFlightGuard() { flag.store(false); }
+
+ private:
+  std::atomic<bool>& flag;
+};
+}  // namespace
+
 ServerClientConnection::ServerClientConnection(
     const std::shared_ptr<SocketHandler>& _socketHandler,
     const string& clientId, int _socketFd, const string& key)
-    : Connection(_socketHandler, clientId, key) {
+    : Connection(_socketHandler, clientId, key), recoveryInFlight(false) {
   socketFd = _socketFd;
   reader = shared_ptr<BackedReader>(
       new BackedReader(socketHandler,
@@ -25,6 +37,20 @@ ServerClientConnection::~ServerClientConnection() {
 }
 
 bool ServerClientConnection::recoverClient(int newSocketFd) {
+  bool idle = false;
+  if (!recoveryInFlight.compare_exchange_strong(idle, true)) {
+    // Waiting for the reconnect that is already running would hold this handler
+    // thread for as long as that one blocks, which against a silent peer is the
+    // full socket timeout. Every other client's handshake runs on the same
+    // small pool, so refusing is cheaper for everyone: a real client is between
+    // attempts of its own reconnect loop and will come back.
+    LOG(INFO) << "Refusing reconnect for " << getId()
+              << ": another one is already in flight";
+    socketHandler->close(newSocketFd);
+    return false;
+  }
+  InFlightGuard inFlightGuard(recoveryInFlight);
+
   // Held across the whole recovery so two reconnects for the same client cannot
   // interleave their socket swaps. connectionMutex is recursive, so recover()
   // re-locking it below is fine.

--- a/src/base/ServerClientConnection.hpp
+++ b/src/base/ServerClientConnection.hpp
@@ -22,6 +22,9 @@ class ServerClientConnection : public Connection {
   /**
    * @brief Attempts recovery on the new fd; closes the old socket only after
    * recover succeeds.
+   *
+   * Returns false without touching the live session if another reconnect for
+   * this client is already in flight.
    */
   bool recoverClient(int newSocketFd);
 
@@ -31,6 +34,13 @@ class ServerClientConnection : public Connection {
   bool verifyPasskey(const string& targetKey);
 
  protected:
+  /**
+   * @brief Set while a reconnect is mid-handshake.
+   *
+   * Lets a second reconnect be refused rather than queued, since queueing it
+   * would occupy a handler thread for as long as the first one blocks.
+   */
+  std::atomic<bool> recoveryInFlight;
 };
 }  // namespace et
 

--- a/src/base/ServerConnection.cpp
+++ b/src/base/ServerConnection.cpp
@@ -119,7 +119,11 @@ void ServerConnection::clientHandler(int clientSocketFd) {
       response.set_status(RETURNING_CLIENT);
       socketHandler->writeProto(clientSocketFd, response, true);
 
-      lock_guard<std::recursive_mutex> guard(classMutex);
+      // Deliberately not under classMutex: recover() blocks on socket I/O for
+      // as long as the socket timeout allows, and holding a server-wide lock
+      // across that stalls the accept loop until the reconnect gives up.
+      // serverClientState keeps the connection alive, and recoverClient()
+      // serializes concurrent reconnects on the connection's own mutex.
       serverClientState->recoverClient(clientSocketFd);
     }
   } catch (const runtime_error& err) {
@@ -141,28 +145,38 @@ void ServerConnection::clientHandler(int clientSocketFd) {
 }
 
 bool ServerConnection::removeClient(const string& id) {
-  lock_guard<std::recursive_mutex> guard(classMutex);
-  if (clientKeys.find(id) == clientKeys.end()) {
-    return false;
+  shared_ptr<ServerClientConnection> connection;
+  {
+    lock_guard<std::recursive_mutex> guard(classMutex);
+    if (clientKeys.find(id) == clientKeys.end()) {
+      return false;
+    }
+    clientKeys.erase(id);
+    const auto it = clientConnections.find(id);
+    if (it == clientConnections.end()) {
+      return true;
+    }
+    connection = it->second;
+    clientConnections.erase(it);
   }
-  clientKeys.erase(id);
-  if (clientConnections.find(id) == clientConnections.end()) {
-    return true;
-  }
-  auto connection = clientConnections[id];
+  // Outside classMutex: shutdown() waits on the connection mutex, which a
+  // reconnect can hold across blocking socket I/O.
   connection->shutdown();
-  clientConnections.erase(id);
   return true;
 }
 
 void ServerConnection::destroyPartialConnection(const string& clientId) {
-  lock_guard<std::recursive_mutex> guard(classMutex);
-  const auto it = clientConnections.find(clientId);
-  if (it == clientConnections.end()) {
-    return;
+  shared_ptr<ServerClientConnection> connection;
+  {
+    lock_guard<std::recursive_mutex> guard(classMutex);
+    const auto it = clientConnections.find(clientId);
+    if (it == clientConnections.end()) {
+      return;
+    }
+    connection = it->second;
+    clientConnections.erase(it);
   }
-  it->second->shutdown();
-  clientConnections.erase(it);
+  connection->shutdown();
 }
 
 }  // namespace et

--- a/src/base/TcpSocketHandler.cpp
+++ b/src/base/TcpSocketHandler.cpp
@@ -1,7 +1,9 @@
 #include "TcpSocketHandler.hpp"
 
 namespace et {
-TcpSocketHandler::TcpSocketHandler() {}
+TcpSocketHandler::TcpSocketHandler(int _listenBacklog)
+    : listenBacklog(_listenBacklog > 0 ? _listenBacklog
+                                       : DEFAULT_LISTEN_BACKLOG) {}
 
 int TcpSocketHandler::connect(const SocketEndpoint& endpoint) {
   lock_guard<std::recursive_mutex> guard(globalMutex);
@@ -229,7 +231,7 @@ set<int> TcpSocketHandler::listen(const SocketEndpoint& endpoint) {
     }
 
     // Listen
-    FATAL_FAIL(::listen(sockFd, 32));
+    FATAL_FAIL(::listen(sockFd, listenBacklog));
     LOG(INFO) << "Listening on "
               << inet_ntoa(((sockaddr_in*)p->ai_addr)->sin_addr) << ":" << port
               << "/" << p->ai_family << "/" << p->ai_socktype << "/"

--- a/src/base/TcpSocketHandler.cpp
+++ b/src/base/TcpSocketHandler.cpp
@@ -3,7 +3,12 @@
 namespace et {
 TcpSocketHandler::TcpSocketHandler(int _listenBacklog)
     : listenBacklog(_listenBacklog > 0 ? _listenBacklog
-                                       : DEFAULT_LISTEN_BACKLOG) {}
+                                       : DEFAULT_LISTEN_BACKLOG) {
+  if (_listenBacklog <= 0) {
+    LOG(WARNING) << "Ignoring listen backlog " << _listenBacklog << ", using "
+                 << DEFAULT_LISTEN_BACKLOG;
+  }
+}
 
 int TcpSocketHandler::connect(const SocketEndpoint& endpoint) {
   lock_guard<std::recursive_mutex> guard(globalMutex);
@@ -227,6 +232,7 @@ set<int> TcpSocketHandler::listen(const SocketEndpoint& endpoint) {
 #else
       FATAL_FAIL(::close(sockFd));
 #endif
+      freeaddrinfo(servinfo);
       throw std::runtime_error(s.c_str());
     }
 
@@ -235,7 +241,7 @@ set<int> TcpSocketHandler::listen(const SocketEndpoint& endpoint) {
     LOG(INFO) << "Listening on "
               << inet_ntoa(((sockaddr_in*)p->ai_addr)->sin_addr) << ":" << port
               << "/" << p->ai_family << "/" << p->ai_socktype << "/"
-              << p->ai_protocol;
+              << p->ai_protocol << " with backlog " << listenBacklog;
 
     // if we get here, we must have connected successfully
     serverSockets.insert(sockFd);
@@ -246,6 +252,7 @@ set<int> TcpSocketHandler::listen(const SocketEndpoint& endpoint) {
   }
 
   portServerSockets[port] = serverSockets;
+  freeaddrinfo(servinfo);
   return serverSockets;
 }
 

--- a/src/base/TcpSocketHandler.hpp
+++ b/src/base/TcpSocketHandler.hpp
@@ -10,8 +10,19 @@ namespace et {
  */
 class TcpSocketHandler : public UnixSocketHandler {
  public:
-  TcpSocketHandler();
+  /**
+   * @brief Default depth of the kernel accept queue for listening sockets.
+   *
+   * The queue only drains as fast as the accept loop runs, so it has to absorb
+   * a burst of clients reconnecting at once.
+   */
+  static constexpr int DEFAULT_LISTEN_BACKLOG = 128;
+
+  explicit TcpSocketHandler(int _listenBacklog = DEFAULT_LISTEN_BACKLOG);
   virtual ~TcpSocketHandler() {}
+
+  /** @brief Accept queue depth this handler passes to listen(). */
+  int getListenBacklog() const { return listenBacklog; }
 
   /**
    * @brief Resolves the hostname/port and connects non-blockingly to the
@@ -34,6 +45,8 @@ class TcpSocketHandler : public UnixSocketHandler {
  protected:
   /** @brief Tracks all listening sockets created per TCP port. */
   map<int, set<int>> portServerSockets;
+  /** @brief Depth of the kernel accept queue, see DEFAULT_LISTEN_BACKLOG. */
+  int listenBacklog;
 
   /**
    * @brief Performs additional TCP-specific socket configuration

--- a/src/terminal/TerminalServer.cpp
+++ b/src/terminal/TerminalServer.cpp
@@ -431,8 +431,7 @@ void TerminalServer::runTerminal(
 void TerminalServer::handleConnection(
     shared_ptr<ServerClientConnection> serverClientState) {
   Packet packet;
-  const time_t initialPayloadDeadline =
-      time(NULL) + INITIAL_PAYLOAD_TIMEOUT_DURATION;
+  const time_t initialPayloadDeadline = time(NULL) + initialPayloadTimeoutSec;
   while (!serverClientState->readPacket(&packet)) {
     bool halted;
     {

--- a/src/terminal/TerminalServer.cpp
+++ b/src/terminal/TerminalServer.cpp
@@ -434,9 +434,14 @@ void TerminalServer::handleConnection(
   const time_t initialPayloadDeadline =
       time(NULL) + INITIAL_PAYLOAD_TIMEOUT_DURATION;
   while (!serverClientState->readPacket(&packet)) {
-    // Both exits matter: without them this thread spins forever on a client
+    bool halted;
+    {
+      lock_guard<std::mutex> guard(terminalThreadMutex);
+      halted = halt;
+    }
+    // Every exit matters: without them this thread spins forever on a client
     // that never speaks, and run() blocks on join() at shutdown.
-    if (serverClientState->isShuttingDown() ||
+    if (halted || serverClientState->isShuttingDown() ||
         time(NULL) > initialPayloadDeadline) {
       LOG(WARNING) << "Giving up waiting for the initial packet from "
                    << serverClientState->getId();

--- a/src/terminal/TerminalServer.cpp
+++ b/src/terminal/TerminalServer.cpp
@@ -431,8 +431,21 @@ void TerminalServer::runTerminal(
 void TerminalServer::handleConnection(
     shared_ptr<ServerClientConnection> serverClientState) {
   Packet packet;
+  const time_t initialPayloadDeadline =
+      time(NULL) + INITIAL_PAYLOAD_TIMEOUT_DURATION;
   while (!serverClientState->readPacket(&packet)) {
-    LOG(INFO) << "Waiting for initial packet...";
+    // Both exits matter: without them this thread spins forever on a client
+    // that never speaks, and run() blocks on join() at shutdown.
+    if (serverClientState->isShuttingDown() ||
+        time(NULL) > initialPayloadDeadline) {
+      LOG(WARNING) << "Giving up waiting for the initial packet from "
+                   << serverClientState->getId();
+      string id = serverClientState->getId();
+      serverClientState.reset();
+      removeClient(id);
+      return;
+    }
+    LOG_EVERY_N(10, INFO) << "Waiting for initial packet...";
     sleep(1);
   }
   if (packet.getHeader() != EtPacketType::INITIAL_PAYLOAD) {

--- a/src/terminal/TerminalServer.hpp
+++ b/src/terminal/TerminalServer.hpp
@@ -59,6 +59,11 @@ class TerminalServer : public ServerConnection {
   bool halt = false;
 
  protected:
+  /**
+   * @brief Seconds to wait for a client's initial payload before giving up.
+   * Overridable so tests do not have to wait out the real deadline.
+   */
+  int initialPayloadTimeoutSec = INITIAL_PAYLOAD_TIMEOUT_DURATION;
   /** @brief Guards access to `terminalThreads` and the halt flag. */
   mutex terminalThreadMutex;
   /** @brief Local pipe endpoint used to signal terminal/jumphost handoffs. */

--- a/src/terminal/TerminalServerMain.cpp
+++ b/src/terminal/TerminalServerMain.cpp
@@ -78,6 +78,7 @@ int main(int argc, char** argv) {
     string maxlogsize = "20971520";
 
     int port = 0;
+    int listenBacklog = TcpSocketHandler::DEFAULT_LISTEN_BACKLOG;
     string bindIp = "";
     bool enableTelemetry = false;
     string logDirectory = GetTempDirectory();
@@ -99,6 +100,11 @@ int main(int argc, char** argv) {
           if (bindIpPtr) {
             bindIp = string(bindIpPtr);
           }
+        }
+
+        const char* backlogString = ini.GetValue("Networking", "backlog", NULL);
+        if (backlogString) {
+          listenBacklog = stoi(backlogString);
         }
 
         enableTelemetry = ini.GetBoolValue("Debug", "telemetry", false);
@@ -185,7 +191,8 @@ int main(int argc, char** argv) {
 
     serverFifo.createDirectoriesIfRequired();
 
-    std::shared_ptr<SocketHandler> tcpSocketHandler(new TcpSocketHandler());
+    std::shared_ptr<SocketHandler> tcpSocketHandler(
+        new TcpSocketHandler(listenBacklog));
     std::shared_ptr<PipeSocketHandler> pipeSocketHandler(
         new PipeSocketHandler());
 

--- a/test/integration_tests/HandleConnectionTimeoutTest.cpp
+++ b/test/integration_tests/HandleConnectionTimeoutTest.cpp
@@ -43,6 +43,22 @@ class FdSocketHandler : public SocketHandler {
   vector<int> getActiveSockets() override { return {}; }
 };
 
+// Exposes the initial-payload deadline so it can be tested without waiting out
+// the production value.
+class TestTerminalServer : public TerminalServer {
+ public:
+  TestTerminalServer(shared_ptr<SocketHandler> socketHandler,
+                     const SocketEndpoint& serverEndpoint,
+                     shared_ptr<PipeSocketHandler> pipeSocketHandler,
+                     const SocketEndpoint& routerEndpoint)
+      : TerminalServer(std::move(socketHandler), serverEndpoint,
+                       std::move(pipeSocketHandler), routerEndpoint) {}
+
+  void setInitialPayloadTimeout(int seconds) {
+    initialPayloadTimeoutSec = seconds;
+  }
+};
+
 // Owns the temp directory holding the server and router pipes.
 struct ServerFixture {
   string directory;
@@ -51,26 +67,34 @@ struct ServerFixture {
   shared_ptr<PipeSocketHandler> serverSocketHandler;
   shared_ptr<PipeSocketHandler> routerSocketHandler;
   // Heap allocated so a worker can keep it alive past this scope, see below.
-  shared_ptr<TerminalServer> server;
+  shared_ptr<TestTerminalServer> server;
+
+  SocketEndpoint serverEndpoint;
+  SocketEndpoint routerEndpoint;
 
   ServerFixture() {
     string pattern = GetTempDirectory() + string("et_handleconn_XXXXXX");
-    directory = string(mkdtemp(&pattern[0]));
+    const char* created = mkdtemp(&pattern[0]);
+    REQUIRE(created != nullptr);
+    directory = string(created);
     serverPipePath = directory + "/pipe_server";
     routerPipePath = directory + "/pipe_router";
 
     serverSocketHandler = make_shared<PipeSocketHandler>();
     routerSocketHandler = make_shared<PipeSocketHandler>();
 
-    SocketEndpoint serverEndpoint;
     serverEndpoint.set_name(serverPipePath);
-    SocketEndpoint routerEndpoint;
     routerEndpoint.set_name(routerPipePath);
-    server = make_shared<TerminalServer>(serverSocketHandler, serverEndpoint,
-                                         routerSocketHandler, routerEndpoint);
+    server =
+        make_shared<TestTerminalServer>(serverSocketHandler, serverEndpoint,
+                                        routerSocketHandler, routerEndpoint);
   }
 
   ~ServerFixture() {
+    // Both constructors above start listening; nothing else closes those
+    // sockets, since TerminalServer::shutdown() only sets the halt flag.
+    serverSocketHandler->stopListening(serverEndpoint);
+    routerSocketHandler->stopListening(routerEndpoint);
     ::remove(serverPipePath.c_str());
     ::remove(routerPipePath.c_str());
     ::rmdir(directory.c_str());
@@ -110,6 +134,21 @@ struct HandleConnectionRun {
     return true;
   }
 };
+
+// A live but silent client: the socket stays open and nothing ever arrives on
+// it, which is the state that used to keep the thread looping forever. The
+// connection gets its own handler because UnixSocketHandler refuses
+// descriptors it did not create.
+shared_ptr<ServerClientConnection> makeSilentClient(int fds[2]) {
+  REQUIRE(::socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == 0);
+  // Non-blocking, as initSocket() leaves every socket the server owns. A
+  // blocking descriptor would park BackedReader::read() instead of reporting
+  // that no data is available.
+  REQUIRE(::fcntl(fds[0], F_SETFL, O_NONBLOCK) == 0);
+  return make_shared<ServerClientConnection>(
+      make_shared<FdSocketHandler>(), "silent-client", fds[0],
+      "abcdefghijklmnopqrstuvwxyz012345");
+}
 }  // namespace
 
 TEST_CASE("handleConnection returns when the connection is shutting down",
@@ -119,6 +158,7 @@ TEST_CASE("handleConnection returns when the connection is shutting down",
   auto connection = make_shared<ServerClientConnection>(
       fixture.serverSocketHandler, "shutdown-client", -1,
       "abcdefghijklmnopqrstuvwxyz012345");
+
   connection->shutdown();
 
   HandleConnectionRun run(fixture.server, connection);
@@ -129,15 +169,8 @@ TEST_CASE("handleConnection returns when the server is halted",
           "[HandleConnectionTimeout][integration]") {
   ServerFixture fixture;
 
-  // A live but silent client: the socket stays open and nothing ever arrives on
-  // it, which is the state that used to keep the thread looping forever.
   int fds[2] = {-1, -1};
-  REQUIRE(::socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == 0);
-  // Non-blocking, as initSocket() leaves every socket the server owns.
-  REQUIRE(::fcntl(fds[0], F_SETFL, O_NONBLOCK) == 0);
-  auto connection = make_shared<ServerClientConnection>(
-      make_shared<FdSocketHandler>(), "silent-client", fds[0],
-      "abcdefghijklmnopqrstuvwxyz012345");
+  auto connection = makeSilentClient(fds);
 
   fixture.server->shutdown();
 
@@ -147,6 +180,25 @@ TEST_CASE("handleConnection returns when the server is halted",
   if (returned) {
     // Only safe once handleConnection() is done, since shutdown() waits on the
     // mutex it holds. Skipping it on failure keeps teardown from hanging.
+    connection->shutdown();
+  }
+  ::close(fds[1]);
+  REQUIRE(returned);
+}
+
+TEST_CASE("handleConnection gives up on a client that never sends a payload",
+          "[HandleConnectionTimeout][integration]") {
+  ServerFixture fixture;
+  fixture.server->setInitialPayloadTimeout(1);
+
+  int fds[2] = {-1, -1};
+  auto connection = makeSilentClient(fds);
+
+  // Neither halted nor shutting down, so only the deadline can end this wait.
+  HandleConnectionRun run(fixture.server, connection);
+  const bool returned = run.returnedWithin(std::chrono::seconds(10));
+
+  if (returned) {
     connection->shutdown();
   }
   ::close(fds[1]);

--- a/test/integration_tests/HandleConnectionTimeoutTest.cpp
+++ b/test/integration_tests/HandleConnectionTimeoutTest.cpp
@@ -4,6 +4,8 @@
  * never speaks, and run() never finishes joining it at shutdown.
  */
 
+#include <fcntl.h>
+#include <sys/socket.h>
 #include <unistd.h>
 
 #include <chrono>
@@ -17,53 +19,136 @@
 
 using namespace et;
 
+namespace {
+// Reads and writes raw descriptors, so a plain socketpair can stand in for a
+// connected client. UnixSocketHandler refuses descriptors it did not create.
+class FdSocketHandler : public SocketHandler {
+ public:
+  bool hasData(int fd) override { return waitOnSocketData(fd); }
+
+  ssize_t read(int fd, void* buf, size_t count) override {
+    return ::read(fd, buf, count);
+  }
+
+  ssize_t write(int fd, const void* buf, size_t count) override {
+    return ::write(fd, buf, count);
+  }
+
+  int connect(const SocketEndpoint&) override { return -1; }
+  set<int> listen(const SocketEndpoint&) override { return {}; }
+  set<int> getEndpointFds(const SocketEndpoint&) override { return {}; }
+  int accept(int) override { return -1; }
+  void stopListening(const SocketEndpoint&) override {}
+  void close(int fd) override { ::close(fd); }
+  vector<int> getActiveSockets() override { return {}; }
+};
+
+// Owns the temp directory holding the server and router pipes.
+struct ServerFixture {
+  string directory;
+  string serverPipePath;
+  string routerPipePath;
+  shared_ptr<PipeSocketHandler> serverSocketHandler;
+  shared_ptr<PipeSocketHandler> routerSocketHandler;
+  // Heap allocated so a worker can keep it alive past this scope, see below.
+  shared_ptr<TerminalServer> server;
+
+  ServerFixture() {
+    string pattern = GetTempDirectory() + string("et_handleconn_XXXXXX");
+    directory = string(mkdtemp(&pattern[0]));
+    serverPipePath = directory + "/pipe_server";
+    routerPipePath = directory + "/pipe_router";
+
+    serverSocketHandler = make_shared<PipeSocketHandler>();
+    routerSocketHandler = make_shared<PipeSocketHandler>();
+
+    SocketEndpoint serverEndpoint;
+    serverEndpoint.set_name(serverPipePath);
+    SocketEndpoint routerEndpoint;
+    routerEndpoint.set_name(routerPipePath);
+    server = make_shared<TerminalServer>(serverSocketHandler, serverEndpoint,
+                                         routerSocketHandler, routerEndpoint);
+  }
+
+  ~ServerFixture() {
+    ::remove(serverPipePath.c_str());
+    ::remove(routerPipePath.c_str());
+    ::rmdir(directory.c_str());
+  }
+};
+
+// Runs handleConnection() on its own thread and reports whether it returned
+// within the deadline. A regression makes it never return, so the worker is
+// detached rather than joined on failure: that lets the suite report the
+// failure instead of hanging, and the worker owns shared_ptrs to everything it
+// touches, so leaking it stays safe.
+struct HandleConnectionRun {
+  shared_ptr<std::promise<void>> finished = make_shared<std::promise<void>>();
+  std::future<void> future = finished->get_future();
+  std::thread worker;
+
+  HandleConnectionRun(shared_ptr<TerminalServer> server,
+                      shared_ptr<ServerClientConnection> connection) {
+    auto done = finished;
+    worker = std::thread([server, connection, done]() {
+      server->handleConnection(connection);
+      done->set_value();
+    });
+  }
+
+  ~HandleConnectionRun() {
+    if (worker.joinable()) {
+      worker.detach();
+    }
+  }
+
+  bool returnedWithin(std::chrono::seconds deadline) {
+    if (future.wait_for(deadline) != std::future_status::ready) {
+      return false;
+    }
+    worker.join();
+    return true;
+  }
+};
+}  // namespace
+
 TEST_CASE("handleConnection returns when the connection is shutting down",
           "[HandleConnectionTimeout][integration]") {
-  auto serverSocketHandler = make_shared<PipeSocketHandler>();
-  auto routerSocketHandler = make_shared<PipeSocketHandler>();
+  ServerFixture fixture;
 
-  string pattern = GetTempDirectory() + string("et_handleconn_XXXXXX");
-  string directory = string(mkdtemp(&pattern[0]));
-  REQUIRE_FALSE(directory.empty());
-
-  const string serverPipePath = directory + "/pipe_server";
-  const string routerPipePath = directory + "/pipe_router";
-  SocketEndpoint serverEndpoint;
-  serverEndpoint.set_name(serverPipePath);
-  SocketEndpoint routerEndpoint;
-  routerEndpoint.set_name(routerPipePath);
-
-  // Heap allocated and captured by value below so the worker keeps everything
-  // it touches alive even if this scope exits first.
-  auto server = make_shared<TerminalServer>(
-      serverSocketHandler, serverEndpoint, routerSocketHandler, routerEndpoint);
   auto connection = make_shared<ServerClientConnection>(
-      serverSocketHandler, "shutdown-client", -1,
+      fixture.serverSocketHandler, "shutdown-client", -1,
       "abcdefghijklmnopqrstuvwxyz012345");
   connection->shutdown();
 
-  auto handled = make_shared<std::promise<void>>();
-  std::future<void> handledFuture = handled->get_future();
+  HandleConnectionRun run(fixture.server, connection);
+  REQUIRE(run.returnedWithin(std::chrono::seconds(5)));
+}
 
-  // A regression makes handleConnection() never return. Detaching instead of
-  // joining lets the suite report that as a failure rather than hang.
-  struct DetachOnFailure {
-    std::thread worker;
-    ~DetachOnFailure() {
-      if (worker.joinable()) {
-        worker.detach();
-      }
-    }
-  } guard{std::thread([server, connection, handled]() {
-    server->handleConnection(connection);
-    handled->set_value();
-  })};
+TEST_CASE("handleConnection returns when the server is halted",
+          "[HandleConnectionTimeout][integration]") {
+  ServerFixture fixture;
 
-  REQUIRE(handledFuture.wait_for(std::chrono::seconds(5)) ==
-          std::future_status::ready);
-  guard.worker.join();
+  // A live but silent client: the socket stays open and nothing ever arrives on
+  // it, which is the state that used to keep the thread looping forever.
+  int fds[2] = {-1, -1};
+  REQUIRE(::socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == 0);
+  // Non-blocking, as initSocket() leaves every socket the server owns.
+  REQUIRE(::fcntl(fds[0], F_SETFL, O_NONBLOCK) == 0);
+  auto connection = make_shared<ServerClientConnection>(
+      make_shared<FdSocketHandler>(), "silent-client", fds[0],
+      "abcdefghijklmnopqrstuvwxyz012345");
 
-  ::remove(serverPipePath.c_str());
-  ::remove(routerPipePath.c_str());
-  ::rmdir(directory.c_str());
+  fixture.server->shutdown();
+
+  HandleConnectionRun run(fixture.server, connection);
+  const bool returned = run.returnedWithin(std::chrono::seconds(5));
+
+  if (returned) {
+    // Only safe once handleConnection() is done, since shutdown() waits on the
+    // mutex it holds. Skipping it on failure keeps teardown from hanging.
+    connection->shutdown();
+  }
+  ::close(fds[1]);
+  REQUIRE(returned);
 }

--- a/test/integration_tests/HandleConnectionTimeoutTest.cpp
+++ b/test/integration_tests/HandleConnectionTimeoutTest.cpp
@@ -1,0 +1,69 @@
+/**
+ * TerminalServer::handleConnection() waits for the client's initial payload. It
+ * must be able to give up: otherwise the thread spins forever on a client that
+ * never speaks, and run() never finishes joining it at shutdown.
+ */
+
+#include <unistd.h>
+
+#include <chrono>
+#include <future>
+#include <thread>
+
+#include "PipeSocketHandler.hpp"
+#include "ServerClientConnection.hpp"
+#include "TerminalServer.hpp"
+#include "TestHeaders.hpp"
+
+using namespace et;
+
+TEST_CASE("handleConnection returns when the connection is shutting down",
+          "[HandleConnectionTimeout][integration]") {
+  auto serverSocketHandler = make_shared<PipeSocketHandler>();
+  auto routerSocketHandler = make_shared<PipeSocketHandler>();
+
+  string pattern = GetTempDirectory() + string("et_handleconn_XXXXXX");
+  string directory = string(mkdtemp(&pattern[0]));
+  REQUIRE_FALSE(directory.empty());
+
+  const string serverPipePath = directory + "/pipe_server";
+  const string routerPipePath = directory + "/pipe_router";
+  SocketEndpoint serverEndpoint;
+  serverEndpoint.set_name(serverPipePath);
+  SocketEndpoint routerEndpoint;
+  routerEndpoint.set_name(routerPipePath);
+
+  // Heap allocated and captured by value below so the worker keeps everything
+  // it touches alive even if this scope exits first.
+  auto server = make_shared<TerminalServer>(
+      serverSocketHandler, serverEndpoint, routerSocketHandler, routerEndpoint);
+  auto connection = make_shared<ServerClientConnection>(
+      serverSocketHandler, "shutdown-client", -1,
+      "abcdefghijklmnopqrstuvwxyz012345");
+  connection->shutdown();
+
+  auto handled = make_shared<std::promise<void>>();
+  std::future<void> handledFuture = handled->get_future();
+
+  // A regression makes handleConnection() never return. Detaching instead of
+  // joining lets the suite report that as a failure rather than hang.
+  struct DetachOnFailure {
+    std::thread worker;
+    ~DetachOnFailure() {
+      if (worker.joinable()) {
+        worker.detach();
+      }
+    }
+  } guard{std::thread([server, connection, handled]() {
+    server->handleConnection(connection);
+    handled->set_value();
+  })};
+
+  REQUIRE(handledFuture.wait_for(std::chrono::seconds(5)) ==
+          std::future_status::ready);
+  guard.worker.join();
+
+  ::remove(serverPipePath.c_str());
+  ::remove(routerPipePath.c_str());
+  ::rmdir(directory.c_str());
+}

--- a/test/unit_tests/AcceptStarvationTest.cpp
+++ b/test/unit_tests/AcceptStarvationTest.cpp
@@ -62,6 +62,62 @@ void writeConnectRequest(const shared_ptr<SocketHandler>& handler, int fd,
   request.set_version(PROTOCOL_VERSION);
   handler->writeProto(fd, request, true);
 }
+
+// Runs before the thread/future are destroyed: closing the stuck peer lets
+// recover() fail and release whatever it holds, so nothing hangs on teardown.
+struct Cleanup {
+  ServerConnection& server;
+  std::thread& reconnectThread;
+  int& stuckPeerFd;
+  int& livePeerFd;
+  int& extraPeerFd;
+  ~Cleanup() {
+    if (stuckPeerFd >= 0) {
+      ::close(stuckPeerFd);
+      stuckPeerFd = -1;
+    }
+    if (reconnectThread.joinable()) {
+      reconnectThread.join();
+    }
+    if (livePeerFd >= 0) {
+      ::close(livePeerFd);
+      livePeerFd = -1;
+    }
+    if (extraPeerFd >= 0) {
+      ::close(extraPeerFd);
+      extraPeerFd = -1;
+    }
+    server.shutdown();
+  }
+};
+
+// Leaves the server in the state the incident produces: a registered session
+// plus a reconnect for it blocked inside recover(). Returns once that block is
+// provable, so a test can act while it is still in effect.
+void wedgeReconnect(const shared_ptr<SocketHandler>& handler,
+                    TestServerConnection& server, const string& clientId,
+                    int live[2], int stuck[2], std::thread& reconnectThread) {
+  // A live session the reconnect can come back to.
+  REQUIRE(::socketpair(AF_UNIX, SOCK_STREAM, 0, live) == 0);
+  writeConnectRequest(handler, live[1], clientId);
+  server.clientHandler(live[0]);
+  REQUIRE(server.clientConnectionExists(clientId));
+  handler->readProto<ConnectResponse>(live[1], true);
+
+  // The reconnect. Nothing ever answers on the peer end, so recover() blocks
+  // waiting for the sequence header reply.
+  REQUIRE(::socketpair(AF_UNIX, SOCK_STREAM, 0, stuck) == 0);
+  writeConnectRequest(handler, stuck[1], clientId);
+  const int stuckServerFd = stuck[0];
+  reconnectThread = std::thread(
+      [&server, stuckServerFd]() { server.clientHandler(stuckServerFd); });
+
+  // recover() is provably in flight once it has answered RETURNING_CLIENT and
+  // written its sequence header; the next thing it does is block on the reply.
+  handler->readProto<ConnectResponse>(stuck[1], true);
+  handler->readProto<SequenceHeader>(stuck[1], true,
+                                     SocketHandler::MAX_HANDSHAKE_PROTO_LENGTH);
+}
 }  // namespace
 
 TEST_CASE("Reconnect stuck in recover still allows new connections",
@@ -79,53 +135,9 @@ TEST_CASE("Reconnect stuck in recover still allows new connections",
   int fresh[2] = {-1, -1};
   std::thread reconnectThread;
   std::future<bool> accepted;
+  Cleanup cleanup{server, reconnectThread, stuck[1], live[1], fresh[1]};
 
-  // Runs before the thread/future are destroyed: closing the stuck peer lets
-  // recover() fail and release whatever it holds, so nothing hangs on teardown.
-  struct Cleanup {
-    TestServerConnection& server;
-    std::thread& reconnectThread;
-    int& stuckPeerFd;
-    int& livePeerFd;
-    int& freshPeerFd;
-    ~Cleanup() {
-      if (stuckPeerFd >= 0) {
-        ::close(stuckPeerFd);
-        stuckPeerFd = -1;
-      }
-      if (reconnectThread.joinable()) {
-        reconnectThread.join();
-      }
-      if (livePeerFd >= 0) {
-        ::close(livePeerFd);
-        livePeerFd = -1;
-      }
-      if (freshPeerFd >= 0) {
-        ::close(freshPeerFd);
-        freshPeerFd = -1;
-      }
-      server.shutdown();
-    }
-  } cleanup{server, reconnectThread, stuck[1], live[1], fresh[1]};
-
-  // A live session the reconnect can come back to.
-  REQUIRE(::socketpair(AF_UNIX, SOCK_STREAM, 0, live) == 0);
-  writeConnectRequest(handler, live[1], clientId);
-  server.clientHandler(live[0]);
-  REQUIRE(server.clientConnectionExists(clientId));
-  handler->readProto<ConnectResponse>(live[1], true);
-
-  // The reconnect. Nothing ever answers on the peer end, so recover() blocks
-  // waiting for the sequence header reply.
-  REQUIRE(::socketpair(AF_UNIX, SOCK_STREAM, 0, stuck) == 0);
-  writeConnectRequest(handler, stuck[1], clientId);
-  reconnectThread = std::thread([&]() { server.clientHandler(stuck[0]); });
-
-  // recover() is provably in flight once it has answered RETURNING_CLIENT and
-  // written its sequence header; the next thing it does is block on the reply.
-  handler->readProto<ConnectResponse>(stuck[1], true);
-  handler->readProto<SequenceHeader>(stuck[1], true,
-                                     SocketHandler::MAX_HANDSHAKE_PROTO_LENGTH);
+  wedgeReconnect(handler, server, clientId, live, stuck, reconnectThread);
 
   // An unrelated client must still get accepted. The pooled handler owns and
   // closes fresh[0]; an oversized length makes it fail fast instead of
@@ -142,4 +154,45 @@ TEST_CASE("Reconnect stuck in recover still allows new connections",
   REQUIRE(accepted.wait_for(std::chrono::seconds(5)) ==
           std::future_status::ready);
   REQUIRE(accepted.get());
+}
+
+TEST_CASE("A second reconnect is refused while one is in flight",
+          "[AcceptStarvation][ServerClientConnection]") {
+  auto handler = make_shared<SocketPairHandler>();
+  SocketEndpoint endpoint;
+  endpoint.set_name("server");
+  TestServerConnection server(handler, endpoint);
+
+  const string clientId = "starved-client";
+  server.addClientKey(clientId, "abcdefghijklmnopqrstuvwxyz012345");
+
+  int live[2] = {-1, -1};
+  int stuck[2] = {-1, -1};
+  int second[2] = {-1, -1};
+  std::thread reconnectThread;
+  std::future<void> refused;
+  Cleanup cleanup{server, reconnectThread, stuck[1], live[1], second[1]};
+
+  wedgeReconnect(handler, server, clientId, live, stuck, reconnectThread);
+
+  // A second reconnect for the same client, arriving while the first is still
+  // blocked. Queueing it would hold this handler until the first one's socket
+  // timeout expires, and handlers are the resource every other client needs.
+  REQUIRE(::socketpair(AF_UNIX, SOCK_STREAM, 0, second) == 0);
+  writeConnectRequest(handler, second[1], clientId);
+  refused = std::async(std::launch::async,
+                       [&]() { server.clientHandler(second[0]); });
+
+  INFO("the second reconnect waited for the first instead of being refused");
+  REQUIRE(refused.wait_for(std::chrono::seconds(5)) ==
+          std::future_status::ready);
+  refused.get();
+
+  // It is answered and then dropped, so the client retries on its own schedule.
+  REQUIRE(handler->readProto<ConnectResponse>(second[1], true).status() ==
+          RETURNING_CLIENT);
+  REQUIRE_THROWS(handler->readProto<SequenceHeader>(
+      second[1], true, SocketHandler::MAX_HANDSHAKE_PROTO_LENGTH));
+  // The live session is untouched: only the refused socket was closed.
+  REQUIRE(server.clientConnectionExists(clientId));
 }

--- a/test/unit_tests/AcceptStarvationTest.cpp
+++ b/test/unit_tests/AcceptStarvationTest.cpp
@@ -1,0 +1,145 @@
+/**
+ * Regression test for accept starvation while a client reconnects.
+ *
+ * A returning client whose network path died blocks inside
+ * Connection::recover() until the socket timeout expires. The server must keep
+ * accepting new connections while that happens, so the reconnect path must not
+ * hold a server-wide lock across blocking socket I/O.
+ */
+
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <future>
+#include <thread>
+
+#include "ServerClientConnection.hpp"
+#include "ServerConnection.hpp"
+#include "TestHeaders.hpp"
+
+using namespace et;
+
+namespace {
+// Socket handler driven by pre-made socketpairs. accept() hands back the
+// descriptor it is given so acceptNewConnection() can be called directly.
+class SocketPairHandler : public SocketHandler {
+ public:
+  bool hasData(int fd) override { return waitOnSocketData(fd); }
+
+  ssize_t read(int fd, void* buf, size_t count) override {
+    return ::read(fd, buf, count);
+  }
+
+  ssize_t write(int fd, const void* buf, size_t count) override {
+    return ::write(fd, buf, count);
+  }
+
+  int connect(const SocketEndpoint&) override { return -1; }
+  set<int> listen(const SocketEndpoint&) override { return {}; }
+  set<int> getEndpointFds(const SocketEndpoint&) override { return {}; }
+  int accept(int fd) override { return fd; }
+  void stopListening(const SocketEndpoint&) override {}
+  void close(int fd) override { ::close(fd); }
+  vector<int> getActiveSockets() override { return {}; }
+};
+
+class TestServerConnection : public ServerConnection {
+ public:
+  TestServerConnection(std::shared_ptr<SocketHandler> socketHandler,
+                       const SocketEndpoint& endpoint)
+      : ServerConnection(std::move(socketHandler), endpoint) {}
+
+  // The real server starts a session thread here; the test only needs the
+  // connection to stay registered.
+  bool newClient(shared_ptr<ServerClientConnection>) override { return true; }
+};
+
+void writeConnectRequest(const shared_ptr<SocketHandler>& handler, int fd,
+                         const string& clientId) {
+  ConnectRequest request;
+  request.set_clientid(clientId);
+  request.set_version(PROTOCOL_VERSION);
+  handler->writeProto(fd, request, true);
+}
+}  // namespace
+
+TEST_CASE("Reconnect stuck in recover still allows new connections",
+          "[AcceptStarvation][ServerConnection]") {
+  auto handler = make_shared<SocketPairHandler>();
+  SocketEndpoint endpoint;
+  endpoint.set_name("server");
+  TestServerConnection server(handler, endpoint);
+
+  const string clientId = "starved-client";
+  server.addClientKey(clientId, "abcdefghijklmnopqrstuvwxyz012345");
+
+  int live[2] = {-1, -1};
+  int stuck[2] = {-1, -1};
+  int fresh[2] = {-1, -1};
+  std::thread reconnectThread;
+  std::future<bool> accepted;
+
+  // Runs before the thread/future are destroyed: closing the stuck peer lets
+  // recover() fail and release whatever it holds, so nothing hangs on teardown.
+  struct Cleanup {
+    TestServerConnection& server;
+    std::thread& reconnectThread;
+    int& stuckPeerFd;
+    int& livePeerFd;
+    int& freshPeerFd;
+    ~Cleanup() {
+      if (stuckPeerFd >= 0) {
+        ::close(stuckPeerFd);
+        stuckPeerFd = -1;
+      }
+      if (reconnectThread.joinable()) {
+        reconnectThread.join();
+      }
+      if (livePeerFd >= 0) {
+        ::close(livePeerFd);
+        livePeerFd = -1;
+      }
+      if (freshPeerFd >= 0) {
+        ::close(freshPeerFd);
+        freshPeerFd = -1;
+      }
+      server.shutdown();
+    }
+  } cleanup{server, reconnectThread, stuck[1], live[1], fresh[1]};
+
+  // A live session the reconnect can come back to.
+  REQUIRE(::socketpair(AF_UNIX, SOCK_STREAM, 0, live) == 0);
+  writeConnectRequest(handler, live[1], clientId);
+  server.clientHandler(live[0]);
+  REQUIRE(server.clientConnectionExists(clientId));
+  handler->readProto<ConnectResponse>(live[1], true);
+
+  // The reconnect. Nothing ever answers on the peer end, so recover() blocks
+  // waiting for the sequence header reply.
+  REQUIRE(::socketpair(AF_UNIX, SOCK_STREAM, 0, stuck) == 0);
+  writeConnectRequest(handler, stuck[1], clientId);
+  reconnectThread = std::thread([&]() { server.clientHandler(stuck[0]); });
+
+  // recover() is provably in flight once it has answered RETURNING_CLIENT and
+  // written its sequence header; the next thing it does is block on the reply.
+  handler->readProto<ConnectResponse>(stuck[1], true);
+  handler->readProto<SequenceHeader>(stuck[1], true,
+                                     SocketHandler::MAX_HANDSHAKE_PROTO_LENGTH);
+
+  // An unrelated client must still get accepted. The pooled handler owns and
+  // closes fresh[0]; an oversized length makes it fail fast instead of
+  // occupying a worker.
+  REQUIRE(::socketpair(AF_UNIX, SOCK_STREAM, 0, fresh) == 0);
+  int64_t oversize = SocketHandler::MAX_HANDSHAKE_PROTO_LENGTH + 1;
+  REQUIRE(handler->writeAllOrReturn(fresh[1], &oversize, sizeof(oversize)) ==
+          (int)sizeof(oversize));
+
+  accepted = std::async(std::launch::async,
+                        [&]() { return server.acceptNewConnection(fresh[0]); });
+
+  INFO("acceptNewConnection blocked while another client was recovering");
+  REQUIRE(accepted.wait_for(std::chrono::seconds(5)) ==
+          std::future_status::ready);
+  REQUIRE(accepted.get());
+}

--- a/test/unit_tests/TcpSocketHandlerTest.cpp
+++ b/test/unit_tests/TcpSocketHandlerTest.cpp
@@ -26,7 +26,9 @@ TEST_CASE("TcpSocketHandler uses a configurable listen backlog",
   }
 }
 
-TEST_CASE("TcpSocketHandler listens with a non-default backlog",
+// The kernel accept queue depth cannot be read back portably, so this only
+// covers that a custom backlog reaches listen() without being rejected.
+TEST_CASE("TcpSocketHandler listen succeeds with a custom backlog",
           "[TcpSocketHandler]") {
   TcpSocketHandler handler(64);
   SocketEndpoint endpoint;

--- a/test/unit_tests/TcpSocketHandlerTest.cpp
+++ b/test/unit_tests/TcpSocketHandlerTest.cpp
@@ -1,0 +1,40 @@
+#include "TcpSocketHandler.hpp"
+#include "TestHeaders.hpp"
+
+using namespace et;
+
+TEST_CASE("TcpSocketHandler uses a configurable listen backlog",
+          "[TcpSocketHandler]") {
+  SECTION("defaults when unspecified") {
+    TcpSocketHandler handler;
+    REQUIRE(handler.getListenBacklog() ==
+            TcpSocketHandler::DEFAULT_LISTEN_BACKLOG);
+  }
+
+  SECTION("keeps an explicit value") {
+    TcpSocketHandler handler(512);
+    REQUIRE(handler.getListenBacklog() == 512);
+  }
+
+  SECTION("falls back to the default on a non-positive value") {
+    TcpSocketHandler zero(0);
+    REQUIRE(zero.getListenBacklog() ==
+            TcpSocketHandler::DEFAULT_LISTEN_BACKLOG);
+    TcpSocketHandler negative(-1);
+    REQUIRE(negative.getListenBacklog() ==
+            TcpSocketHandler::DEFAULT_LISTEN_BACKLOG);
+  }
+}
+
+TEST_CASE("TcpSocketHandler listens with a non-default backlog",
+          "[TcpSocketHandler]") {
+  TcpSocketHandler handler(64);
+  SocketEndpoint endpoint;
+  // Loopback and an ephemeral port: no firewall prompts, no fixed-port clashes.
+  endpoint.set_name("127.0.0.1");
+  endpoint.set_port(0);
+
+  set<int> fds = handler.listen(endpoint);
+  REQUIRE_FALSE(fds.empty());
+  handler.stopListening(endpoint);
+}


### PR DESCRIPTION
## Symptom

etserver stops accepting connections entirely while a single client is reconnecting over a dead network path. `et host` hangs, no matching line ever appears in the server log, `ssh` to the same host is unaffected, and service only comes back when the stuck clients are killed.

Observed on 7.0.0 (Ubuntu, port 2022). `ss -tln` showed the listening socket carrying 22-27 queued connections against a backlog of 32, all from a single source address. That address turned out to be one laptop behind NAT running four `et` clients abandoned days earlier, each still retrying.

## Mechanism

`TerminalServer::run()` does everything on one thread. The same `select()` loop accepts TCP clients and accepts the router connection that registers a new session's key:

```cpp
for (int i : serverPortFds) {
  if (FD_ISSET(i, &rfds)) {
    acceptNewConnection(i);
  }
}
if (FD_ISSET(terminalRouter->getServerFd(), &rfds)) {
  auto idKeyPair = terminalRouter->acceptNewConnection();
  if (idKeyPair.id.length()) {
    addClientKey(idKeyPair.id, idKeyPair.key);
  }
}
```

`acceptNewConnection()` takes `classMutex` to enqueue the new descriptor. A returning client is handled on one of the eight pool threads, which took the same lock around the recovery:

```cpp
lock_guard<std::recursive_mutex> guard(classMutex);
serverClientState->recoverClient(clientSocketFd);
```

`recoverClient()` calls `Connection::recover()`, which writes a `SequenceHeader`, reads the client's reply, exchanges catchup buffers, and only then returns. All four of those socket operations block. Reads are bounded by `SOCKET_IDLE_TIMEOUT_SEC` (30s idle) and `SOCKET_ABSOLUTE_TIMEOUT_SEC` (60s absolute), checked every iteration. Writes are bounded only by the 30s idle timer, which `writeAllOrThrow()` resets on every partial write, so a peer that accepts a trickle holds a write open indefinitely.

So one recovery against a client that is no longer reachable holds `classMutex` for as long as its timeouts allow, and for that entire time nothing can be accepted -- not TCP clients, and not the router connection either, since `run()` handles both on the same thread. `ClientConnection::pollReconnect()` keeps trying: apart from its own shutdown it gives up only when the server answers `INVALID_KEY`. With several such clients the stalls chain back to back, the accept queue fills, and further clients never complete a handshake.

The same lock ordering appears inverted in `removeClient()` and `destroyPartialConnection()`, which called `Connection::shutdown()` while holding `classMutex`; `shutdown()` waits on `connectionMutex`, which a reconnect holds across that same blocking I/O.

## Changes

Seven commits, independently reviewable:

1. **Stop a stuck reconnect from blocking every new connection.** Takes the recovery out of `classMutex`. The lock was providing two things: keeping the connection alive across the call, and serializing concurrent reconnects for one client. The first is already covered, since `serverClientState` is a `shared_ptr` copy taken under the lock. The second moves to the connection's own mutex -- `recoverClient()` now holds `connectionMutex` across the whole socket swap rather than just its first half, so two reconnects for one client still cannot interleave, while reconnects for different clients stop blocking each other and the accept loop. `connectionMutex` is recursive, so `recover()` re-locking it is fine. Holding it for the whole call also closes two pre-existing windows, where another thread could observe `socketFd == -1` with no recovery in progress, or where a `shutdown()` slipping between a failed `recover()` and the restore would let the restore revive a torn-down connection. `removeClient()` and `destroyPartialConnection()` drop their map entry under `classMutex` and shut the connection down after releasing it. `recover()` returns early when the connection is already shutting down, since with the global lock gone a session can be torn down while a reconnect for it is in flight.

2. **Make the listen backlog configurable.** `listen()` hardcoded 32, which is small for a daemon whose clients tend to reconnect all at once. Defaults to 128, overridable through `backlog` in the `[Networking]` section of `et.cfg`.

3. **Bound the wait for a client's initial payload.** `handleConnection()` looped forever on `readPacket()`, one log line per second. On the affected server one such thread had been logging for over forty minutes. Now gives up when the connection is shutting down or after ten minutes; the initial payload is what starts the terminal, so a client that never sends one has no session to preserve, and a client whose path recovers before the deadline still reaches the same thread through the normal reconnect. Note that giving up erases the client key, so a client returning after the deadline gets `INVALID_KEY` and stops retrying.

4. **Exit that wait when the server is halted.** The connection's own shutdown flag is not what stops this server: `TerminalServer::shutdown()` only sets `halt`, and it hides `ServerConnection::shutdown()`, so the unqualified call in `run()` resolves to the derived one and nothing ever marks these connections as shutting down. Without a `halt` check the thread kept looping and `run()` blocked joining it until the deadline. Checks `halt` under `terminalThreadMutex`, the way the session loops in `runJumpHost()` and `runTerminal()` already do, reading it into a local so the lock is released before `removeClient()` takes `classMutex`.

5. **Free the address info in `TcpSocketHandler::listen()`.** A pre-existing leak of the `getaddrinfo()` result, on both the normal return and the bind failure that throws, while `connect()` frees it on every exit. It went unnoticed because nothing called `listen()` in process until this branch added a test, and LeakSanitizer is unavailable on macOS. Also logs the backlog that was actually applied and warns when a configured value is discarded.

6. **Test the initial-payload deadline directly.** The deadline is read through a protected member so a test subclass can lower it, instead of being unreachable behind a ten minute constant.

7. **Refuse a reconnect while one is in flight for that client.** Freeing `classMutex` leaves the recovery occupying the handler thread it runs on, and reconnects for one client serialize on that connection's mutex, so overlapping attempts each park a worker behind the ones ahead of them. A real client cannot overlap its own attempts, since `pollReconnect()` blocks in its own half of the same handshake before retrying, but an unauthenticated peer can: a reconnect needs nothing but a client id. The refused socket is closed before the live session is touched, and a genuine client returns on its next attempt.

## Testing

`test/unit_tests/AcceptStarvationTest.cpp` registers a client, opens a second connection for the same client whose peer never answers the sequence header -- leaving `recover()` blocked exactly where a dead path leaves it -- and then requires `acceptNewConnection()` to complete for an unrelated descriptor. Pre-fix the accept is still blocked when the five second deadline expires; post-fix it returns in under a millisecond. Waiting for the sequence header rather than the `ConnectResponse` is what makes it deterministic: pre-fix, the recovery's `classMutex` was taken after that response was written. A second case requires a further reconnect for the same client to be refused within five seconds instead of queueing behind the wedged one.

`test/integration_tests/HandleConnectionTimeoutTest.cpp` covers all three exits: a connection already shutting down, an open but silent client once the server is halted, and the same client against a one second deadline with neither flag set.

`test/unit_tests/TcpSocketHandlerTest.cpp` covers the backlog default, an explicit value, and the non-positive fallback. Its `listen()` case only checks that a custom backlog is accepted -- the kernel queue depth is not portably readable.

Every regression test was confirmed to fail on the commit that introduced it and pass after, on macOS and on Linux. None of them hangs the suite when it fails: the starvation tests unblock their stuck worker in teardown, and the timeout tests detach their worker and skip the teardown that would wait on a held mutex.

- macOS, `-DDISABLE_VCPKG=ON -DDISABLE_TELEMETRY=ON`: 162/162.
- Ubuntu 24.04, GCC 13.3, same flags: 162/162.
- Ubuntu 24.04, `-DSANITIZE_ADDRESS=ON` (what the `linux_ci` asan leg runs): 162/162. Reverting only commit 5 flips the backlog test's exit code from 0 to 1 with a `getaddrinfo` leak report, so that diagnosis is verified rather than inferred.
- ThreadSanitizer on macOS: no races, including the existing `recoverClient` coverage in `SecurityNoticesTest`. One unrelated abort at process exit in `SocketHandler helpers read/write encoded payloads` reproduces identically on the parent commit.

### End to end

The unit tests pin the mechanism; this checks the reported symptom against real binaries. On Ubuntu 24.04 with sshd, a real `etserver`, `etterminal` and `et`: one live session, then reconnects for that session which complete the TCP handshake, read `RETURNING_CLIENT` and the server's sequence header, and then answer nothing -- the state a dead path produces, driven from a script so the timing is deterministic. Meanwhile a client that has never connected before attempts a session five times, at four second intervals, through a two minute window in which four such reconnects arrive every fifteen seconds.

    unpatched     hung 45s  hung 45s  13s  0s  0s
    commits 1-6   0s        0s        42s  1s  13s
    commit 7      0s        0s        0s   0s  1s

Unpatched, the first two attempts never got a session and were killed at the 45 second timeout, which is the reported symptom. The 13 second and 42 second figures are recoveries timing out and releasing what the next attempt was waiting on. With the incident's own shape -- four separate abandoned clients rather than repeated attempts at one session -- commits 1-6 alone already answer every attempt in under a second.

## Not addressed here

A recovery still occupies its handler thread for the length of its timeouts, so enough distinct clients recovering at once can still fill an eight thread pool. Commit 7 caps it at one thread per client, which is what makes the measured case behave; removing the exposure entirely would mean not running recovery on a pool thread at all.

`ServerConnection::shutdown()` still calls `Connection::shutdown()` and drains the handler pool while holding `classMutex`, so a worker waiting on `classMutex` would never be joined. It is left alone because `TerminalServer::shutdown()` hides it, as commit 4 describes, so the base version is only reached from tests -- `AcceptStarvationTest` avoids the hazard only because its extra client fails its handshake before touching `classMutex`.

`PipeSocketHandler::listen()` still hardcodes a backlog of 5 for the router socket, drained by the same loop this change protects.

Reconnect authentication remains as #784 left it, needing a `PROTOCOL_VERSION` bump.