### PR TITLE
Replace select() with epoll/kqueue and poll()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -428,6 +428,10 @@ add_library(
   src/base/Connection.cpp
   src/base/CryptoHandler.hpp
   src/base/CryptoHandler.cpp
+  src/base/FdPoller.hpp
+  src/base/FdPoller.cpp
+  src/base/FdPollerKqueue.cpp
+  src/base/FdPollerLinux.cpp
   src/base/ServerClientConnection.hpp
   src/base/ServerClientConnection.cpp
   src/base/ServerConnection.hpp
@@ -609,14 +613,16 @@ if(WIN32)
       ${CMAKE_CURRENT_SOURCE_DIR}/test/unit_tests/*Test.cpp)
 
     # These tests exercise production facilities that do not exist on Windows:
-    # fork/SCM_RIGHTS privilege dropping, Unix server/terminal handlers, or a
-    # POSIX PTY/terminal host. Keep this exclusion list explicit so every new
-    # portable test is included on Windows automatically.
+    # fork/SCM_RIGHTS privilege dropping, Unix server/terminal handlers, a
+    # POSIX PTY/terminal host, or epoll/kqueue readiness polling. Keep this
+    # exclusion list explicit so every new portable test is included on
+    # Windows automatically.
     set(WINDOWS_UNSUPPORTED_TEST_SRCS
       ${CMAKE_CURRENT_SOURCE_DIR}/test/integration_tests/HandleConnectionTimeoutTest.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/test/integration_tests/JumphostTest.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/test/integration_tests/TerminalServerTest.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/test/integration_tests/TerminalTest.cpp
+      ${CMAKE_CURRENT_SOURCE_DIR}/test/unit_tests/FdPollerTest.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/test/unit_tests/HtmGhosttyE2eTest.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/test/unit_tests/ServerFifoPathTest.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/test/unit_tests/UserSocketOpsTest.cpp

--- a/src/base/FdPoller.cpp
+++ b/src/base/FdPoller.cpp
@@ -1,0 +1,47 @@
+#ifndef WIN32
+#include "FdPoller.hpp"
+
+namespace et {
+FdPoller::~FdPoller() { ::close(pollerFd); }
+
+void FdPoller::setFds(const set<int>& readFds, const set<int>& writeFds,
+                      const set<int>& refreshFds) {
+  auto interestFor = [&readFds, &writeFds](int fd) -> short {
+    short interest = 0;
+    if (readFds.count(fd) != 0) {
+      interest |= kRead;
+    }
+    if (writeFds.count(fd) != 0) {
+      interest |= kWrite;
+    }
+    return interest;
+  };
+
+  for (auto it = registeredFds.begin(); it != registeredFds.end();) {
+    if (interestFor(it->first) != it->second ||
+        refreshFds.count(it->first) != 0) {
+      removeFd(it->first, it->second);
+      it = registeredFds.erase(it);
+    } else {
+      ++it;
+    }
+  }
+
+  set<int> allFds = readFds;
+  allFds.insert(writeFds.begin(), writeFds.end());
+  for (int fd : allFds) {
+    if (registeredFds.count(fd) == 0 && addFd(fd, interestFor(fd))) {
+      registeredFds[fd] = interestFor(fd);
+    }
+  }
+}
+
+FdPoller::Ready FdPoller::wait(int timeoutMs) {
+  // kqueue reports each filter separately, so a descriptor watched both ways
+  // yields two events. epoll_wait() rejects a zero-sized buffer and kevent()
+  // would return without waiting, hence the floor of one.
+  return waitImpl(static_cast<int>(max<size_t>(registeredFds.size() * 2, 1)),
+                  timeoutMs);
+}
+}  // namespace et
+#endif

--- a/src/base/FdPoller.hpp
+++ b/src/base/FdPoller.hpp
@@ -1,0 +1,55 @@
+#ifndef __ET_FD_POLLER_H__
+#define __ET_FD_POLLER_H__
+
+#include "Headers.hpp"
+
+namespace et {
+/**
+ * @brief Readiness poller backed by epoll on Linux and kqueue on BSD/macOS.
+ *
+ * Unlike select() there is no FD_SETSIZE ceiling, so a descriptor at or above
+ * 1024 is safe to watch.
+ */
+class FdPoller {
+ public:
+  /** @brief Descriptors reported ready, split by direction. */
+  struct Ready {
+    set<int> readable;
+    set<int> writable;
+  };
+
+  FdPoller();
+  ~FdPoller();
+
+  FdPoller(const FdPoller&) = delete;
+  FdPoller& operator=(const FdPoller&) = delete;
+
+  /**
+   * @brief Replaces the watched set, skipping any descriptor already closed.
+   *
+   * A descriptor may appear in both sets. Those in `refreshFds` are re-added
+   * even when already watched: the poller drops a descriptor once it is
+   * closed, so a number a new descriptor has recycled since the last call is
+   * otherwise indistinguishable from the one still registered under it.
+   */
+  void setFds(const set<int>& readFds, const set<int>& writeFds = {},
+              const set<int>& refreshFds = {});
+
+  /** @brief Returns the descriptors reported ready, empty on timeout or when
+   * interrupted by a signal. */
+  Ready wait(int timeoutMs);
+
+ private:
+  static constexpr short kRead = 1;
+  static constexpr short kWrite = 2;
+
+  bool addFd(int fd, short interest);
+  void removeFd(int fd, short interest);
+  Ready waitImpl(int capacity, int timeoutMs);
+
+  int pollerFd;
+  unordered_map<int, short> registeredFds;
+};
+}  // namespace et
+
+#endif  // __ET_FD_POLLER_H__

--- a/src/base/FdPollerKqueue.cpp
+++ b/src/base/FdPollerKqueue.cpp
@@ -1,0 +1,87 @@
+#if !defined(WIN32) && !defined(__linux__)
+#if __has_include(<sys/event.h>)
+#include <sys/event.h>
+
+#include "FdPoller.hpp"
+
+namespace et {
+FdPoller::FdPoller() : pollerFd(kqueue()) {
+  if (pollerFd < 0) {
+    throw runtime_error(string("kqueue failed: ") + strerror(errno));
+  }
+  if (fcntl(pollerFd, F_SETFD, FD_CLOEXEC) < 0) {
+    int savedErrno = errno;
+    ::close(pollerFd);
+    throw runtime_error(string("fcntl failed: ") + strerror(savedErrno));
+  }
+}
+
+FdPoller::Ready FdPoller::waitImpl(int capacity, int timeoutMs) {
+  vector<struct kevent> events(capacity);
+  struct timespec timeout = {timeoutMs / 1000,
+                             (timeoutMs % 1000) * 1000 * 1000};
+  int count = kevent(pollerFd, nullptr, 0, events.data(), capacity, &timeout);
+  if (count < 0) {
+    if (errno == EINTR) {
+      return {};
+    }
+    throw runtime_error(string("kevent failed: ") + strerror(errno));
+  }
+
+  Ready ready;
+  for (int i = 0; i < count; ++i) {
+    if ((events[i].flags & EV_ERROR) != 0) {
+      throw runtime_error(string("kevent reported an error: ") +
+                          strerror(static_cast<int>(events[i].data)));
+    }
+    const int fd = static_cast<int>(events[i].ident);
+    if (events[i].filter == EVFILT_READ) {
+      ready.readable.insert(fd);
+    } else if (events[i].filter == EVFILT_WRITE) {
+      ready.writable.insert(fd);
+    }
+  }
+  return ready;
+}
+
+// Each direction is a separate filter registration, so each is added and
+// deleted on its own.
+bool FdPoller::addFd(int fd, short interest) {
+  struct kevent changes[2];
+  int count = 0;
+  if ((interest & kRead) != 0) {
+    EV_SET(&changes[count++], fd, EVFILT_READ, EV_ADD | EV_ENABLE, 0, 0,
+           nullptr);
+  }
+  if ((interest & kWrite) != 0) {
+    EV_SET(&changes[count++], fd, EVFILT_WRITE, EV_ADD | EV_ENABLE, 0, 0,
+           nullptr);
+  }
+  if (kevent(pollerFd, changes, count, nullptr, 0, nullptr) < 0) {
+    if (errno == EBADF) {
+      return false;
+    }
+    throw runtime_error(string("kevent add failed: ") + strerror(errno));
+  }
+  return true;
+}
+
+void FdPoller::removeFd(int fd, short interest) {
+  struct kevent changes[2];
+  int count = 0;
+  if ((interest & kRead) != 0) {
+    EV_SET(&changes[count++], fd, EVFILT_READ, EV_DELETE, 0, 0, nullptr);
+  }
+  if ((interest & kWrite) != 0) {
+    EV_SET(&changes[count++], fd, EVFILT_WRITE, EV_DELETE, 0, 0, nullptr);
+  }
+  if (kevent(pollerFd, changes, count, nullptr, 0, nullptr) < 0 &&
+      errno != EBADF && errno != ENOENT) {
+    throw runtime_error(string("kevent delete failed: ") + strerror(errno));
+  }
+}
+}  // namespace et
+#else
+#error "FdPoller requires epoll or kqueue"
+#endif
+#endif

