### PR TITLE
Document Mobile SSH as a third-party mobile ET client

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,10 @@ et dev (etserver running on port 2022 on both hostname and jumphost)
 et dev:8000 -jport 9000 (etserver running on port 9000 on jumphost)
 ```
 
+### Third-party mobile client
+
+[Mobile SSH](https://mobile-ssh.github.io/) is a third-party Android and iOS SSH client with optional Eternal Terminal transport. Beta builds are available through a [Google Play closed test](https://play.google.com/apps/testing/io.github.mobile_ssh) and [TestFlight](https://testflight.apple.com/join/Ku4JtTEg).
+
 ## Building from Source
 
 ### macOS


### PR DESCRIPTION
The README currently documents desktop/WSL clients but does not point mobile users to a native Android or iOS option. This adds a short, explicitly third-party note for Mobile SSH and labels both distribution channels as beta.

Disclosure: I maintain Mobile SSH. Its ET transport is optional; the app otherwise operates as an independent SSH client.