### PR TITLE
Fix terminal size query failure propagation

### DIFF
--- a/src/terminal/Console.hpp
+++ b/src/terminal/Console.hpp
@@ -1,6 +1,8 @@
 #ifndef __CONSOLE_HPP__
 #define __CONSOLE_HPP__
 
+#include <optional>
+
 #include "ETerminal.pb.h"
 #include "Headers.hpp"
 #include "RawSocketUtils.hpp"
@@ -12,9 +14,9 @@ namespace et {
  */
 class Console {
  public:
-  /** @brief Returns metadata about the console (size, pixels) for the remote
-   * client. */
-  virtual TerminalInfo getTerminalInfo() = 0;
+  /** @brief Returns console dimensions, or no value when they cannot be read.
+   */
+  virtual std::optional<TerminalInfo> getTerminalInfo() = 0;
   /** @brief Prepares the console/terminal before handing control to ET. */
   virtual void setup() = 0;
   /** @brief Restores the console state before exiting ET. */

--- a/src/terminal/PseudoTerminalConsole.hpp
+++ b/src/terminal/PseudoTerminalConsole.hpp
@@ -73,7 +73,7 @@ class PseudoTerminalConsole : public Console {
   }
 
   /** @brief Queries the current terminal window dimensions. */
-  virtual TerminalInfo getTerminalInfo() {
+  virtual std::optional<TerminalInfo> getTerminalInfo() {
 #ifdef WIN32
     CONSOLE_SCREEN_BUFFER_INFO csbi;
     int columns, rows;
@@ -96,8 +96,10 @@ class PseudoTerminalConsole : public Console {
 
     return ti;
 #else
-    winsize win;
-    ioctl(1, TIOCGWINSZ, &win);
+    winsize win{};
+    if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &win) < 0) {
+      return std::nullopt;
+    }
     TerminalInfo ti;
     ti.set_row(win.ws_row);
     ti.set_column(win.ws_col);

--- a/src/terminal/TerminalClient.cpp
+++ b/src/terminal/TerminalClient.cpp
@@ -367,15 +367,15 @@ void TerminalClient::run(const string& command, const bool noexit) {
       }
 
       if (console) {
-        TerminalInfo ti = console->getTerminalInfo();
+        auto ti = console->getTerminalInfo();
 
-        if (ti != lastTerminalInfo) {
-          VLOG(1) << "Window size changed: row: " << ti.row()
-                  << " column: " << ti.column() << " width: " << ti.width()
-                  << " height: " << ti.height();
-          lastTerminalInfo = ti;
+        if (ti && *ti != lastTerminalInfo) {
+          VLOG(1) << "Window size changed: row: " << ti->row()
+                  << " column: " << ti->column() << " width: " << ti->width()
+                  << " height: " << ti->height();
+          lastTerminalInfo = *ti;
           connection->writePacket(
-              Packet(TerminalPacketType::TERMINAL_INFO, protoToString(ti)));
+              Packet(TerminalPacketType::TERMINAL_INFO, protoToString(*ti)));
         }
       }
 

--- a/test/FakeConsole.hpp
+++ b/test/FakeConsole.hpp
@@ -14,6 +14,8 @@ class FakeConsole : public Console {
   FakeConsole(shared_ptr<PipeSocketHandler> _socketHandler)
       : socketHandler(_socketHandler),
         getTerminalInfoCount(0),
+        terminalInfoAvailable(true),
+        automaticallyChangeTerminalInfo(true),
         clientServerFd(-1) {}
 
   virtual ~FakeConsole() {}
@@ -87,13 +89,26 @@ class FakeConsole : public Console {
     FATAL_FAIL(::remove(pipeDirectory.c_str()));
   }
 
-  virtual TerminalInfo getTerminalInfo() {
+  virtual std::optional<TerminalInfo> getTerminalInfo() {
+    lock_guard<recursive_mutex> lock(_mutex);
     getTerminalInfoCount++;
-    if (getTerminalInfoCount % 100 == 0) {
+    if (!terminalInfoAvailable) {
+      return std::nullopt;
+    }
+    if (automaticallyChangeTerminalInfo && getTerminalInfoCount % 100 == 0) {
       // Bump the terminal info
       fakeTerminalInfo.set_row(fakeTerminalInfo.row() + 1);
     }
     return fakeTerminalInfo;
+  }
+
+  void setTerminalInfoResult(const std::optional<TerminalInfo>& terminalInfo) {
+    lock_guard<recursive_mutex> lock(_mutex);
+    automaticallyChangeTerminalInfo = false;
+    terminalInfoAvailable = terminalInfo.has_value();
+    if (terminalInfo) {
+      fakeTerminalInfo = *terminalInfo;
+    }
   }
 
   virtual int getFd() {
@@ -135,6 +150,8 @@ class FakeConsole : public Console {
   shared_ptr<PipeSocketHandler> socketHandler;
   TerminalInfo fakeTerminalInfo;
   int getTerminalInfoCount;
+  bool terminalInfoAvailable;
+  bool automaticallyChangeTerminalInfo;
   int serverClientFd;
   int clientServerFd;
   string pipeDirectory;
@@ -147,6 +164,7 @@ class FakeUserTerminal : public UserTerminal {
       : socketHandler(_socketHandler),
         serverClientFd(-1),
         clientServerFd(-1),
+        setInfoCount(0),
         didCleanUp(false),
         didHandleSessionEnd(false) {
     memset(&lastWinInfo, 0, sizeof(winsize));
@@ -220,15 +238,32 @@ class FakeUserTerminal : public UserTerminal {
   }
   virtual void handleSessionEnd() { didHandleSessionEnd = true; }
   virtual void cleanup() { didCleanUp = true; }
-  virtual void setInfo(const winsize& tmpwin) { lastWinInfo = tmpwin; }
+  virtual void setInfo(const winsize& tmpwin) {
+    lock_guard<recursive_mutex> lock(terminalInfoMutex);
+    lastWinInfo = tmpwin;
+    setInfoCount++;
+  }
+
+  int getSetInfoCount() {
+    lock_guard<recursive_mutex> lock(terminalInfoMutex);
+    return setInfoCount;
+  }
+
+  winsize getLastWinInfo() {
+    lock_guard<recursive_mutex> lock(terminalInfoMutex);
+    return lastWinInfo;
+  }
 
  protected:
   recursive_mutex _mutex;
+  // Keep geometry updates independent from blocking socket I/O under _mutex.
+  recursive_mutex terminalInfoMutex;
   shared_ptr<PipeSocketHandler> socketHandler;
   int serverClientFd;
   int clientServerFd;
   string pipeDirectory;
   string pipePath;
+  int setInfoCount;
   bool didCleanUp;
   bool didHandleSessionEnd;
   winsize lastWinInfo;

--- a/test/integration_tests/TerminalTest.cpp
+++ b/test/integration_tests/TerminalTest.cpp
@@ -36,6 +36,22 @@ void waitForFakeConsoleSetup(const shared_ptr<FakeConsole>& fakeConsole) {
   REQUIRE(fakeConsole->isSetup());
 }
 
+bool waitForTerminalInfo(const shared_ptr<FakeUserTerminal>& fakeUserTerminal,
+                         const TerminalInfo& expected) {
+  const auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::seconds(30);
+  while (std::chrono::steady_clock::now() < deadline) {
+    winsize actual = fakeUserTerminal->getLastWinInfo();
+    if (actual.ws_row == expected.row() && actual.ws_col == expected.column() &&
+        actual.ws_xpixel == expected.width() &&
+        actual.ws_ypixel == expected.height()) {
+      return true;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  return false;
+}
+
 void readWriteTest(shared_ptr<PipeSocketHandler> routerSocketHandler,
                    shared_ptr<FakeUserTerminal> fakeUserTerminal,
                    SocketEndpoint serverEndpoint,
@@ -109,6 +125,59 @@ void readWriteTest(shared_ptr<PipeSocketHandler> routerSocketHandler,
 
   unsetenv("ET_TEST_VAR1");
   unsetenv("ET_TEST_VAR2_EMPTY");
+}
+
+void terminalInfoQueryFailureTest(
+    shared_ptr<PipeSocketHandler> routerSocketHandler,
+    shared_ptr<FakeUserTerminal> fakeUserTerminal,
+    SocketEndpoint serverEndpoint,
+    shared_ptr<SocketHandler> clientSocketHandler,
+    shared_ptr<SocketHandler> clientPipeSocketHandler,
+    shared_ptr<FakeConsole> fakeConsole, const SocketEndpoint& routerEndpoint) {
+  auto fakeSubprocessUtils = make_shared<FakeSubprocessUtils>();
+  auto sshSetupHandler = make_shared<FakeSshSetupHandler>(fakeSubprocessUtils);
+  auto [id, passkey] = sshSetupHandler->SetupSsh(
+      "", "localhost", "localhost", 2022, "", "", false, 0, "", "", {});
+
+  auto uth = shared_ptr<UserTerminalHandler>(
+      new UserTerminalHandler(routerSocketHandler, fakeUserTerminal, true,
+                              routerEndpoint, id + "/" + passkey));
+  thread uthThread([uth]() { uth->run(); });
+  sleep(1);
+
+  shared_ptr<TerminalClient> terminalClient(
+      new TerminalClient(clientSocketHandler, clientPipeSocketHandler,
+                         serverEndpoint, id, passkey, fakeConsole, false, "",
+                         "", false, "", MAX_CLIENT_KEEP_ALIVE_DURATION, {}));
+  thread terminalClientThread(
+      [terminalClient]() { terminalClient->run("", false); });
+  sleep(3);
+  waitForFakeConsoleSetup(fakeConsole);
+
+  TerminalInfo terminalInfo;
+  terminalInfo.set_row(24);
+  terminalInfo.set_column(80);
+  terminalInfo.set_width(640);
+  terminalInfo.set_height(480);
+  fakeConsole->setTerminalInfoResult(terminalInfo);
+  REQUIRE(waitForTerminalInfo(fakeUserTerminal, terminalInfo));
+
+  int setInfoCount = fakeUserTerminal->getSetInfoCount();
+  fakeConsole->setTerminalInfoResult(std::nullopt);
+  std::this_thread::sleep_for(std::chrono::milliseconds(250));
+  REQUIRE(fakeUserTerminal->getSetInfoCount() == setInfoCount);
+
+  fakeConsole->setTerminalInfoResult(terminalInfo);
+  std::this_thread::sleep_for(std::chrono::milliseconds(250));
+  REQUIRE(fakeUserTerminal->getSetInfoCount() == setInfoCount);
+
+  terminalClient->shutdown();
+  terminalClientThread.join();
+  terminalClient.reset();
+
+  uth->shutdown();
+  uthThread.join();
+  uth.reset();
 }
 
 // A UserTerminal backed by a *real* pty running `cat`, so the test exercises
@@ -305,7 +374,7 @@ class FileBackedConsole : public Console {
     ::remove(directory.c_str());
   }
 
-  virtual TerminalInfo getTerminalInfo() {
+  virtual std::optional<TerminalInfo> getTerminalInfo() {
     TerminalInfo ti;
     ti.set_row(24);
     ti.set_column(80);
@@ -569,6 +638,14 @@ TEST_CASE_METHOD(EndToEndTestFixture, "EndToEndTest",
   readWriteTest(routerSocketHandler, fakeUserTerminal, serverEndpoint,
                 clientSocketHandler, clientPipeSocketHandler, fakeConsole,
                 routerEndpoint);
+}
+
+TEST_CASE_METHOD(EndToEndTestFixture, "TerminalInfoQueryFailure",
+                 "[EndToEndTest][integration]") {
+  terminalInfoQueryFailureTest(routerSocketHandler, fakeUserTerminal,
+                               serverEndpoint, clientSocketHandler,
+                               clientPipeSocketHandler, fakeConsole,
+                               routerEndpoint);
 }
 
 TEST_CASE_METHOD(EndToEndTestFixture, "LargeInputNoDeadlock",


### PR DESCRIPTION
## Summary

- make terminal-size query failure explicit in the internal `Console` contract
- return no observation when Unix `TIOCGWINSZ` fails
- keep the last successful geometry and suppress `TERMINAL_INFO` emission on failure
- add an end-to-end regression for success, failure, and unchanged recovery

## Why

`TIOCGWINSZ` can fail without writing the caller-provided `winsize`. The previous code ignored the return value, read that untouched storage, and could serialize it as remote terminal geometry.

This change handles the confirmed latent defect without adding receiver-side size policy, protocol changes, or arbitrary geometry limits.

## Validation

- `cmake --fresh -S . -B build -G Ninja`
- `ninja -C build`
- `./build/et-test TerminalInfoQueryFailure --reporter compact` — passed, 3 assertions
- deliberate failure injection converted absence to default geometry — regression failed at the receiver resize-count assertion; restored implementation passed
- `bash format.sh`
- `git diff --check`
- independent final review — approved with explicit residual risk

Full `ctest --parallel --output-on-failure` completed with three HTM system-test timeouts:

- `htm_pty_e2e`: `INSERT_KEYS` stalled while panes were printing
- `htm_features_e2e`: timed out waiting for concurrent `APPEND_TO_PANE`
- `htm_stress_e2e`: timed out waiting for bulk output and injected keys

These are likely unrelated by source reachability: the HTM tests do not launch `TerminalClient`, HTM does not call `getTerminalInfo()`, and the failures occur in HTM key/output flow. No clean `master` A/B run was recorded, so this is not claimed categorically. Two additional parallel integration timeouts (`EndToEndTest`, `JumphostEndToEndTest`) passed on serial/isolated reruns.

Native Windows and opt-in Ghostty, iTerm2, and Hyper E2E suites were not run.
