### PR TITLE
Add optional raw stack traces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,6 +222,7 @@ endif()
 option(CODE_COVERAGE "Enable code coverage" OFF)
 option(FUZZING "Enable builds for fuzz testing" OFF)
 option(DISABLE_CRASH_LOG "Disable installing easylogging crash handler" OFF)
+option(RAW_STACKTRACE "Log stack traces without symbolization" OFF)
 option(INSTALL_BASH_COMPLETION "Install bash completion script" ON)
 option(INSTALL_ZSH_COMPLETION "Install zsh completion script" ON)
 
@@ -247,6 +248,10 @@ if(DISABLE_CRASH_LOG)
   set(CMAKE_CXX_FLAGS
     "${CMAKE_CXX_FLAGS} -DELPP_DISABLE_DEFAULT_CRASH_HANDLING")
 endif(DISABLE_CRASH_LOG)
+
+if(RAW_STACKTRACE)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DET_RAW_STACKTRACE")
+endif(RAW_STACKTRACE)
 
 if(UNIX)
   # Enable debug info
@@ -350,6 +355,10 @@ else()
   if(HAVE_STDCXXFS)
     list(APPEND CORE_LIBRARIES stdc++fs)
   endif()
+endif()
+
+if(RAW_STACKTRACE)
+  list(APPEND CORE_LIBRARIES ${CMAKE_DL_LIBS})
 endif()
 
 IF(Unwind_FOUND)

--- a/src/base/Headers.hpp
+++ b/src/base/Headers.hpp
@@ -145,7 +145,14 @@ namespace fs = boost::filesystem
 #include "sago/platform_folders.h"
 #include "sole.hpp"
 
-#if !defined(__ANDROID__)
+#if defined(ET_RAW_STACKTRACE) && !defined(__ANDROID__)
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <dlfcn.h>
+#include <execinfo.h>
+#endif
+#elif !defined(__ANDROID__)
 #include "ust.hpp"
 #endif
 
@@ -204,7 +211,49 @@ const int SERVER_KEEP_ALIVE_DURATION = 11;
 // rather than waiting for a client that is not coming back.
 const int INITIAL_PAYLOAD_TIMEOUT_DURATION = 600;
 
-#if defined(__ANDROID__)
+#if defined(ET_RAW_STACKTRACE) && !defined(__ANDROID__)
+inline string GetRawStackTrace() {
+  void* frames[64];
+#ifdef _WIN32
+  const int count = CaptureStackBackTrace(0, 64, frames, nullptr);
+#else
+  const int count = backtrace(frames, 64);
+#endif
+  ostringstream trace;
+  for (int i = 0; i < count; ++i) {
+    const char* moduleName = "?";
+    const void* moduleBase = nullptr;
+#ifdef _WIN32
+    HMODULE module = nullptr;
+    char path[4096];
+    if (GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+                               GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                           static_cast<const char*>(frames[i]), &module)) {
+      const auto length = GetModuleFileNameA(module, path, sizeof(path));
+      if (length > 0 && length < sizeof(path)) {
+        moduleName = path;
+      }
+      moduleBase = module;
+    }
+#else
+    Dl_info info{};
+    if (dladdr(frames[i], &info)) {
+      if (info.dli_fname) {
+        moduleName = info.dli_fname;
+      }
+      moduleBase = info.dli_fbase;
+    }
+#endif
+    trace << "[" << i << "] " << moduleName << " pc=" << frames[i]
+          << " base=" << moduleBase << '\n';
+  }
+  return trace.str();
+}
+
+#define STFATAL LOG(FATAL) << "Stack Trace: " << endl << GetRawStackTrace()
+
+#define STERROR LOG(ERROR) << "Stack Trace: " << endl << GetRawStackTrace()
+#elif defined(__ANDROID__)
 #define STFATAL LOG(FATAL) << "No Stack Trace on Android" << endl
 
 #define STERROR LOG(ERROR) << "No Stack Trace on Android" << endl


### PR DESCRIPTION
Synchronous symbolization can hold the logger mutex and block new connections. Add `RAW_STACKTRACE` (default OFF) to log PCs, module paths, and load addresses for offline symbolization.

Tested: macOS build, 270 tests, formatting, and forwarding-reset repro with offline symbolization.

----

I observed etserver freeze completely for about 10 minutes on two separate servers while waiting for addr2line to symbolize stack traces. During each freeze, new connections could not be established, and all existing sessions became unresponsive.