--- a/src/base/FdPollerLinux.cpp
+++ b/src/base/FdPollerLinux.cpp
@@ -1,0 +1,71 @@
+#ifdef __linux__
+#include <sys/epoll.h>
+
+#include "FdPoller.hpp"
+
+namespace et {
+FdPoller::FdPoller() : pollerFd(epoll_create1(EPOLL_CLOEXEC)) {
+  if (pollerFd < 0) {
+    throw runtime_error(string("epoll_create1 failed: ") + strerror(errno));
+  }
+}
+
+FdPoller::Ready FdPoller::waitImpl(int capacity, int timeoutMs) {
+  vector<epoll_event> events(capacity);
+  int count = epoll_wait(pollerFd, events.data(), capacity, timeoutMs);
+  if (count < 0) {
+    if (errno == EINTR) {
+      return {};
+    }
+    throw runtime_error(string("epoll_wait failed: ") + strerror(errno));
+  }
+
+  Ready ready;
+  for (int i = 0; i < count; ++i) {
+    const int fd = events[i].data.fd;
+    const uint32_t reported = events[i].events;
+    // EPOLLHUP and EPOLLERR arrive unrequested, so report them only in the
+    // direction the caller asked about.
+    auto it = registeredFds.find(fd);
+    const short interest =
+        it == registeredFds.end() ? kRead | kWrite : it->second;
+    if ((interest & kRead) != 0 &&
+        (reported & (EPOLLIN | EPOLLRDHUP | EPOLLHUP | EPOLLERR)) != 0) {
+      ready.readable.insert(fd);
+    }
+    if ((interest & kWrite) != 0 &&
+        (reported & (EPOLLOUT | EPOLLHUP | EPOLLERR)) != 0) {
+      ready.writable.insert(fd);
+    }
+  }
+  return ready;
+}
+
+bool FdPoller::addFd(int fd, short interest) {
+  epoll_event event = {};
+  if ((interest & kRead) != 0) {
+    event.events |= EPOLLIN | EPOLLRDHUP;
+  }
+  if ((interest & kWrite) != 0) {
+    event.events |= EPOLLOUT;
+  }
+  event.data.fd = fd;
+  if (epoll_ctl(pollerFd, EPOLL_CTL_ADD, fd, &event) < 0) {
+    if (errno == EBADF) {
+      return false;
+    }
+    throw runtime_error(string("epoll_ctl add failed: ") + strerror(errno));
+  }
+  return true;
+}
+
+// epoll keys the interest list by descriptor, so one delete clears both
+// directions.
+void FdPoller::removeFd(int fd, short) {
+  if (epoll_ctl(pollerFd, EPOLL_CTL_DEL, fd, nullptr) < 0 && errno != EBADF &&
+      errno != ENOENT) {
+    throw runtime_error(string("epoll_ctl delete failed: ") + strerror(errno));
+  }
+}
+}  // namespace et
+#endif

