### PR TITLE
Fix session and forwarding FD leaks

### DIFF
--- a/src/terminal/TerminalServer.cpp
+++ b/src/terminal/TerminalServer.cpp
@@ -179,7 +179,7 @@ void TerminalServer::run() {
 
 void TerminalServer::runJumpHost(
     shared_ptr<ServerClientConnection> serverClientState,
-    const InitialPayload& payload) {
+    const InitialPayload& payload, const TerminalUserInfo& userInfo) {
   InitialResponse response;
   serverClientState->writePacket(
       Packet(uint8_t(EtPacketType::INITIAL_RESPONSE), protoToString(response)));
@@ -187,16 +187,7 @@ void TerminalServer::runJumpHost(
   el::Helpers::setThreadName(serverClientState->getId());
   bool run = true;
 
-  int terminalFd = -1;
-  if (auto maybeUserInfo =
-          terminalRouter->tryGetInfoForConnection(serverClientState)) {
-    terminalFd = maybeUserInfo->fd();
-  } else {
-    LOG(ERROR) << "Jumphost failed to bind to terminal router";
-    serverClientState->closeSocket();
-    return;
-  }
-
+  int terminalFd = userInfo.fd();
   shared_ptr<SocketHandler> terminalSocketHandler =
       terminalRouter->getSocketHandler();
   FdPoller poller;
@@ -323,26 +314,11 @@ void TerminalServer::runJumpHost(
       serverClientState->closeSocket();
     }
   }
-  {
-    string id = serverClientState->getId();
-    serverClientState.reset();
-    removeClient(id);
-  }
 }
 
 void TerminalServer::runTerminal(
     shared_ptr<ServerClientConnection> serverClientState,
-    const InitialPayload& payload) {
-  auto maybeUserInfo =
-      terminalRouter->tryGetInfoForConnection(serverClientState);
-  if (!maybeUserInfo) {
-    LOG(ERROR) << "Terminal client failed to bind to terminal router";
-    serverClientState->closeSocket();
-    return;
-  }
-
-  const auto userInfo = std::move(maybeUserInfo.value());
-
+    const InitialPayload& payload, const TerminalUserInfo& userInfo) {
   InitialResponse response;
   shared_ptr<SocketHandler> serverSocketHandler = getSocketHandler();
   shared_ptr<SocketHandler> pipeSocketHandler(new PipeSocketHandler());
@@ -411,7 +387,7 @@ void TerminalServer::runTerminal(
   while (run) {
     {
       lock_guard<std::mutex> guard(terminalThreadMutex);
-      if (halt) {
+      if (halt || serverClientState->isShuttingDown()) {
         break;
       }
     }
@@ -598,69 +574,65 @@ void TerminalServer::runTerminal(
       STERROR << "Error: " << re.what();
       CLOG(INFO, "stdout") << "Error: " << re.what();
       serverClientState->closeSocket();
-      // If the client disconnects the session, it shouldn't end
-      // because the client may be starting a new one.  TODO: Start a
-      // timer which eventually kills the server.
-
-      // run=false;
+      // recoverClient() resumes this session after a transient disconnect.
     }
-  }
-  {
-    string id = serverClientState->getId();
-    serverClientState.reset();
-    removeClient(id);
   }
 }
 
 void TerminalServer::handleConnection(
     shared_ptr<ServerClientConnection> serverClientState) {
-  Packet packet;
-  const time_t initialPayloadDeadline = time(NULL) + initialPayloadTimeoutSec;
-  while (!serverClientState->readPacket(&packet)) {
-    bool halted;
-    {
-      lock_guard<std::mutex> guard(terminalThreadMutex);
-      halted = halt;
+  std::optional<TerminalUserInfo> userInfo;
+  try {
+    Packet packet;
+    const time_t initialPayloadDeadline = time(NULL) + initialPayloadTimeoutSec;
+    while (!serverClientState->readPacket(&packet)) {
+      bool halted;
+      {
+        lock_guard<std::mutex> guard(terminalThreadMutex);
+        halted = halt;
+      }
+      // Every exit matters: without them this thread spins forever on a client
+      // that never speaks, and run() blocks on join() at shutdown.
+      if (halted || serverClientState->isShuttingDown() ||
+          time(NULL) > initialPayloadDeadline) {
+        LOG(WARNING) << "Giving up waiting for the initial packet from "
+                     << serverClientState->getId();
+        removeClient(serverClientState->getId());
+        return;
+      }
+      LOG_EVERY_N(10, INFO) << "Waiting for initial packet...";
+      sleep(1);
     }
-    // Every exit matters: without them this thread spins forever on a client
-    // that never speaks, and run() blocks on join() at shutdown.
-    if (halted || serverClientState->isShuttingDown() ||
-        time(NULL) > initialPayloadDeadline) {
-      LOG(WARNING) << "Giving up waiting for the initial packet from "
-                   << serverClientState->getId();
-      string id = serverClientState->getId();
-      serverClientState.reset();
-      removeClient(id);
-      return;
+    if (packet.getHeader() != EtPacketType::INITIAL_PAYLOAD) {
+      STFATAL << "Invalid header: expecting INITIAL_PAYLOAD but got "
+              << packet.getHeader();
     }
-    LOG_EVERY_N(10, INFO) << "Waiting for initial packet...";
-    sleep(1);
+    InitialPayload payload = stringToProto<InitialPayload>(packet.getPayload());
+    userInfo = terminalRouter->tryGetInfoForConnection(serverClientState);
+    if (!userInfo) {
+      LOG(ERROR) << "Client failed to bind to terminal router";
+    } else if (payload.jumphost()) {
+      LOG(INFO) << "RUNNING JUMPHOST";
+      runJumpHost(serverClientState, payload, *userInfo);
+    } else {
+      LOG(INFO) << "RUNNING TERMINAL";
+      runTerminal(serverClientState, payload, *userInfo);
+    }
+  } catch (const std::exception& ex) {
+    LOG(ERROR) << "Terminal thread failed: " << ex.what();
   }
-  if (packet.getHeader() != EtPacketType::INITIAL_PAYLOAD) {
-    STFATAL << "Invalid header: expecting INITIAL_PAYLOAD but got "
-            << packet.getHeader();
-  }
-  InitialPayload payload = stringToProto<InitialPayload>(packet.getPayload());
-  if (payload.jumphost()) {
-    LOG(INFO) << "RUNNING JUMPHOST";
-    runJumpHost(serverClientState, payload);
-  } else {
-    LOG(INFO) << "RUNNING TERMINAL";
-    runTerminal(serverClientState, payload);
+
+  removeClient(serverClientState->getId());
+  if (userInfo) {
+    terminalRouter->removeConnection(*userInfo);
   }
 }
 
 bool TerminalServer::newClient(
     shared_ptr<ServerClientConnection> serverClientState) {
   lock_guard<std::mutex> guard(terminalThreadMutex);
-  auto t = make_shared<thread>([this, serverClientState]() {
-    try {
-      handleConnection(serverClientState);
-    } catch (const std::exception& ex) {
-      LOG(ERROR) << "Terminal thread failed: " << ex.what();
-      removeClient(serverClientState->getId());
-    }
-  });
+  auto t = make_shared<thread>(&TerminalServer::handleConnection, this,
+                               serverClientState);
   terminalThreads.push_back(t);
   return true;
 }

--- a/src/terminal/TerminalServer.hpp
+++ b/src/terminal/TerminalServer.hpp
@@ -32,10 +32,12 @@ class TerminalServer : public ServerConnection {
   virtual ~TerminalServer();
   /** @brief Drives a jumphost proxy session for the authenticated client. */
   void runJumpHost(shared_ptr<ServerClientConnection> serverClientState,
-                   const InitialPayload& payload);
+                   const InitialPayload& payload,
+                   const TerminalUserInfo& userInfo);
   /** @brief Launches the interactive terminal session for a client. */
   void runTerminal(shared_ptr<ServerClientConnection> serverClientState,
-                   const InitialPayload& payload);
+                   const InitialPayload& payload,
+                   const TerminalUserInfo& userInfo);
   /** @brief Sets up the client state and pushes it into the terminal router. */
   void handleConnection(shared_ptr<ServerClientConnection> serverClientState);
   /** @brief Callback from ServerConnection when a new client is authenticated.

--- a/src/terminal/UserTerminalRouter.cpp
+++ b/src/terminal/UserTerminalRouter.cpp
@@ -79,4 +79,15 @@ std::optional<TerminalUserInfo> UserTerminalRouter::tryGetInfoForConnection(
   return it->second;
 }
 
+void UserTerminalRouter::removeConnection(const TerminalUserInfo& userInfo) {
+  lock_guard<recursive_mutex> guard(routerMutex);
+  auto it = idInfoMap.find(userInfo.id());
+  if (it == idInfoMap.end() || it->second.fd() != userInfo.fd() ||
+      it->second.passkey() != userInfo.passkey()) {
+    return;
+  }
+  socketHandler->close(it->second.fd());
+  idInfoMap.erase(it);
+}
+
 }  // namespace et

--- a/src/terminal/UserTerminalRouter.hpp
+++ b/src/terminal/UserTerminalRouter.hpp
@@ -37,6 +37,8 @@ class UserTerminalRouter {
   std::optional<TerminalUserInfo> tryGetInfoForConnection(
       const shared_ptr<ServerClientConnection>& serverClientState);
 
+  void removeConnection(const TerminalUserInfo& userInfo);
+
   /** @brief Returns the router-side socket handler used by this router. */
   inline shared_ptr<PipeSocketHandler> getSocketHandler() {
     return socketHandler;

--- a/src/terminal/forwarding/ForwardDestinationHandler.cpp
+++ b/src/terminal/forwarding/ForwardDestinationHandler.cpp
@@ -5,7 +5,15 @@ ForwardDestinationHandler::ForwardDestinationHandler(
     shared_ptr<SocketHandler> _socketHandler, int _fd, int _socketId)
     : socketHandler(_socketHandler), fd(_fd), socketId(_socketId) {}
 
-void ForwardDestinationHandler::close() { socketHandler->close(fd); }
+ForwardDestinationHandler::~ForwardDestinationHandler() { close(); }
+
+void ForwardDestinationHandler::close() {
+  if (fd >= 0) {
+    int closedFd = fd;
+    fd = -1;
+    socketHandler->close(closedFd);
+  }
+}
 
 void ForwardDestinationHandler::write(const string& s) {
   VLOG(1) << "Writing " << s.length() << " bytes to port destination";
@@ -50,8 +58,7 @@ void ForwardDestinationHandler::update(vector<PortForwardData>* retval,
         STERROR << "Socket " << socketId << " closed with error " << readErrno
                 << ' ' << strerror(readErrno);
       }
-      socketHandler->close(fd);
-      fd = -1;
+      close();
       break;
     }
   }

--- a/src/terminal/forwarding/ForwardDestinationHandler.hpp
+++ b/src/terminal/forwarding/ForwardDestinationHandler.hpp
@@ -15,6 +15,12 @@ class ForwardDestinationHandler {
    * downstream. */
   ForwardDestinationHandler(shared_ptr<SocketHandler> _socketHandler, int _fd,
                             int _socketId);
+  ~ForwardDestinationHandler();
+
+  ForwardDestinationHandler(const ForwardDestinationHandler&) = delete;
+  ForwardDestinationHandler& operator=(const ForwardDestinationHandler&) =
+      delete;
+
   /** @brief Sends bytes that need to travel to the destination socket. */
   void write(const string& s);
 

--- a/src/terminal/forwarding/ForwardSourceHandler.cpp
+++ b/src/terminal/forwarding/ForwardSourceHandler.cpp
@@ -13,6 +13,12 @@ ForwardSourceHandler::ForwardSourceHandler(
 }
 
 ForwardSourceHandler::~ForwardSourceHandler() {
+  for (const auto& socket : socketFdMap) {
+    socketHandler->close(socket.second);
+  }
+  for (int fd : unassignedFds) {
+    socketHandler->close(fd);
+  }
   socketHandler->stopListening(source);
 }
 

--- a/src/terminal/forwarding/ForwardSourceHandler.hpp
+++ b/src/terminal/forwarding/ForwardSourceHandler.hpp
@@ -23,6 +23,9 @@ class ForwardSourceHandler {
 
   ~ForwardSourceHandler();
 
+  ForwardSourceHandler(const ForwardSourceHandler&) = delete;
+  ForwardSourceHandler& operator=(const ForwardSourceHandler&) = delete;
+
   /** @brief Accepts one pending connection and returns its fd, or -1 if none.
    * Accepts only on endpoints named in `readyFds`; `nullptr` tries every one.
    */

--- a/src/terminal/forwarding/PortForwardHandler.cpp
+++ b/src/terminal/forwarding/PortForwardHandler.cpp
@@ -13,6 +13,18 @@ PortForwardHandler::PortForwardHandler(
       sessionUid(userid),
       sessionGid(groupid) {}
 
+PortForwardHandler::~PortForwardHandler() {
+  socketIdSourceHandlerMap.clear();
+  sourceHandlers.clear();
+  for (const auto& directory : temporaryDirectories) {
+    try {
+      fs::remove(directory);
+    } catch (const fs::filesystem_error& ex) {
+      LOG(WARNING) << "Could not remove forwarding directory: " << ex.what();
+    }
+  }
+}
+
 void PortForwardHandler::update(vector<PortForwardDestinationRequest>* requests,
                                 vector<PortForwardData>* dataToSend,
                                 const set<int>* readyFds) {
@@ -65,6 +77,7 @@ PortForwardSourceResponse PortForwardHandler::createSource(
       string sourceDirectory = mktemp(&sourcePattern[0]);
       FATAL_FAIL(mkdir(&sourceDirectory[0]));
 #endif
+      temporaryDirectories.push_back(sourceDirectory);
       string sourcePath = string(sourceDirectory) + "/sock";
 
       source.set_name(sourcePath);
@@ -167,9 +180,8 @@ PortForwardDestinationResponse PortForwardHandler::createDestination(
     }
     if (!pfdresponse.has_error()) {
       LOG(INFO) << "Created socket/fd pair: " << socketId << ' ' << fd;
-      destinationHandlers[socketId] =
-          shared_ptr<ForwardDestinationHandler>(new ForwardDestinationHandler(
-              isTcp ? networkSocketHandler : pipeSocketHandler, fd, socketId));
+      destinationHandlers[socketId] = make_unique<ForwardDestinationHandler>(
+          isTcp ? networkSocketHandler : pipeSocketHandler, fd, socketId);
       pfdresponse.set_socketid(socketId);
       ++forwardFdsGeneration;
     }
@@ -188,33 +200,23 @@ void PortForwardHandler::handlePacket(const Packet& packet,
         if (it == destinationHandlers.end()) {
           LOG(WARNING) << "Got data for a socket id that has already closed: "
                        << pwd.socketid();
+        } else if (pwd.has_closed() || pwd.has_error()) {
+          LOG(INFO) << "Port forward socket "
+                    << (pwd.has_closed() ? "closed: " : "errored: ")
+                    << pwd.socketid();
+          destinationHandlers.erase(it);
+          ++forwardFdsGeneration;
         } else {
-          if (pwd.has_closed()) {
-            LOG(INFO) << "Port forward socket closed: " << pwd.socketid();
-            it->second->close();
-            destinationHandlers.erase(it);
-            ++forwardFdsGeneration;
-          } else if (pwd.has_error()) {
-            // TODO: Probably need to do something better here
-            LOG(INFO) << "Port forward socket errored: " << pwd.socketid();
-            it->second->close();
-            destinationHandlers.erase(it);
-            ++forwardFdsGeneration;
-          } else {
-            it->second->write(pwd.buffer());
-          }
+          it->second->write(pwd.buffer());
         }
+      } else if (pwd.has_closed() || pwd.has_error()) {
+        LOG(INFO) << "Port forward socket "
+                  << (pwd.has_closed() ? "closed: " : "errored: ")
+                  << pwd.socketid();
+        closeSourceSocketId(pwd.socketid());
       } else {
-        if (pwd.has_closed()) {
-          LOG(INFO) << "Port forward socket closed: " << pwd.socketid();
-          closeSourceSocketId(pwd.socketid());
-        } else if (pwd.has_error()) {
-          LOG(INFO) << "Port forward socket errored: " << pwd.socketid();
-          closeSourceSocketId(pwd.socketid());
-        } else {
-          VLOG(1) << "Got data for source socket: " << pwd.socketid();
-          sendDataToSourceOnSocket(pwd.socketid(), pwd.buffer());
-        }
+        VLOG(1) << "Got data for source socket: " << pwd.socketid();
+        sendDataToSourceOnSocket(pwd.socketid(), pwd.buffer());
       }
       break;
     }

--- a/src/terminal/forwarding/PortForwardHandler.hpp
+++ b/src/terminal/forwarding/PortForwardHandler.hpp
@@ -24,6 +24,11 @@ class PortForwardHandler {
                               shared_ptr<SocketHandler> _pipeSocketHandler,
                               uid_t userid = static_cast<uid_t>(-1),
                               gid_t groupid = static_cast<gid_t>(-1));
+  ~PortForwardHandler();
+
+  PortForwardHandler(const PortForwardHandler&) = delete;
+  PortForwardHandler& operator=(const PortForwardHandler&) = delete;
+
   /** @brief Polls handlers and collects destination requests and
    * `PortForwardData` for the caller to send. Touches only the descriptors
    * named in `readyFds`; `nullptr` polls every one. */
@@ -63,7 +68,7 @@ class PortForwardHandler {
   /** @brief Session gid for UNIX connect/listen; (gid_t)-1 disables drop. */
   gid_t sessionGid;
   /** @brief Active destination handlers keyed by socket id. */
-  unordered_map<int, shared_ptr<ForwardDestinationHandler>> destinationHandlers;
+  unordered_map<int, unique_ptr<ForwardDestinationHandler>> destinationHandlers;
 
   /** @brief Handlers for the listening port forward sources. */
   vector<shared_ptr<ForwardSourceHandler>> sourceHandlers;
@@ -74,6 +79,7 @@ class PortForwardHandler {
    * `getForwardFds`: a recycled fd number yields an identical set, so this is
    * a poller's only signal that it must re-register. */
   uint64_t forwardFdsGeneration = 0;
+  vector<string> temporaryDirectories;
 };
 }  // namespace et
 

--- a/test/unit_tests/ForwardDestinationHandlerTest.cpp
+++ b/test/unit_tests/ForwardDestinationHandlerTest.cpp
@@ -71,6 +71,33 @@ class MockSocketHandler : public SocketHandler {
 };
 }  // namespace
 
+TEST_CASE("ForwardDestinationHandler closes its socket on destruction",
+          "[ForwardDestinationHandler]") {
+  auto socketHandler = std::make_shared<MockSocketHandler>();
+  { ForwardDestinationHandler handler(socketHandler, 42, 123); }
+  CHECK(socketHandler->closedFds == std::vector<int>{42});
+}
+
+TEST_CASE("ForwardDestinationHandler does not close released sockets twice",
+          "[ForwardDestinationHandler]") {
+  auto socketHandler = std::make_shared<MockSocketHandler>();
+  {
+    ForwardDestinationHandler handler(socketHandler, 42, 123);
+    SECTION("Explicit close") {
+      handler.close();
+      handler.close();
+    }
+    SECTION("Peer EOF") {
+      socketHandler->enqueueHasData(true);
+      socketHandler->enqueueRead(0);
+      std::vector<PortForwardData> data;
+      handler.update(&data);
+    }
+    CHECK(handler.getFd() == -1);
+  }
+  CHECK(socketHandler->closedFds == std::vector<int>{42});
+}
+
 TEST_CASE("ForwardDestinationHandler forwards outbound payloads",
           "[ForwardDestinationHandler]") {
   auto socketHandler = std::make_shared<MockSocketHandler>();

--- a/test/unit_tests/ForwardSourceHandlerTest.cpp
+++ b/test/unit_tests/ForwardSourceHandlerTest.cpp
@@ -134,6 +134,53 @@ TEST_CASE("ForwardSourceHandler stops listening on destruction",
   REQUIRE(socketHandler->stopListeningCalls[0].port() == source.port());
 }
 
+TEST_CASE("ForwardSourceHandler closes remaining sockets on destruction",
+          "[ForwardSourceHandler]") {
+  auto socketHandler = std::make_shared<MockSocketHandler>();
+  socketHandler->setEndpointFds({100});
+  socketHandler->enqueueAccept(42);
+  socketHandler->enqueueAccept(43);
+
+  {
+    ForwardSourceHandler handler(socketHandler, SocketEndpoint(),
+                                 SocketEndpoint());
+    handler.addSocket(123, handler.listen());
+    REQUIRE(handler.listen() == 43);
+    CHECK(socketHandler->closedFds.empty());
+  }
+
+  std::sort(socketHandler->closedFds.begin(), socketHandler->closedFds.end());
+  CHECK(socketHandler->closedFds == std::vector<int>{42, 43});
+  CHECK(socketHandler->stopListeningCalls.size() == 1);
+}
+
+TEST_CASE("ForwardSourceHandler does not close released sockets twice",
+          "[ForwardSourceHandler]") {
+  auto socketHandler = std::make_shared<MockSocketHandler>();
+  socketHandler->setEndpointFds({100});
+  socketHandler->enqueueAccept(42);
+
+  {
+    ForwardSourceHandler handler(socketHandler, SocketEndpoint(),
+                                 SocketEndpoint());
+    int fd = handler.listen();
+    SECTION("Pending socket") { handler.closeUnassignedFd(fd); }
+    SECTION("Assigned socket") {
+      handler.addSocket(123, fd);
+      handler.closeSocket(123);
+    }
+    SECTION("Peer EOF") {
+      handler.addSocket(123, fd);
+      socketHandler->enqueueHasData(true);
+      socketHandler->enqueueRead(0);
+      std::vector<PortForwardData> data;
+      handler.update(&data);
+    }
+  }
+
+  CHECK(socketHandler->closedFds == std::vector<int>{42});
+}
+
 TEST_CASE("ForwardSourceHandler listen accepts new connections",
           "[ForwardSourceHandler]") {
   auto socketHandler = std::make_shared<MockSocketHandler>();

--- a/test/unit_tests/PortForwardHandlerTest.cpp
+++ b/test/unit_tests/PortForwardHandlerTest.cpp
@@ -1,3 +1,4 @@
+#include "PipeSocketHandler.hpp"
 #include "PortForwardHandler.hpp"
 #include "TestHeaders.hpp"
 
@@ -177,6 +178,84 @@ TEST_CASE("PortForwardHandler createSource with port forward",
   CHECK_FALSE(response.has_error());
 }
 
+#ifndef WIN32
+TEST_CASE("PortForwardHandler removes its generated socket directory",
+          "[PortForwardHandler]") {
+  auto networkHandler = make_shared<FakePortForwardSocketHandler>();
+  auto pipeHandler = make_shared<PipeSocketHandler>();
+  string sourceName;
+  {
+    PortForwardHandler handler(networkHandler, pipeHandler);
+    PortForwardSourceRequest request;
+    request.mutable_destination()->set_name("/unused/destination");
+    auto response =
+        handler.createSource(request, &sourceName, getuid(), getgid());
+    REQUIRE_FALSE(response.has_error());
+    REQUIRE_FALSE(sourceName.empty());
+    CHECK(fs::exists(sourceName));
+  }
+  CHECK_FALSE(fs::exists(sourceName));
+  CHECK_FALSE(fs::exists(fs::path(sourceName).parent_path()));
+}
+
+TEST_CASE("PortForwardHandler preserves user-specified socket directories",
+          "[PortForwardHandler]") {
+  string pattern = GetTempDirectory() + "et_forward_test_XXXXXX";
+  char* directory = mkdtemp(&pattern[0]);
+  REQUIRE(directory != nullptr);
+  const string sourceName = string(directory) + "/sock";
+  {
+    auto networkHandler = make_shared<FakePortForwardSocketHandler>();
+    auto pipeHandler = make_shared<PipeSocketHandler>();
+    PortForwardHandler handler(networkHandler, pipeHandler);
+    PortForwardSourceRequest request;
+    request.mutable_source()->set_name(sourceName);
+    request.mutable_destination()->set_name("/unused/destination");
+    auto response = handler.createSource(request, nullptr, getuid(), getgid());
+    REQUIRE_FALSE(response.has_error());
+  }
+  CHECK(fs::exists(directory));
+  fs::remove(sourceName);
+  fs::remove(directory);
+}
+
+TEST_CASE("PortForwardHandler directory removal does not follow symlinks",
+          "[PortForwardHandler]") {
+  string pattern = GetTempDirectory() + "et_forward_test_XXXXXX";
+  char* directory = mkdtemp(&pattern[0]);
+  REQUIRE(directory != nullptr);
+  const fs::path root(directory);
+  const auto target = root / "target";
+  const auto moved = root / "moved";
+  fs::create_directory(target);
+  {
+    std::ofstream marker((target / "sock").string());
+    marker << "preserve this file";
+  }
+  string sourceName;
+  {
+    auto networkHandler = make_shared<FakePortForwardSocketHandler>();
+    auto pipeHandler = make_shared<FakePortForwardSocketHandler>();
+    PortForwardHandler handler(networkHandler, pipeHandler);
+    PortForwardSourceRequest request;
+    request.mutable_destination()->set_name("/unused/destination");
+    auto response =
+        handler.createSource(request, &sourceName, getuid(), getgid());
+    REQUIRE_FALSE(response.has_error());
+    auto sourceDirectory = fs::path(sourceName).parent_path();
+    fs::rename(sourceDirectory, moved);
+    fs::create_directory_symlink(target, sourceDirectory);
+  }
+  CHECK(fs::exists(target / "sock"));
+  CHECK_FALSE(fs::exists(fs::path(sourceName).parent_path()));
+  fs::remove(moved / "sock");
+  fs::remove(moved);
+  fs::remove(target / "sock");
+  fs::remove(target);
+  fs::remove(root);
+}
+#endif
+
 // SKIPPED: Test creates actual Unix sockets and chmod fails in some
 // environments (WSL) Error: chmod fails with EINVAL (22) on Unix domain sockets
 // in WSL2
@@ -351,74 +430,31 @@ TEST_CASE("PortForwardHandler handlePacket PORT_FORWARD_DATA destination",
   CHECK(networkHandler->writes[42][0] == "test data");
 }
 
-TEST_CASE("PortForwardHandler handlePacket PORT_FORWARD_DATA close destination",
+TEST_CASE("PortForwardHandler closes destinations on remote close or error",
           "[PortForwardHandler]") {
   auto networkHandler = make_shared<FakePortForwardSocketHandler>();
   auto pipeHandler = make_shared<FakePortForwardSocketHandler>();
   PortForwardHandler handler(networkHandler, pipeHandler);
   auto connection = make_shared<FakeConnection>();
 
-  // First create a destination
   networkHandler->setConnectResult(42);
   PortForwardDestinationRequest destRequest;
-  SocketEndpoint destination;
-  destination.set_port(8080);
-  *destRequest.mutable_destination() = destination;
+  destRequest.mutable_destination()->set_port(8080);
   destRequest.set_fd(100);
   PortForwardDestinationResponse destResponse =
       handler.createDestination(destRequest);
   REQUIRE_FALSE(destResponse.has_error());
-  int socketId = destResponse.socketid();
-
-  // Send close signal
   PortForwardData data;
   data.set_sourcetodestination(true);
-  data.set_socketid(socketId);
-  data.set_closed(true);
+  data.set_socketid(destResponse.socketid());
+  SECTION("Close") { data.set_closed(true); }
+  SECTION("Error") { data.set_error("connection error"); }
 
   Packet packet(uint8_t(TerminalPacketType::PORT_FORWARD_DATA),
                 protoToString(data));
   handler.handlePacket(packet, connection);
 
-  // Check that socket was closed
-  CHECK(std::find(networkHandler->closedFds.begin(),
-                  networkHandler->closedFds.end(),
-                  42) != networkHandler->closedFds.end());
-}
-
-TEST_CASE("PortForwardHandler handlePacket PORT_FORWARD_DATA error destination",
-          "[PortForwardHandler]") {
-  auto networkHandler = make_shared<FakePortForwardSocketHandler>();
-  auto pipeHandler = make_shared<FakePortForwardSocketHandler>();
-  PortForwardHandler handler(networkHandler, pipeHandler);
-  auto connection = make_shared<FakeConnection>();
-
-  // First create a destination
-  networkHandler->setConnectResult(42);
-  PortForwardDestinationRequest destRequest;
-  SocketEndpoint destination;
-  destination.set_port(8080);
-  *destRequest.mutable_destination() = destination;
-  destRequest.set_fd(100);
-  PortForwardDestinationResponse destResponse =
-      handler.createDestination(destRequest);
-  REQUIRE_FALSE(destResponse.has_error());
-  int socketId = destResponse.socketid();
-
-  // Send error signal
-  PortForwardData data;
-  data.set_sourcetodestination(true);
-  data.set_socketid(socketId);
-  data.set_error("connection error");
-
-  Packet packet(uint8_t(TerminalPacketType::PORT_FORWARD_DATA),
-                protoToString(data));
-  handler.handlePacket(packet, connection);
-
-  // Check that socket was closed
-  CHECK(std::find(networkHandler->closedFds.begin(),
-                  networkHandler->closedFds.end(),
-                  42) != networkHandler->closedFds.end());
+  CHECK(networkHandler->closedFds == vector<int>{42});
 }
 
 TEST_CASE("PortForwardHandler handlePacket PORT_FORWARD_DESTINATION_REQUEST",

--- a/test/unit_tests/TerminalServerLifecycleTest.cpp
+++ b/test/unit_tests/TerminalServerLifecycleTest.cpp
@@ -1,0 +1,236 @@
+#ifndef WIN32
+#include <future>
+
+#include "TerminalServer.hpp"
+#include "TestHeaders.hpp"
+
+using namespace et;
+
+namespace {
+class LifecycleClient : public ServerClientConnection {
+ public:
+  LifecycleClient(shared_ptr<SocketHandler> socketHandler, const string& id,
+                  const string& key)
+      : ServerClientConnection(socketHandler, id, -1, key) {}
+
+  bool readPacket(Packet* packet) override {
+    *packet = Packet(EtPacketType::INITIAL_PAYLOAD, protoToString(payload));
+    return true;
+  }
+
+  void writePacket(const Packet& packet) override {
+    if (failInitialResponse &&
+        packet.getHeader() == EtPacketType::INITIAL_RESPONSE) {
+      throw std::runtime_error("Initial response failed");
+    }
+    if (packet.getHeader() == TerminalPacketType::TERMINAL_BUFFER) {
+      terminalOutput.set_value(
+          stringToProto<TerminalBuffer>(packet.getPayload()).buffer());
+    }
+  }
+
+  InitialPayload payload;
+  bool failInitialResponse = false;
+  std::promise<string> terminalOutput;
+};
+
+class LifecycleServer : public TerminalServer {
+ public:
+  using TerminalServer::TerminalServer;
+
+  void registerClient(const shared_ptr<ServerClientConnection>& client,
+                      const string& key) {
+    addClientKey(client->getId(), key);
+    clientConnections[client->getId()] = client;
+  }
+};
+
+class TerminalSessionFixture {
+ public:
+  TerminalSessionFixture() {
+    string pattern = GetTempDirectory() + "et_session_test_XXXXXX";
+    char* directory = mkdtemp(&pattern[0]);
+    REQUIRE(directory != nullptr);
+    pipeDirectory = directory;
+    serverEndpoint.set_name(pipeDirectory + "/server");
+    routerEndpoint.set_name(pipeDirectory + "/router");
+    server = std::make_shared<LifecycleServer>(networkHandler, serverEndpoint,
+                                               routerHandler, routerEndpoint);
+    client = std::make_shared<LifecycleClient>(networkHandler, id, key);
+    server->registerClient(client, key);
+    registerTerminal();
+  }
+
+  ~TerminalSessionFixture() {
+    server->shutdown();
+    closeTerminal();
+    client->shutdown();
+    joinSession();
+    for (int fd : routerHandler->getActiveSockets()) {
+      routerHandler->close(fd);
+    }
+    server->ServerConnection::shutdown();
+    routerHandler->stopListening(routerEndpoint);
+    ::remove(serverEndpoint.name().c_str());
+    ::remove(routerEndpoint.name().c_str());
+    ::remove(pipeDirectory.c_str());
+  }
+
+  void registerTerminal() {
+    terminalPeer = peerHandler->connect(routerEndpoint);
+    REQUIRE(terminalPeer >= 0);
+    TerminalUserInfo userInfo;
+    userInfo.set_id(id);
+    userInfo.set_passkey(key);
+    userInfo.set_uid(getuid());
+    userInfo.set_gid(getgid());
+    peerHandler->writePacket(terminalPeer,
+                             Packet(TerminalPacketType::TERMINAL_USER_INFO,
+                                    protoToString(userInfo)));
+    REQUIRE(server->terminalRouter->acceptNewConnection().id == id);
+    auto info = server->terminalRouter->tryGetInfoForConnection(client);
+    REQUIRE(info.has_value());
+    terminalFd = info->fd();
+  }
+
+  void startSession() { REQUIRE(server->newClient(client)); }
+
+  void waitForInit() {
+    REQUIRE(peerHandler->waitForData(terminalPeer, 2, 0));
+    Packet packet;
+    REQUIRE(peerHandler->readPacket(terminalPeer, &packet));
+    CHECK(packet.getHeader() == (client->payload.jumphost()
+                                     ? TerminalPacketType::JUMPHOST_INIT
+                                     : TerminalPacketType::TERMINAL_INIT));
+  }
+
+  void closeTerminal() {
+    if (terminalPeer >= 0) {
+      peerHandler->close(terminalPeer);
+      terminalPeer = -1;
+    }
+  }
+
+  void joinSession() {
+    for (const auto& thread : server->terminalThreads) {
+      if (thread->joinable()) {
+        thread->join();
+      }
+    }
+  }
+
+  void waitForSessionEnd() {
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (server->clientConnectionExists(id) &&
+           std::chrono::steady_clock::now() < deadline) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    REQUIRE_FALSE(server->clientConnectionExists(id));
+    joinSession();
+  }
+
+  void checkSessionClosed() {
+    CHECK(fcntl(terminalFd, F_GETFD) == -1);
+    CHECK(errno == EBADF);
+    CHECK_FALSE(server->clientKeyExists(id));
+    CHECK_FALSE(server->clientConnectionExists(id));
+  }
+
+  const string id = "session-test";
+  const string key = string(32, 'k');
+  shared_ptr<PipeSocketHandler> networkHandler =
+      std::make_shared<PipeSocketHandler>();
+  shared_ptr<PipeSocketHandler> routerHandler =
+      std::make_shared<PipeSocketHandler>();
+  shared_ptr<PipeSocketHandler> peerHandler =
+      std::make_shared<PipeSocketHandler>();
+  shared_ptr<LifecycleServer> server;
+  shared_ptr<LifecycleClient> client;
+  SocketEndpoint serverEndpoint;
+  SocketEndpoint routerEndpoint;
+  string pipeDirectory;
+  int terminalPeer = -1;
+  int terminalFd = -1;
+};
+}  // namespace
+
+TEST_CASE_METHOD(TerminalSessionFixture,
+                 "Finished sessions release their router connection",
+                 "[TerminalServerLifecycle]") {
+  SECTION("Terminal") { client->payload.set_jumphost(false); }
+  SECTION("Jumphost") { client->payload.set_jumphost(true); }
+  startSession();
+  waitForInit();
+  closeTerminal();
+  waitForSessionEnd();
+  checkSessionClosed();
+  registerTerminal();
+}
+
+TEST_CASE_METHOD(TerminalSessionFixture,
+                 "Session setup exceptions release their router connection",
+                 "[TerminalServerLifecycle]") {
+  SECTION("Terminal") { client->payload.set_jumphost(false); }
+  SECTION("Jumphost") { client->payload.set_jumphost(true); }
+  client->failInitialResponse = true;
+  startSession();
+  waitForSessionEnd();
+  checkSessionClosed();
+}
+
+TEST_CASE_METHOD(TerminalSessionFixture,
+                 "Rejected forwarding setup releases the session",
+                 "[TerminalServerLifecycle]") {
+  auto* request = client->payload.add_reversetunnels();
+  request->mutable_source()->set_port(8080);
+  request->set_environmentvariable("TEST_FORWARD");
+  startSession();
+  waitForSessionEnd();
+  checkSessionClosed();
+}
+
+TEST_CASE_METHOD(TerminalSessionFixture,
+                 "Failed router authentication preserves the registered route",
+                 "[TerminalServerLifecycle]") {
+  auto wrongClient =
+      std::make_shared<LifecycleClient>(networkHandler, id, string(32, 'x'));
+  server->registerClient(wrongClient, string(32, 'x'));
+  REQUIRE(server->newClient(wrongClient));
+  waitForSessionEnd();
+  CHECK(fcntl(terminalFd, F_GETFD) >= 0);
+  auto info = server->terminalRouter->tryGetInfoForConnection(client);
+  REQUIRE(info.has_value());
+  CHECK(info->fd() == terminalFd);
+  CHECK(wrongClient->isShuttingDown());
+}
+
+TEST_CASE_METHOD(TerminalSessionFixture,
+                 "Permanent client shutdown releases the session",
+                 "[TerminalServerLifecycle]") {
+  startSession();
+  waitForInit();
+  client->shutdown();
+  waitForSessionEnd();
+  checkSessionClosed();
+}
+
+TEST_CASE_METHOD(TerminalSessionFixture,
+                 "Disconnected sessions retain their router until terminal EOF",
+                 "[TerminalServerLifecycle]") {
+  auto output = client->terminalOutput.get_future();
+  startSession();
+  waitForInit();
+  REQUIRE(client->isDisconnected());
+  const string text = "terminal still alive";
+  REQUIRE(peerHandler->write(terminalPeer, text.data(), text.size()) ==
+          static_cast<ssize_t>(text.size()));
+  REQUIRE(output.wait_for(std::chrono::seconds(2)) ==
+          std::future_status::ready);
+  CHECK(output.get() == text);
+  CHECK(fcntl(terminalFd, F_GETFD) >= 0);
+  CHECK(server->clientConnectionExists(id));
+  closeTerminal();
+  waitForSessionEnd();
+  checkSessionClosed();
+}
+#endif


### PR DESCRIPTION
Close completed sessions' router connections and remaining client/server forwarding sockets. Remove generated socket directories. Preserve reconnects and polling timeouts.

Validation: macOS build, all 282 CTest tests, and `bash format.sh` (`clang-format` 18).