--- a/src/base/Headers.hpp
+++ b/src/base/Headers.hpp
@@ -59,6 +59,7 @@ struct winsize {
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <paths.h>
+#include <poll.h>
 #include <pthread.h>
 #include <pwd.h>
 #include <resolv.h>
@@ -388,16 +389,18 @@ inline string protoToString(const T& t) {
 /**
  * Wait on a fd to have data available.
  *
- * @return true if the fd has data, or false if the timeout (of 1 second) is
- *   reached or if the call is interrupted by a syscall.
+ * @return true if the fd is readable, or (POSIX only) has hung up, errored, or
+ *   become invalid, so the caller's read reports the condition; false if the
+ *   timeout is reached or the call is interrupted by a syscall.
  */
-inline bool waitOnSocketData(int fd) {
+inline bool waitOnSocketData(int fd, int64_t sec = 1, int64_t usec = 0) {
+#ifdef WIN32
   fd_set fdset;
   FD_ZERO(&fdset);
   FD_SET(fd, &fdset);
   timeval tv;
-  tv.tv_sec = 1;
-  tv.tv_usec = 0;
+  tv.tv_sec = sec;
+  tv.tv_usec = usec;
   VLOG(4) << "Before selecting sockFd";
   const int selectResult = select(fd + 1, &fdset, NULL, NULL, &tv);
   if (selectResult < 0) {
@@ -409,21 +412,36 @@ inline bool waitOnSocketData(int fd) {
     }
   }
   return FD_ISSET(fd, &fdset);
+#else
+  struct pollfd pollFd = {fd, POLLIN, 0};
+  const int timeoutMs = static_cast<int>(sec * 1000 + usec / 1000);
+  const int pollResult = poll(&pollFd, 1, timeoutMs);
+  if (pollResult < 0) {
+    if (errno == EINTR) {
+      return false;
+    } else {
+      FATAL_FAIL(pollResult);
+    }
+  }
+  return pollResult > 0 &&
+         (pollFd.revents & (POLLIN | POLLERR | POLLHUP | POLLNVAL)) != 0;
+#endif
 }
 
 /**
  * Check whether a fd would accept a write right now without blocking.
  *
- * @return true if the fd is writable, or false if its buffer is full or the
- *   check is interrupted by a syscall.
+ * @return true if the fd is writable, or false if its buffer is full, the fd
+ *   was closed under us, or the check is interrupted by a syscall.
  */
-inline bool isSocketWritable(int fd) {
+inline bool isSocketWritable(int fd, int64_t sec = 0, int64_t usec = 0) {
+#ifdef WIN32
   fd_set fdset;
   FD_ZERO(&fdset);
   FD_SET(fd, &fdset);
   timeval tv;
-  tv.tv_sec = 0;
-  tv.tv_usec = 0;
+  tv.tv_sec = sec;
+  tv.tv_usec = usec;
   const int selectResult = select(fd + 1, NULL, &fdset, NULL, &tv);
   if (selectResult < 0) {
     if (errno == EINTR || errno == EBADF || errno == EINVAL) {
@@ -436,6 +454,22 @@ inline bool isSocketWritable(int fd) {
     }
   }
   return FD_ISSET(fd, &fdset);
+#else
+  struct pollfd pollFd = {fd, POLLOUT, 0};
+  const int timeoutMs = static_cast<int>(sec * 1000 + usec / 1000);
+  const int pollResult = poll(&pollFd, 1, timeoutMs);
+  if (pollResult < 0) {
+    if (errno == EINTR) {
+      return false;
+    } else {
+      FATAL_FAIL(pollResult);
+    }
+  }
+  // POLLNVAL is deliberately excluded: an fd closed under us reports "not
+  // writable" here, matching the EBADF handling in the select() branch.
+  return pollResult > 0 &&
+         (pollFd.revents & (POLLOUT | POLLERR | POLLHUP)) != 0;
+#endif
 }
 
 inline string genRandomAlphaNum(int len) {

--- a/src/base/PipeSocketHandler.cpp
+++ b/src/base/PipeSocketHandler.cpp
@@ -74,18 +74,12 @@ int PipeSocketHandler::connect(const SocketEndpoint& endpoint) {
     return sockFd;
   }
 
-  fd_set fdset;
-  FD_ZERO(&fdset);
-  FD_SET(sockFd, &fdset);
-  timeval tv;
-  tv.tv_sec = 3; /* 3 second timeout */
-  tv.tv_usec = 0;
-  VLOG(4) << "Before selecting sockFd";
-  int selectResult = select(sockFd + 1, NULL, &fdset, NULL, &tv);
-  VLOG(3) << "AF_UNIX connect select returned " << selectResult;
+  VLOG(4) << "Before waiting on sockFd";
+  const bool writable = isSocketWritable(sockFd, 3 /* 3 second timeout */);
+  VLOG(3) << "AF_UNIX connect wait returned " << writable;
 
-  if (FD_ISSET(sockFd, &fdset)) {
-    VLOG(4) << "sockFd " << sockFd << " is selected";
+  if (writable) {
+    VLOG(4) << "sockFd " << sockFd << " is writable";
     int so_error;
     socklen_t len = sizeof so_error;
 

--- a/src/base/TcpSocketHandler.cpp
+++ b/src/base/TcpSocketHandler.cpp
@@ -91,17 +91,8 @@ int TcpSocketHandler::connect(const SocketEndpoint& endpoint) {
       sockFd = -1;
       continue;
     }
-    fd_set fdset;
-    FD_ZERO(&fdset);
-    FD_SET(sockFd, &fdset);
-    timeval tv;
-    tv.tv_sec = 3; /* 3 second timeout */
-    tv.tv_usec = 0;
-    VLOG(4) << "Before selecting sockFd";
-    select(sockFd + 1, NULL, &fdset, NULL, &tv);
-
-    if (FD_ISSET(sockFd, &fdset)) {
-      VLOG(4) << "sockFd " << sockFd << " is selected";
+    if (isSocketWritable(sockFd, 3)) {
+      VLOG(4) << "sockFd " << sockFd << " is writable";
       int so_error;
       socklen_t len = sizeof so_error;
 

--- a/src/base/UnixSocketHandler.cpp
+++ b/src/base/UnixSocketHandler.cpp
@@ -6,21 +6,8 @@ namespace et {
 UnixSocketHandler::UnixSocketHandler() {}
 
 bool UnixSocketHandler::waitForData(int fd, int64_t sec, int64_t usec) {
-  fd_set input;
-  FD_ZERO(&input);
-  FD_SET(fd, &input);
-  struct timeval timeout;
-  timeout.tv_sec = sec;
-  timeout.tv_usec = usec;
-  int n = select(fd + 1, &input, NULL, NULL, &timeout);
-  if (n == -1) {
-    // Select timed out or failed.
-    VLOG(4) << "socket select timeout";
+  if (!et::waitOnSocketData(fd, sec, usec)) {
     return false;
-  } else if (n == 0)
-    return false;
-  if (!FD_ISSET(fd, &input)) {
-    STFATAL << "FD_ISSET is false but we should have data by now.";
   }
   VLOG(4) << "socket " << fd << " has data";
   return true;

--- a/src/base/UnixSocketHandler.hpp
+++ b/src/base/UnixSocketHandler.hpp
@@ -13,9 +13,7 @@ class UnixSocketHandler : public SocketHandler {
   UnixSocketHandler();
   virtual ~UnixSocketHandler() {}
 
-  /**
-   * @brief Blocks with select() until the fd becomes readable.
-   */
+  /** @brief Blocks until the fd becomes readable or the timeout expires. */
   virtual bool waitForData(int fd, int64_t sec, int64_t usec);
   /** @brief Queries whether the descriptor currently has readable bytes. */
   virtual bool hasData(int fd);

--- a/src/terminal/TerminalClient.cpp
+++ b/src/terminal/TerminalClient.cpp
@@ -88,20 +88,13 @@ TerminalClient::TerminalClient(
       if (connection->connect()) {
         connection->writePacket(
             Packet(EtPacketType::INITIAL_PAYLOAD, protoToString(payload)));
-        fd_set rfd;
-        timeval tv;
         for (int a = 0; a < 3; a++) {
-          FD_ZERO(&rfd);
           int clientFd = connection->getSocketFd();
           if (clientFd < 0) {
             std::this_thread::sleep_for(std::chrono::seconds(1));
             continue;
           }
-          FD_SET(clientFd, &rfd);
-          tv.tv_sec = 1;
-          tv.tv_usec = 0;
-          select(clientFd + 1, &rfd, NULL, NULL, &tv);
-          if (FD_ISSET(clientFd, &rfd)) {
+          if (waitOnSocketData(clientFd)) {
             Packet initialResponsePacket;
             if (connection->readPacket(&initialResponsePacket)) {
               if (initialResponsePacket.getHeader() !=
@@ -198,57 +191,109 @@ void TerminalClient::run(const string& command, const bool noexit) {
         break;
       }
     }
-    // Data structures needed for select() and
-    // non-blocking I/O.
-    fd_set rfd, wfd;
-    timeval tv;
-
-    FD_ZERO(&rfd);
-    FD_ZERO(&wfd);
-    int maxfd = -1;
     int consoleFd = -1;
     if (console && !consoleInputDisabled) {
       consoleFd = console->getFd();
-      maxfd = consoleFd;
+    }
+    const bool consoleWritable = console && consoleOut.hasPendingData();
+    const int clientFd = connection->getSocketFd();
+    const bool watchClient =
+        clientFd > 0 && consoleOut.size() < WriteBuffer::FLUSH_THRESHOLD;
+    // Include port forward sockets for low-latency forwarding.
+    set<int> pfFds;
+    portForwardHandler->getForwardFds(&pfFds);
+
+    set<int> readyFds;
+#ifdef WIN32
+    fd_set rfd, wfd;
+    FD_ZERO(&rfd);
+    FD_ZERO(&wfd);
+    int maxfd = -1;
+    if (consoleFd >= 0) {
       FD_SET(consoleFd, &rfd);
-#ifndef WIN32
-      // PseudoTerminalConsole writes to stdout and reads keystrokes from
-      // stdin. FakeConsole (tests) uses one pipe for both; selecting the
-      // process stdin there races an always-ready EOF and disables input.
-      if (consoleFd == STDOUT_FILENO) {
-        FD_SET(STDIN_FILENO, &rfd);
-        maxfd = max(maxfd, STDIN_FILENO);
-      }
-#endif
+      maxfd = consoleFd;
     }
-    if (console && consoleOut.hasPendingData()) {
-      int outFd = console->getFd();
-      FD_SET(outFd, &wfd);
-      maxfd = max(maxfd, outFd);
+    if (consoleWritable) {
+      FD_SET(console->getFd(), &wfd);
+      maxfd = max(maxfd, console->getFd());
     }
-    int clientFd = connection->getSocketFd();
-    if (clientFd > 0 && consoleOut.size() < WriteBuffer::FLUSH_THRESHOLD) {
+    if (watchClient) {
       FD_SET(clientFd, &rfd);
       maxfd = max(maxfd, clientFd);
     }
-    // Include port forward sockets in select for low-latency forwarding.
-    set<int> pfFds;
-    portForwardHandler->getForwardFds(&pfFds);
     for (int fd : pfFds) {
       FD_SET(fd, &rfd);
       maxfd = max(maxfd, fd);
     }
+    timeval tv;
     tv.tv_sec = 0;
     tv.tv_usec = 10000;
     select(maxfd + 1, &rfd, &wfd, NULL, &tv);
+    if (consoleFd >= 0 && FD_ISSET(consoleFd, &rfd)) {
+      readyFds.insert(consoleFd);
+    }
+    if (watchClient && FD_ISSET(clientFd, &rfd)) {
+      readyFds.insert(clientFd);
+    }
+    for (int fd : pfFds) {
+      if (FD_ISSET(fd, &rfd)) {
+        readyFds.insert(fd);
+      }
+    }
+#else
+    // poll() has no FD_SETSIZE ceiling, and unlike epoll it accepts the
+    // regular file nohup(1) leaves on the console descriptor.
+    vector<struct pollfd> pollFds;
+    // The console read and write descriptors are the same fd, so interest is
+    // merged rather than appended.
+    auto watch = [&pollFds](int fd, short events) {
+      for (auto& pollFd : pollFds) {
+        if (pollFd.fd == fd) {
+          pollFd.events |= events;
+          return;
+        }
+      }
+      pollFds.push_back({fd, events, 0});
+    };
+    if (consoleFd >= 0) {
+      watch(consoleFd, POLLIN);
+      // PseudoTerminalConsole writes to stdout and reads keystrokes from
+      // stdin. FakeConsole (tests) uses one pipe for both; watching the
+      // process stdin there races an always-ready EOF and disables input.
+      if (consoleFd == STDOUT_FILENO) {
+        watch(STDIN_FILENO, POLLIN);
+      }
+    }
+    if (consoleWritable) {
+      // Only needs to wake the loop; the drain below re-checks writability.
+      watch(console->getFd(), POLLOUT);
+    }
+    if (watchClient) {
+      watch(clientFd, POLLIN);
+    }
+    for (int fd : pfFds) {
+      watch(fd, POLLIN);
+    }
+    const int pollResult =
+        poll(pollFds.data(), static_cast<nfds_t>(pollFds.size()), 10);
+    if (pollResult < 0 && errno != EINTR) {
+      FATAL_FAIL(pollResult);
+    }
+    for (const auto& pollFd : pollFds) {
+      if ((pollFd.events & POLLIN) != 0 &&
+          (pollFd.revents & (POLLIN | POLLERR | POLLHUP | POLLNVAL)) != 0) {
+        readyFds.insert(pollFd.fd);
+      }
+    }
+#endif
 
     try {
       bool skipServerRead = false;
       if (console && consoleFd >= 0) {
-        bool inputReady = FD_ISSET(consoleFd, &rfd);
+        bool inputReady = readyFds.count(consoleFd) != 0;
 #ifndef WIN32
         if (consoleFd == STDOUT_FILENO) {
-          inputReady = inputReady || FD_ISSET(STDIN_FILENO, &rfd);
+          inputReady = inputReady || readyFds.count(STDIN_FILENO) != 0;
         }
 #endif
         if (inputReady) {
@@ -293,7 +338,8 @@ void TerminalClient::run(const string& command, const bool noexit) {
 #else
           if (console) {
             int readFd = consoleFd;
-            if (consoleFd == STDOUT_FILENO && FD_ISSET(STDIN_FILENO, &rfd)) {
+            if (consoleFd == STDOUT_FILENO &&
+                readyFds.count(STDIN_FILENO) != 0) {
               readFd = STDIN_FILENO;
             }
             int rc = ::read(readFd, b, BUF_SIZE);
@@ -343,7 +389,7 @@ void TerminalClient::run(const string& command, const bool noexit) {
         }
       }
 
-      if (!skipServerRead && clientFd > 0 && FD_ISSET(clientFd, &rfd)) {
+      if (!skipServerRead && clientFd > 0 && readyFds.count(clientFd) != 0) {
         VLOG(4) << "Clientfd is selected";
         // Cap how much we pull from the server so Ctrl+C can be handled
         // before megabytes of flood are painted. Sequence numbers are
@@ -433,7 +479,13 @@ void TerminalClient::run(const string& command, const bool noexit) {
 
       vector<PortForwardDestinationRequest> requests;
       vector<PortForwardData> dataToSend;
+#ifdef WIN32
+      // select() silently drops descriptors past FD_SETSIZE, so readiness is
+      // not authoritative here and every handler has to be checked.
       portForwardHandler->update(&requests, &dataToSend);
+#else
+      portForwardHandler->update(&requests, &dataToSend, &readyFds);
+#endif
       for (auto& pfr : requests) {
         connection->writePacket(
             Packet(TerminalPacketType::PORT_FORWARD_DESTINATION_REQUEST,

--- a/src/terminal/TerminalServer.cpp
+++ b/src/terminal/TerminalServer.cpp
@@ -3,6 +3,7 @@
 
 #include <cstdint>
 
+#include "FdPoller.hpp"
 #include "JumphostPending.hpp"
 #include "TelemetryService.hpp"
 #include "TmuxCcFilter.hpp"
@@ -17,13 +18,7 @@ void drainDiscardReadableBytes(int fd, WriteBuffer* buf) {
   char bufBytes[BUF_SIZE];
   bool got = false;
   while (true) {
-    fd_set rfds;
-    FD_ZERO(&rfds);
-    FD_SET(fd, &rfds);
-    timeval tv;
-    tv.tv_sec = 0;
-    tv.tv_usec = 0;
-    if (select(fd + 1, &rfds, NULL, NULL, &tv) <= 0) {
+    if (!waitOnSocketData(fd, 0, 0)) {
       break;
     }
     int rc = ::read(fd, bufBytes, BUF_SIZE);
@@ -136,19 +131,11 @@ TerminalServer::~TerminalServer() {}
 
 void TerminalServer::run() {
   LOG(INFO) << "Creating server";
-  fd_set coreFds;
-  int numCoreFds = 0;
-  int maxCoreFd = 0;
-  FD_ZERO(&coreFds);
   set<int> serverPortFds = socketHandler->getEndpointFds(serverEndpoint);
-  for (int i : serverPortFds) {
-    FD_SET(i, &coreFds);
-    maxCoreFd = max(maxCoreFd, i);
-    numCoreFds++;
-  }
-  FD_SET(terminalRouter->getServerFd(), &coreFds);
-  maxCoreFd = max(maxCoreFd, terminalRouter->getServerFd());
-  numCoreFds++;
+  set<int> coreFds = serverPortFds;
+  coreFds.insert(terminalRouter->getServerFd());
+  FdPoller poller;
+  poller.setFds(coreFds);
 
   if (TelemetryService::exists()) {
     TelemetryService::get()->logToDatadog("Server started", el::Level::Info,
@@ -162,39 +149,17 @@ void TerminalServer::run() {
         break;
       }
     }
-    // Select blocks until there is something useful to do
-    fd_set rfds = coreFds;
-    int numFds = numCoreFds;
-    int maxFd = maxCoreFd;
-    timeval tv;
-
-    if (numFds > FD_SETSIZE) {
-      STFATAL << "Tried to select() on too many FDs";
-    }
-
-    tv.tv_sec = 0;
-    tv.tv_usec = 100000;
-
-    const int numFdsSet = select(maxFd + 1, &rfds, NULL, NULL, &tv);
-    if (numFdsSet < 0 && errno == EINTR) {
-      // If EINTR was returned, then the syscall was interrupted by a signal.
-      // This is not an error, but can be a signal that the program is being
-      // shutdown, so restart the loop to check for the halt condition.
+    set<int> readyFds = poller.wait(100).readable;
+    if (readyFds.empty()) {
       continue;
     }
 
-    FATAL_FAIL(numFdsSet);
-    if (numFdsSet == 0) {
-      continue;
-    }
-
-    // We have something to do!
     for (int i : serverPortFds) {
-      if (FD_ISSET(i, &rfds)) {
+      if (readyFds.count(i) != 0) {
         acceptNewConnection(i);
       }
     }
-    if (FD_ISSET(terminalRouter->getServerFd(), &rfds)) {
+    if (readyFds.count(terminalRouter->getServerFd()) != 0) {
       auto idKeyPair = terminalRouter->acceptNewConnection();
       if (idKeyPair.id.length()) {
         addClientKey(idKeyPair.id, idKeyPair.key);
@@ -234,6 +199,7 @@ void TerminalServer::runJumpHost(
 
   shared_ptr<SocketHandler> terminalSocketHandler =
       terminalRouter->getSocketHandler();
+  FdPoller poller;
 
   terminalSocketHandler->writePacket(
       terminalFd,
@@ -251,12 +217,9 @@ void TerminalServer::runJumpHost(
       }
     }
 
-    fd_set rfd, wfd;
-    timeval tv;
-
-    FD_ZERO(&rfd);
-    FD_ZERO(&wfd);
-    int maxfd = -1;
+    set<int> readFds;
+    set<int> writeFds;
+    set<int> refreshFds;
     int serverClientFd = serverClientState->getSocketFd();
     const bool connected = serverClientFd > 0;
     // Connected: bound the userspace queue. Disconnected: keep today's
@@ -265,28 +228,27 @@ void TerminalServer::runJumpHost(
                             ? pending.canAcceptMore()
                             : serverClientState->canBufferWrite(2 * BUF_SIZE);
     if (readTerminal && !holdDroppableForClient) {
-      FD_SET(terminalFd, &rfd);
-      maxfd = terminalFd;
+      readFds.insert(terminalFd);
     }
     if (connected) {
       getSocketHandler()->minimizeKernelBuffering(serverClientFd);
-      FD_SET(serverClientFd, &rfd);
-      maxfd = max(maxfd, serverClientFd);
+      readFds.insert(serverClientFd);
+      // A reconnect can hand back the same fd number for a new socket.
+      refreshFds.insert(serverClientFd);
       if (!pending.empty() && !holdDroppableForClient) {
-        FD_SET(serverClientFd, &wfd);
+        writeFds.insert(serverClientFd);
       }
     }
-    tv.tv_sec = 0;
-    tv.tv_usec = 100000;
-    if (select(maxfd + 1, &rfd, &wfd, NULL, &tv) < 0 && errno == EINTR) {
-      continue;
-    }
+    poller.setFds(readFds, writeFds, refreshFds);
+    // Write readiness only needs to wake the loop; the drain below re-checks
+    // it per write.
+    const set<int> readyFds = poller.wait(100).readable;
 
     try {
       // Read client input before draining, so Ctrl+C can drop the backlog
       // instead of losing the race to a writable socket.
-      if (serverClientFd > 0 && FD_ISSET(serverClientFd, &rfd)) {
-        VLOG(4) << "Jumphost is selected";
+      if (serverClientFd > 0 && readyFds.count(serverClientFd) != 0) {
+        VLOG(4) << "Jumphost socket is ready";
         if (serverClientState->hasData()) {
           VLOG(4) << "Jumphost serverClientState has data";
           Packet packet;
@@ -335,7 +297,7 @@ void TerminalServer::runJumpHost(
             serverClientState.get(), stillConnected ? serverClientFd : -1);
       }
 
-      if (FD_ISSET(terminalFd, &rfd)) {
+      if (readyFds.count(terminalFd) != 0) {
         try {
           Packet packet;
           if (terminalSocketHandler->readPacket(terminalFd, &packet)) {
@@ -430,6 +392,8 @@ void TerminalServer::runTerminal(
   int terminalFd = userInfo.fd();
   shared_ptr<SocketHandler> terminalSocketHandler =
       terminalRouter->getSocketHandler();
+  FdPoller poller;
+  uint64_t forwardFdsGeneration = portForwardHandler->getForwardFdsGeneration();
 
   TermInit termInit;
   for (auto& it : environmentVariables) {
@@ -452,14 +416,9 @@ void TerminalServer::runTerminal(
       }
     }
 
-    // Data structures needed for select() and
-    // non-blocking I/O.
-    fd_set rfd, wfd;
-    timeval tv;
-
-    FD_ZERO(&rfd);
-    FD_ZERO(&wfd);
-    int maxfd = -1;
+    set<int> readFds;
+    set<int> writeFds;
+    set<int> refreshFds;
     int serverClientFd = serverClientState->getSocketFd();
     const bool connected = serverClientFd > 0;
     // Connected: stage in WriteBuffer (16MB cap). Disconnected: today's
@@ -469,38 +428,41 @@ void TerminalServer::runTerminal(
                             ? terminalOutputBuffer.canAcceptMore()
                             : serverClientState->canBufferWrite(2 * BUF_SIZE);
     if (readTerminal && !holdDroppableForClient) {
-      FD_SET(terminalFd, &rfd);
-      maxfd = terminalFd;
+      readFds.insert(terminalFd);
     }
     if (connected) {
       // Reapply every iteration: reconnect replaces the socket, kernel
       // tuning is per-socket, and fd numbers are reused.
       serverSocketHandler->minimizeKernelBuffering(serverClientFd);
-      FD_SET(serverClientFd, &rfd);
-      maxfd = max(maxfd, serverClientFd);
+      readFds.insert(serverClientFd);
+      refreshFds.insert(serverClientFd);
       if (terminalOutputBuffer.hasPendingData() && !holdDroppableForClient) {
-        FD_SET(serverClientFd, &wfd);
+        writeFds.insert(serverClientFd);
       }
     }
-    // Include port forward sockets in select for low-latency forwarding.
+    // Include port forward sockets for low-latency forwarding.
     set<int> pfFds;
     portForwardHandler->getForwardFds(&pfFds);
-    for (int fd : pfFds) {
-      FD_SET(fd, &rfd);
-      maxfd = max(maxfd, fd);
+    readFds.insert(pfFds.begin(), pfFds.end());
+
+    // Any open or close since the last pass may have recycled an fd number.
+    uint64_t currentForwardFdsGeneration =
+        portForwardHandler->getForwardFdsGeneration();
+    if (currentForwardFdsGeneration != forwardFdsGeneration) {
+      refreshFds.insert(pfFds.begin(), pfFds.end());
+      forwardFdsGeneration = currentForwardFdsGeneration;
     }
-    tv.tv_sec = 0;
-    tv.tv_usec = 100000;
-    if (select(maxfd + 1, &rfd, &wfd, NULL, &tv) < 0 && errno == EINTR) {
-      continue;
-    }
+    poller.setFds(readFds, writeFds, refreshFds);
+    // Write readiness only needs to wake the loop; the drain below re-checks
+    // it per write.
+    const set<int> readyFds = poller.wait(100).readable;
 
     try {
       // Handle client input before draining the output queue. Otherwise a
       // writable socket (fast client, or a client just resumed) sends the
       // whole backlog before Ctrl+C is read, and flushIfLarge sees nothing.
-      if (serverClientFd > 0 && FD_ISSET(serverClientFd, &rfd)) {
-        VLOG(3) << "ServerClientFd is selected";
+      if (serverClientFd > 0 && readyFds.count(serverClientFd) != 0) {
+        VLOG(3) << "ServerClientFd is ready";
         while (serverClientState->hasData()) {
           VLOG(3) << "ServerClientState has data";
           Packet packet;
@@ -585,7 +547,7 @@ void TerminalServer::runTerminal(
       // Check for data to receive; the received
       // data includes also the data previously sent
       // on the same master descriptor (line 90).
-      if (FD_ISSET(terminalFd, &rfd)) {
+      if (readyFds.count(terminalFd) != 0) {
         // Read from terminal and write to client
         memset(b, 0, BUF_SIZE);
         int rc = read(terminalFd, b, BUF_SIZE);
@@ -622,7 +584,7 @@ void TerminalServer::runTerminal(
 
       vector<PortForwardDestinationRequest> requests;
       vector<PortForwardData> dataToSend;
-      portForwardHandler->update(&requests, &dataToSend);
+      portForwardHandler->update(&requests, &dataToSend, &readyFds);
       for (auto& pfr : requests) {
         serverClientState->writePacket(
             Packet(TerminalPacketType::PORT_FORWARD_DESTINATION_REQUEST,
@@ -691,8 +653,14 @@ void TerminalServer::handleConnection(
 bool TerminalServer::newClient(
     shared_ptr<ServerClientConnection> serverClientState) {
   lock_guard<std::mutex> guard(terminalThreadMutex);
-  shared_ptr<thread> t = shared_ptr<thread>(
-      new thread(&TerminalServer::handleConnection, this, serverClientState));
+  auto t = make_shared<thread>([this, serverClientState]() {
+    try {
+      handleConnection(serverClientState);
+    } catch (const std::exception& ex) {
+      LOG(ERROR) << "Terminal thread failed: " << ex.what();
+      removeClient(serverClientState->getId());
+    }
+  });
   terminalThreads.push_back(t);
   return true;
 }

--- a/src/terminal/forwarding/ForwardDestinationHandler.cpp
+++ b/src/terminal/forwarding/ForwardDestinationHandler.cpp
@@ -12,8 +12,12 @@ void ForwardDestinationHandler::write(const string& s) {
   socketHandler->writeAllOrReturn(fd, s.c_str(), s.length());
 }
 
-void ForwardDestinationHandler::update(vector<PortForwardData>* retval) {
+void ForwardDestinationHandler::update(vector<PortForwardData>* retval,
+                                       const set<int>* readyFds) {
   if (fd == -1) {
+    return;
+  }
+  if (readyFds != nullptr && readyFds->count(fd) == 0) {
     return;
   }
 

--- a/src/terminal/forwarding/ForwardDestinationHandler.hpp
+++ b/src/terminal/forwarding/ForwardDestinationHandler.hpp
@@ -18,8 +18,10 @@ class ForwardDestinationHandler {
   /** @brief Sends bytes that need to travel to the destination socket. */
   void write(const string& s);
 
-  /** @brief Polls for incoming data to send back to the source. */
-  void update(vector<PortForwardData>* retval);
+  /** @brief Polls for incoming data to send back to the source. Does nothing
+   * unless `readyFds` names this handler's fd; `nullptr` always polls. */
+  void update(vector<PortForwardData>* retval,
+              const set<int>* readyFds = nullptr);
 
   /** @brief Closes the destination socket and marks the handler inactive. */
   void close();

--- a/src/terminal/forwarding/ForwardSourceHandler.cpp
+++ b/src/terminal/forwarding/ForwardSourceHandler.cpp
@@ -16,9 +16,11 @@ ForwardSourceHandler::~ForwardSourceHandler() {
   socketHandler->stopListening(source);
 }
 
-int ForwardSourceHandler::listen() {
-  // TODO: Replace with select
+int ForwardSourceHandler::listen(const set<int>* readyFds) {
   for (int i : socketHandler->getEndpointFds(source)) {
+    if (readyFds != nullptr && readyFds->count(i) == 0) {
+      continue;
+    }
     int fd = socketHandler->accept(i);
     if (fd > -1) {
       LOG(INFO) << "Tunnel " << source << " -> " << destination
@@ -30,12 +32,16 @@ int ForwardSourceHandler::listen() {
   return -1;
 }
 
-void ForwardSourceHandler::update(vector<PortForwardData>* data) {
+bool ForwardSourceHandler::update(vector<PortForwardData>* data,
+                                  const set<int>* readyFds) {
   vector<int> socketsToRemove;
 
   for (auto& it : socketFdMap) {
     int socketId = it.first;
     int fd = it.second;
+    if (readyFds != nullptr && readyFds->count(fd) == 0) {
+      continue;
+    }
 
     while (socketHandler->hasData(fd)) {
       char buf[1024];
@@ -71,6 +77,7 @@ void ForwardSourceHandler::update(vector<PortForwardData>* data) {
   for (auto& it : socketsToRemove) {
     socketFdMap.erase(it);
   }
+  return !socketsToRemove.empty();
 }
 
 bool ForwardSourceHandler::hasUnassignedFd(int fd) {
@@ -103,9 +110,6 @@ void ForwardSourceHandler::getActiveFds(set<int>* fds) {
   }
   for (auto& it : socketFdMap) {
     fds->insert(it.second);
-  }
-  for (int fd : unassignedFds) {
-    fds->insert(fd);
   }
 }
 

--- a/src/terminal/forwarding/ForwardSourceHandler.hpp
+++ b/src/terminal/forwarding/ForwardSourceHandler.hpp
@@ -23,13 +23,16 @@ class ForwardSourceHandler {
 
   ~ForwardSourceHandler();
 
-  /** @brief Starts listening on the source endpoint and returns the server fd.
+  /** @brief Accepts one pending connection and returns its fd, or -1 if none.
+   * Accepts only on endpoints named in `readyFds`; `nullptr` tries every one.
    */
-  int listen();
+  int listen(const set<int>* readyFds = nullptr);
 
-  /** @brief Polls all active sockets and stages `PortForwardData` for
-   * destinations. */
-  void update(vector<PortForwardData>* data);
+  /** @brief Reads the sockets named in `readyFds` (all of them when `nullptr`)
+   * and stages `PortForwardData` for destinations.
+   * @return true if any socket was closed and dropped. */
+  bool update(vector<PortForwardData>* data,
+              const set<int>* readyFds = nullptr);
 
   /** @brief Returns true if an accepted socket is pending assignment. */
   bool hasUnassignedFd(int fd);

--- a/src/terminal/forwarding/PortForwardHandler.cpp
+++ b/src/terminal/forwarding/PortForwardHandler.cpp
@@ -14,10 +14,13 @@ PortForwardHandler::PortForwardHandler(
       sessionGid(groupid) {}
 
 void PortForwardHandler::update(vector<PortForwardDestinationRequest>* requests,
-                                vector<PortForwardData>* dataToSend) {
+                                vector<PortForwardData>* dataToSend,
+                                const set<int>* readyFds) {
   for (auto& it : sourceHandlers) {
-    it->update(dataToSend);
-    int fd = it->listen();
+    if (it->update(dataToSend, readyFds)) {
+      ++forwardFdsGeneration;
+    }
+    int fd = it->listen(readyFds);
     if (fd >= 0) {
       PortForwardDestinationRequest pfr;
       *(pfr.mutable_destination()) = it->getDestination();
@@ -27,11 +30,12 @@ void PortForwardHandler::update(vector<PortForwardDestinationRequest>* requests,
   }
 
   for (auto& it : destinationHandlers) {
-    it.second->update(dataToSend);
+    it.second->update(dataToSend, readyFds);
     if (it.second->getFd() == -1) {
       // Kill the handler and don't update the rest: we'll pick
       // them up later
       destinationHandlers.erase(it.first);
+      ++forwardFdsGeneration;
       break;
     }
   }
@@ -79,6 +83,7 @@ PortForwardSourceResponse PortForwardHandler::createSource(
       auto handler = shared_ptr<ForwardSourceHandler>(new ForwardSourceHandler(
           networkSocketHandler, source, pfsr.destination()));
       sourceHandlers.push_back(handler);
+      ++forwardFdsGeneration;
       return PortForwardSourceResponse();
     } else {
 #ifndef WIN32
@@ -93,12 +98,14 @@ PortForwardSourceResponse PortForwardHandler::createSource(
             shared_ptr<ForwardSourceHandler>(new ForwardSourceHandler(
                 pipeSocketHandler, source, pfsr.destination(), true));
         sourceHandlers.push_back(handler);
+        ++forwardFdsGeneration;
         return PortForwardSourceResponse();
       }
 #endif
       auto handler = shared_ptr<ForwardSourceHandler>(new ForwardSourceHandler(
           pipeSocketHandler, source, pfsr.destination()));
       sourceHandlers.push_back(handler);
+      ++forwardFdsGeneration;
       return PortForwardSourceResponse();
     }
   } catch (const std::runtime_error& ex) {
@@ -164,6 +171,7 @@ PortForwardDestinationResponse PortForwardHandler::createDestination(
           shared_ptr<ForwardDestinationHandler>(new ForwardDestinationHandler(
               isTcp ? networkSocketHandler : pipeSocketHandler, fd, socketId));
       pfdresponse.set_socketid(socketId);
+      ++forwardFdsGeneration;
     }
   }
   return pfdresponse;
@@ -185,11 +193,13 @@ void PortForwardHandler::handlePacket(const Packet& packet,
             LOG(INFO) << "Port forward socket closed: " << pwd.socketid();
             it->second->close();
             destinationHandlers.erase(it);
+            ++forwardFdsGeneration;
           } else if (pwd.has_error()) {
             // TODO: Probably need to do something better here
             LOG(INFO) << "Port forward socket errored: " << pwd.socketid();
             it->second->close();
             destinationHandlers.erase(it);
+            ++forwardFdsGeneration;
           } else {
             it->second->write(pwd.buffer());
           }
@@ -257,6 +267,7 @@ void PortForwardHandler::addSourceSocketId(int socketId, int sourceFd) {
     if (it->hasUnassignedFd(sourceFd)) {
       it->addSocket(socketId, sourceFd);
       socketIdSourceHandlerMap[socketId] = it;
+      ++forwardFdsGeneration;
       return;
     }
   }
@@ -273,6 +284,7 @@ void PortForwardHandler::closeSourceSocketId(int socketId) {
   }
   it->second->closeSocket(socketId);
   socketIdSourceHandlerMap.erase(socketId);
+  ++forwardFdsGeneration;
 }
 
 void PortForwardHandler::getForwardFds(set<int>* fds) {

--- a/src/terminal/forwarding/PortForwardHandler.hpp
+++ b/src/terminal/forwarding/PortForwardHandler.hpp
@@ -24,10 +24,12 @@ class PortForwardHandler {
                               shared_ptr<SocketHandler> _pipeSocketHandler,
                               uid_t userid = static_cast<uid_t>(-1),
                               gid_t groupid = static_cast<gid_t>(-1));
-  /** @brief Polls all handlers for new destination/data and sends
-   * `PortForwardData`. */
+  /** @brief Polls handlers and collects destination requests and
+   * `PortForwardData` for the caller to send. Touches only the descriptors
+   * named in `readyFds`; `nullptr` polls every one. */
   void update(vector<PortForwardDestinationRequest>* requests,
-              vector<PortForwardData>* dataToSend);
+              vector<PortForwardData>* dataToSend,
+              const set<int>* readyFds = nullptr);
   /** @brief Handles control packets arriving over the SSH connection. */
   void handlePacket(const Packet& packet, shared_ptr<Connection> connection);
   PortForwardSourceResponse createSource(const PortForwardSourceRequest& pfsr,
@@ -49,6 +51,7 @@ class PortForwardHandler {
    * socket. */
   void sendDataToSourceOnSocket(int socketId, const string& data);
   void getForwardFds(set<int>* fds);
+  uint64_t getForwardFdsGeneration() const { return forwardFdsGeneration; }
 
  protected:
   /** @brief Handler used for the SSH/network-facing sockets. */
@@ -67,6 +70,10 @@ class PortForwardHandler {
   /** @brief Maps control socket IDs to their source handlers for routing data.
    */
   unordered_map<int, shared_ptr<ForwardSourceHandler>> socketIdSourceHandlerMap;
+  /** @brief Bumped by every site that opens or closes a descriptor exposed by
+   * `getForwardFds`: a recycled fd number yields an identical set, so this is
+   * a poller's only signal that it must re-register. */
+  uint64_t forwardFdsGeneration = 0;
 };
 }  // namespace et
 

--- a/test/unit_tests/FdPollerTest.cpp
+++ b/test/unit_tests/FdPollerTest.cpp
@@ -1,0 +1,108 @@
+#include "FdPoller.hpp"
+#include "TcpSocketHandler.hpp"
+#include "TestHeaders.hpp"
+
+using namespace et;
+
+TEST_CASE("FdPoller supports descriptors above FD_SETSIZE", "[FdPoller]") {
+  int pipeFds[2];
+  REQUIRE(pipe(pipeFds) == 0);
+  int highFd = fcntl(pipeFds[0], F_DUPFD, FD_SETSIZE);
+  REQUIRE(highFd >= FD_SETSIZE);
+  REQUIRE(close(pipeFds[0]) == 0);
+  int highWriteFd = fcntl(pipeFds[1], F_DUPFD, FD_SETSIZE);
+  REQUIRE(highWriteFd >= FD_SETSIZE);
+  REQUIRE(close(pipeFds[1]) == 0);
+
+  FdPoller poller;
+  poller.setFds({highFd});
+
+  char byte = 'x';
+  CHECK(isSocketWritable(highWriteFd));
+  REQUIRE(write(highWriteFd, &byte, 1) == 1);
+  CHECK(waitOnSocketData(highFd));
+  TcpSocketHandler socketHandler;
+  CHECK(socketHandler.waitForData(highFd, 0, 0));
+  CHECK(poller.wait(1000).readable.count(highFd) == 1);
+
+  CHECK(close(highFd) == 0);
+  CHECK(close(highWriteFd) == 0);
+}
+
+TEST_CASE("FdPoller replaces its descriptor set", "[FdPoller]") {
+  int firstPipe[2];
+  int secondPipe[2];
+  REQUIRE(pipe(firstPipe) == 0);
+  REQUIRE(pipe(secondPipe) == 0);
+
+  FdPoller poller;
+  poller.setFds({firstPipe[0]});
+  CHECK(poller.wait(0).readable.empty());
+
+  poller.setFds({secondPipe[0]});
+  char byte = 'x';
+  REQUIRE(write(secondPipe[1], &byte, 1) == 1);
+  FdPoller::Ready ready = poller.wait(1000);
+  CHECK(ready.readable.count(firstPipe[0]) == 0);
+  CHECK(ready.readable.count(secondPipe[0]) == 1);
+
+  CHECK(close(firstPipe[0]) == 0);
+  CHECK(close(firstPipe[1]) == 0);
+  CHECK(close(secondPipe[0]) == 0);
+  CHECK(close(secondPipe[1]) == 0);
+}
+
+TEST_CASE("FdPoller reports write readiness", "[FdPoller]") {
+  int pipeFds[2];
+  REQUIRE(pipe(pipeFds) == 0);
+
+  FdPoller poller;
+  poller.setFds({pipeFds[0]}, {pipeFds[1]});
+
+  FdPoller::Ready ready = poller.wait(1000);
+  // An empty pipe is writable but not readable.
+  CHECK(ready.writable.count(pipeFds[1]) == 1);
+  CHECK(ready.readable.count(pipeFds[0]) == 0);
+
+  char byte = 'x';
+  REQUIRE(write(pipeFds[1], &byte, 1) == 1);
+  ready = poller.wait(1000);
+  CHECK(ready.readable.count(pipeFds[0]) == 1);
+
+  CHECK(close(pipeFds[0]) == 0);
+  CHECK(close(pipeFds[1]) == 0);
+}
+
+TEST_CASE("FdPoller refreshes a reused descriptor number", "[FdPoller]") {
+  int firstPipe[2];
+  int secondPipe[2];
+  REQUIRE(pipe(firstPipe) == 0);
+  REQUIRE(pipe(secondPipe) == 0);
+
+  int watchedFd = firstPipe[0];
+  FdPoller poller;
+  poller.setFds({watchedFd});
+
+  REQUIRE(close(watchedFd) == 0);
+  REQUIRE(dup2(secondPipe[0], watchedFd) == watchedFd);
+  REQUIRE(close(secondPipe[0]) == 0);
+  poller.setFds({watchedFd}, {}, {watchedFd});
+
+  char byte = 'x';
+  REQUIRE(write(secondPipe[1], &byte, 1) == 1);
+  CHECK(poller.wait(1000).readable.count(watchedFd) == 1);
+
+  CHECK(close(watchedFd) == 0);
+  CHECK(close(firstPipe[1]) == 0);
+  CHECK(close(secondPipe[1]) == 0);
+}
+
+TEST_CASE("Socket polling surfaces invalid descriptors", "[FdPoller]") {
+  int pipeFds[2];
+  REQUIRE(pipe(pipeFds) == 0);
+  REQUIRE(close(pipeFds[0]) == 0);
+
+  CHECK(waitOnSocketData(pipeFds[0], 0, 0));
+
+  CHECK(close(pipeFds[1]) == 0);
+}

--- a/test/unit_tests/ForwardSourceHandlerTest.cpp
+++ b/test/unit_tests/ForwardSourceHandlerTest.cpp
@@ -339,6 +339,59 @@ TEST_CASE("ForwardSourceHandler update ignores transient EAGAIN reads",
   REQUIRE(socketHandler->closedFds.empty());
 }
 
+TEST_CASE("ForwardSourceHandler update reads only ready fds",
+          "[ForwardSourceHandler]") {
+  auto socketHandler = std::make_shared<MockSocketHandler>();
+  socketHandler->setEndpointFds({100});
+  socketHandler->enqueueAccept(42);
+
+  SocketEndpoint source;
+  source.set_name("localhost");
+  source.set_port(8080);
+  SocketEndpoint destination;
+  destination.set_name("remote");
+  destination.set_port(9090);
+  ForwardSourceHandler handler(socketHandler, source, destination);
+
+  int fd = handler.listen();
+  handler.addSocket(123, fd);
+  socketHandler->enqueueHasData(true);
+  socketHandler->enqueueRead(4, "data");
+  socketHandler->enqueueHasData(false);
+
+  std::vector<PortForwardData> data;
+  set<int> readyFds;
+  handler.update(&data, &readyFds);
+  CHECK(data.empty());
+
+  readyFds.insert(fd);
+  handler.update(&data, &readyFds);
+  REQUIRE(data.size() == 1);
+  CHECK(data[0].buffer() == "data");
+}
+
+TEST_CASE("ForwardSourceHandler listens only on ready fds",
+          "[ForwardSourceHandler]") {
+  auto socketHandler = std::make_shared<MockSocketHandler>();
+  socketHandler->setEndpointFds({100});
+  socketHandler->enqueueAccept(42);
+
+  SocketEndpoint source;
+  source.set_name("localhost");
+  source.set_port(8080);
+  SocketEndpoint destination;
+  destination.set_name("remote");
+  destination.set_port(9090);
+  ForwardSourceHandler handler(socketHandler, source, destination);
+
+  set<int> readyFds;
+  CHECK(handler.listen(&readyFds) == -1);
+  CHECK(socketHandler->acceptCallFds.empty());
+
+  readyFds.insert(100);
+  CHECK(handler.listen(&readyFds) == 42);
+}
+
 TEST_CASE("ForwardSourceHandler sendDataOnSocket writes to socket",
           "[ForwardSourceHandler]") {
   auto socketHandler = std::make_shared<MockSocketHandler>();
@@ -362,7 +415,7 @@ TEST_CASE("ForwardSourceHandler sendDataOnSocket writes to socket",
   REQUIRE(socketHandler->writes[0] == "test data");
 }
 
-TEST_CASE("ForwardSourceHandler getActiveFds returns all fd types",
+TEST_CASE("ForwardSourceHandler getActiveFds excludes unassigned fds",
           "[ForwardSourceHandler]") {
   auto socketHandler = std::make_shared<MockSocketHandler>();
   socketHandler->setEndpointFds({100, 101});
@@ -377,25 +430,22 @@ TEST_CASE("ForwardSourceHandler getActiveFds returns all fd types",
   destination.set_port(9090);
   ForwardSourceHandler handler(socketHandler, source, destination);
 
-  // Accept two connections: assign one, leave other unassigned
-  int fd1 = handler.listen();
-  REQUIRE(fd1 == 42);
-  int fd2 = handler.listen();
-  REQUIRE(fd2 == 43);
+  int assignedFd = handler.listen();
+  REQUIRE(assignedFd == 42);
+  int unassignedFd = handler.listen();
+  REQUIRE(unassignedFd == 43);
 
-  handler.addSocket(123, fd1);  // fd1 (42) moves to socketFdMap
+  handler.addSocket(123, assignedFd);
 
-  // fd2 (43) remains in unassignedFds
+  REQUIRE(handler.hasUnassignedFd(unassignedFd));
   set<int> fds;
   handler.getActiveFds(&fds);
 
-  // Should contain: endpoint fds (100, 101), socketFdMap fd (42),
-  // unassigned fd (43)
   CHECK(fds.count(100) == 1);
   CHECK(fds.count(101) == 1);
-  CHECK(fds.count(42) == 1);
-  CHECK(fds.count(43) == 1);
-  CHECK(fds.size() == 4);
+  CHECK(fds.count(assignedFd) == 1);
+  CHECK(fds.count(unassignedFd) == 0);
+  CHECK(fds.size() == 3);
 }
 
 TEST_CASE("ForwardSourceHandler getActiveFds with no sockets",


### PR DESCRIPTION
select() writes past the end of an fd_set once a descriptor reaches FD_SETSIZE, corrupting the stack, e.g. SIGSEGV. `et -t 8000-9100:8000-9100` reaches that from the command line alone, since each forwarded port is its own listening descriptor.

Add FdPoller (epoll on Linux, kqueue on BSD/macOS) for the server loops, use poll() for single-descriptor waits and the client loop, and process only the descriptors reported ready. Windows keeps select(), where fd_set is a bounded array and cannot overflow. The client uses poll() rather than FdPoller because nohup(1) can leave a regular file on the console descriptor, which epoll_ctl rejects with EPERM.